### PR TITLE
branch cleanup

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -18,9 +18,10 @@ export const allAssetIds = [neoId, gasId]
 
 /**
  * @typedef {Object} Balance
- * @property {number} Neo Amount of NEO in address
- * @property {number} Gas Amount of GAS in address
- * @property {{Neo: Coin[], Gas: Coin[]}} unspent Unspent Assets
+ * @property {{balance: number, unspent: Coin[]}} NEO Amount of NEO in address
+ * @property {{balance: number, unspent: Coin[]}} GAS Amount of GAS in address
+ * @property {string} address - The Address that was queried
+ * @property {string} net - 'MainNet' or 'TestNet'
  */
 
 /**

--- a/src/api.js
+++ b/src/api.js
@@ -179,10 +179,11 @@ export const getClaimAmounts = (net, address) => {
 
 /**
  * Returns the best performing (highest block + fastest) node RPC
- * @param {string} net - 'MainNet' or 'TestNet'
- * @return {Promise<string>} The URL of the best performing node
+ * @param {string} net - 'MainNet' or 'TestNet' or a custom URL.
+ * @return {Promise<string>} The URL of the best performing node or the custom URL provided.
  */
 export const getRPCEndpoint = (net) => {
+  if (net !== 'TestNet' && net !== 'MainNet') return net
   const apiEndpoint = getAPIEndpoint(net)
   return axios.get(apiEndpoint + '/v2/network/best_node').then((response) => {
     return response.data.node

--- a/src/transactions/create.js
+++ b/src/transactions/create.js
@@ -95,7 +95,7 @@ const calculateInputs = (publicKey, balances, intents, gasCost = 0) => {
   // We will work in integers here to be more accurate.
   // As assets are stored as Fixed8, we just multiple everything by 10e8 and round off to get integers.
   const requiredAssets = intents.reduce((assets, intent) => {
-    const fixed8Value = Math.floor(intent.value * 100000000)
+    const fixed8Value = Math.round(intent.value * 100000000)
     assets[intent.assetId] ? assets[intent.assetId] += fixed8Value : assets[intent.assetId] = fixed8Value
     return assets
   }, {})
@@ -108,7 +108,7 @@ const calculateInputs = (publicKey, balances, intents, gasCost = 0) => {
   const inputs = Object.keys(requiredAssets).map((assetId) => {
     const requiredAmt = requiredAssets[assetId]
     const assetBalance = balances[ASSETS[assetId]]
-    if (assetBalance.balance * 100000000 < requiredAmt) throw new Error(`Insufficient ${ASSETS[assetId]}! Need ${requiredAmt} but only found ${assetBalance.balance}`)
+    if (assetBalance.balance * 100000000 < requiredAmt) throw new Error(`Insufficient ${ASSETS[assetId]}! Need ${requiredAmt / 100000000} but only found ${assetBalance.balance}`)
     // Ascending order sort
     assetBalance.unspent.sort((a, b) => a.value - b.value)
     let selectedInputs = 0
@@ -116,7 +116,7 @@ const calculateInputs = (publicKey, balances, intents, gasCost = 0) => {
     // Selected min inputs to satisfy outputs
     while (selectedAmt < requiredAmt) {
       selectedInputs += 1
-      selectedAmt += Math.floor(assetBalance.unspent[selectedInputs - 1].value * 100000000)
+      selectedAmt += Math.round(assetBalance.unspent[selectedInputs - 1].value * 100000000)
     }
     // Construct change output
     if (selectedAmt > requiredAmt) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,7 +46,7 @@ export const num2hexstring = (num, size = 2) => {
  * @return {string} number in Fixed8 representation.
  */
 export const num2fixed8 = (num) => {
-  const hexValue = (num * 100000000).toString(16)
+  const hexValue = Math.round(num * 100000000).toString(16)
   return reverseHex(('0000000000000000' + hexValue).substring(hexValue.length))
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,9 +146,9 @@ export class StringStream {
   }
   readVarInt () {
     let len = parseInt(this.read(1), 16)
-    if (len === 0xfd) { len = parseInt(reverseHex(this.read(2)), 16) }
-    else if (len === 0xfe) { len = parseInt(reverseHex(this.read(4)), 16) }
-    else if (len === 0xff) { len = parseInt(reverseHex(this.read(8)), 16) }
+    if (len === 0xfd) len = parseInt(reverseHex(this.read(2)), 16)
+    else if (len === 0xfe) len = parseInt(reverseHex(this.read(4)), 16)
+    else if (len === 0xff) len = parseInt(reverseHex(this.read(8)), 16)
     return len
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -30,11 +30,14 @@ describe('Wallet', function () {
   const testNet = Neon.getAPIEndpoint('TestNet')
 
   // TODO: this works, but will not work repeatedly for obvious reasons :)
-  it.skip('should claim GAS', (done) => {
-    Neon.doClaimAllGas('TestNet', testKeys.b.wif).then((response) => {
-      console.log("claim", response)
-      done()
-    }).catch((e) => console.log(e))
+  it.skip('should claim GAS', () => {
+    return Neon.doClaimAllGas('TestNet', testKeys.b.wif)
+      .then((response) => {
+        console.log('claim', response)
+      }).catch((e) => {
+        console.log(e)
+        throw e
+      })
   })
 
   it('should generate a new private key', (done) => {
@@ -50,11 +53,14 @@ describe('Wallet', function () {
     account.privateKey.should.equal(ab2hexstring(privateKey))
   })
 
-  it('should encrypt a WIF using nep2', (done) => {
-    Neon.encryptWIF(testKeys.a.wif, testKeys.a.passphrase).then((result) => {
-      result.should.equal(testKeys.a.encryptedWif)
-      done()
-    }).catch((e) => console.log(e))
+  it('should encrypt a WIF using nep2', () => {
+    return Neon.encryptWIF(testKeys.a.wif, testKeys.a.passphrase)
+      .then((result) => {
+        result.should.equal(testKeys.a.encryptedWif)
+      }).catch((e) => {
+        console.log(e)
+        throw e
+      })
   })
 
   it('should verify that script has produces the same address', (done) => {
@@ -79,11 +85,14 @@ describe('Wallet', function () {
     done()
   })
 
-  it('should decrypt a WIF using nep2', (done) => {
-    Neon.decryptWIF(testKeys.a.encryptedWif, testKeys.a.passphrase).then((result) => {
-      result.should.equal(testKeys.a.wif)
-      done()
-    })
+  it('should decrypt a WIF using nep2', () => {
+    return Neon.decryptWIF(testKeys.a.encryptedWif, testKeys.a.passphrase)
+      .then((result) => {
+        result.should.equal(testKeys.a.wif)
+      }).catch((e) => {
+        console.log(e)
+        throw e
+      })
   })
 
   it('should get keys from a WIF', (done) => {
@@ -111,53 +120,74 @@ describe('Wallet', function () {
     done()
   })
 
-  it('should get balance from address', (done) => {
-    Neon.getBalance(Neon.TESTNET, testKeys.a.address).then((response) => {
-      response.NEO.balance.should.be.a('number')
-      response.GAS.balance.should.be.a('number')
-      done()
-    }).catch((e) => console.log(e))
+  it('should get balance from address', () => {
+    return Neon.getBalance('TestNet', testKeys.a.address)
+      .then((response) => {
+        response.NEO.balance.should.be.a('number')
+        response.GAS.balance.should.be.a('number')
+      }).catch((e) => {
+        console.log(e)
+        throw e
+      })
   })
 
-  it('should get unspent transactions', (done) => {
-    Neon.getBalance(Neon.TESTNET, testKeys.a.address, Neon.ansId).then((response) => {
-      response.NEO.unspent.should.be.an('array')
-      response.GAS.unspent.should.be.an('array')
-      done()
-    }).catch((e) => console.log(e))
+  it('should get unspent transactions', () => {
+    return Neon.getBalance('TestNet', testKeys.a.address, Neon.ansId)
+      .then((response) => {
+        response.NEO.unspent.should.be.an('array')
+        response.GAS.unspent.should.be.an('array')
+      }).catch((e) => {
+        console.log(e)
+        throw e
+      })
   })
 
-  it('should send NEO', (done) => {
-    Neon.doSendAsset(testNet, testKeys.b.address, testKeys.a.wif, {"NEO": 1}).then((response) => {
-      response.result.should.equal(true)
-      // send back so we can re-run
-      return Neon.doSendAsset(testNet, testKeys.a.address, testKeys.b.wif, {"NEO": 1})
-    }).then((response) => {
-      response.result.should.equal(true)
-      done()
-    }).catch((e) => console.log(e))
-  })
-
-  it('should send GAS', (done) => {
-    Neon.doSendAsset(testNet, testKeys.b.address, testKeys.a.wif, {"GAS": 1}).then((response) => {
-      response.result.should.equal(true)
-      // send back so we can re-run
-      Neon.doSendAsset(testNet, testKeys.a.address, testKeys.b.wif, {"GAS": 1}).then((response) => {
+  it('should send NEO', () => {
+    return Neon.doSendAsset('TestNet', testKeys.b.address, testKeys.a.wif, { 'NEO': 1 })
+      .then((response) => {
         response.result.should.equal(true)
-        done()
-      }).catch((e) => console.log(e))
-    })
+        // send back so we can re-run
+        return Neon.doSendAsset(testNet, testKeys.a.address, testKeys.b.wif, { 'NEO': 1 })
+      })
+      .then((response) => {
+        response.result.should.equal(true)
+      })
+      .catch((e) => {
+        console.log(e)
+        throw e
+      })
   })
 
+  it('should send GAS', () => {
+    return Neon.doSendAsset('TestNet', testKeys.b.address, testKeys.a.wif, { 'GAS': 1 })
+      .then((response) => {
+        response.should.have.property('result', true)
+        // send back so we can re-run
+        return Neon.doSendAsset('TestNet', testKeys.a.address, testKeys.b.wif, { 'GAS': 1 })
+      })
+      .then((response) => {
+        response.should.have.property('result', true)
+      })
+      .catch((e) => {
+        console.log(e)
+        throw e
+      })
+  })
   // this test passes, but cannot be run immediately following previous tests given state changes
   it.skip('should send NEO and GAS', (done) => {
-    Neon.doSendAsset(testNet, testKeys.b.address, testKeys.a.wif, {"GAS": 1, "NEO": 1}).then((response) => {
-      response.result.should.equal(true)
-      // send back so we can re-run
-      Neon.doSendAsset(testNet, testKeys.a.address, testKeys.b.wif, {"GAS": 1, "NEO": 1}).then((response) => {
-        response.result.should.equal(true)
+    return Neon.doSendAsset('TestNet', testKeys.b.address, testKeys.a.wif, { 'GAS': 1, 'NEO': 1 })
+      .then((response) => {
+        response.should.have.property('result', true)
+        // send back so we can re-run
+        return Neon.doSendAsset('TestNet', testKeys.a.address, testKeys.b.wif, { 'GAS': 1, 'NEO': 1 })
+      })
+      .then((response) => {
+        response.should.have.property('result', true)
         done()
-      }).catch((e) => console.log(e))
-    })
+      })
+      .catch((e) => {
+        console.log(e)
+        throw e
+      })
   })
 })


### PR DESCRIPTION
## Content
- Fix floating point error
  - `num2fixed8` uses `Math.round` to ensure that there is no trailing decimals
- fix addressToScriptHash
  - Implementation was missing `reverseHex`. Updated to `getScriptHashfromAddress` (naming convention in line with most wallet methods of getThisFromThat)
- Clean up `tests/index`
  - Convert promise cases to return promises instead of calling `done()`
  - Add catch and console logs to promises for better error exposure (Mocha compresses the object when we want to see the error returned by RPC)
- `getRPCEndpoint` to allow custom URLs.
  - This will make queryURL more flexible and let us query custom nodes if we wish to. Just pass in the custom url directly instead of `TestNet` or `MainNet`.

## Discussion

https://github.com/CityOfZion/neon-js/blob/84e2fde090ec7112f07db09bd57560da91fafc16/src/api.js#L91
 - How will we handle multiple intents if we want the transaction to handle it? Lets say i want to send 1 Neo and 1 Gas to 3 ppl. I think a simple helper for constructing intents is better (simple method that pulls assetId and converts address to scriptHash)

https://github.com/CityOfZion/neon-js/blob/84e2fde090ec7112f07db09bd57560da91fafc16/src/api.js#L236
  - I think we can extract and make `queryRPC` a more generic method to allow custom URLs.
  - I have added a check at `getRPCEndpoint` to allow custom URLs.

Most of the design decisions have been made to 
1. Make things human-readable. Storing as numbers and Big Endian so that we can print and see. Not sure if we want to abstract this to the UI level instead.
2.  Reduce the typing of the system. Most of the methods work with `string` intentionally because they are simple to work with, easy to debug and have a consistent API across all languages. Having a consistent string in, string out approach makes the methods very simple and clear.