### PR TITLE
Replace constants api.TESTNET and api.MAINNET

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,22 @@ const testKeys = {
 }
 
 // Get balance of account "a" on TestNet using Neon Wallet API
-api.getBalance(api.TESTNET, testKeys.a.address).then((balance) => {
+api.getBalance('TestNet', testKeys.a.address).then((balance) => {
   console.log(balance);
 });
 
 // Get balance of account "a" on MainNet using Neon Wallet API
-api.getBalance(api.MAINNET, testKeys.a.address).then((balance) => {
+api.getBalance('MainNet', testKeys.a.address).then((balance) => {
   console.log(balance);
 });
 
 // Claim all available GAS for account "a" on TestNet
-api.claimAllGAS(api.TESTNET, testKeys.a.wif).then((response) => {
+api.claimAllGAS('TestNet', testKeys.a.wif).then((response) => {
   console.log(response);
 });
 
 // Send 1 ANS to "a" from "b" on TestNet
-api.sendAssetTransaction(api.TESTNET, testKeys.a.address, testKeys.b.wif, "AntShares", 1).then((response) => {
+api.sendAssetTransaction('TestNet', testKeys.a.address, testKeys.b.wif, "AntShares", 1).then((response) => {
   console.log("Transaction complete!");
 });
 ```


### PR DESCRIPTION
It seems like these constants don't exist anymore -- replaced with strings `MainNet` and `TestNet`.