### PR TITLE
bugfix to _emitNum w/unit tests

### DIFF
--- a/src/sc/scriptBuilder.js
+++ b/src/sc/scriptBuilder.js
@@ -1,4 +1,4 @@
-import { StringStream, num2hexstring, reverseHex, int2hex, hex2bytes } from '../utils.js'
+import { StringStream, num2hexstring, reverseHex, int2hex } from '../utils.js'
 import OpCode from './opCode.js'
 
 export default class ScriptBuilder extends StringStream {

--- a/src/sc/scriptBuilder.js
+++ b/src/sc/scriptBuilder.js
@@ -60,7 +60,7 @@ export default class ScriptBuilder extends StringStream {
     if (num === -1) return this.emit(OpCode.PUSHM1)
     if (num === 0) return this.emit(OpCode.PUSH0)
     if (num > 0 && num <= 16) return this.emit(OpCode.PUSH1 - 1 + num)
-    return this.emitPush(hex2bytes(int2hex(num), true).join(""))
+    return this.emitPush(hex2bytes(int2hex(num), true).join(''))
   }
 
   /**

--- a/src/sc/scriptBuilder.js
+++ b/src/sc/scriptBuilder.js
@@ -1,4 +1,4 @@
-import { StringStream, num2hexstring, reverseHex } from '../utils.js'
+import { StringStream, num2hexstring, reverseHex, int2hex, hex2bytes } from '../utils.js'
 import OpCode from './opCode.js'
 
 export default class ScriptBuilder extends StringStream {
@@ -60,7 +60,7 @@ export default class ScriptBuilder extends StringStream {
     if (num === -1) return this.emit(OpCode.PUSHM1)
     if (num === 0) return this.emit(OpCode.PUSH0)
     if (num > 0 && num <= 16) return this.emit(OpCode.PUSH1 - 1 + num)
-    return this.emitPush(num.toString(16))
+    return this.emitPush(hex2bytes(int2hex(num), true).join(""))
   }
 
   /**

--- a/src/sc/scriptBuilder.js
+++ b/src/sc/scriptBuilder.js
@@ -60,7 +60,7 @@ export default class ScriptBuilder extends StringStream {
     if (num === -1) return this.emit(OpCode.PUSHM1)
     if (num === 0) return this.emit(OpCode.PUSH0)
     if (num > 0 && num <= 16) return this.emit(OpCode.PUSH1 - 1 + num)
-    return this.emitPush(hex2bytes(int2hex(num), true).join(''))
+    return this.emitPush(reverseHex(int2hex(num)))
   }
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,6 +31,33 @@ export const ab2hexstring = arr => {
 }
 
 /**
+ * convert a hex string to a 'byte' array
+ * @param {string} mString
+ * @param {bool} reverse=false reverse order of bits
+ * @returns {*}
+ */
+export const hex2bytes = (mString, reverse = false) => {
+  let ret = [];
+  for (let i = 0; i < mString.length; i += 2) {
+    let char = mString[i] + "" + mString[i + 1];
+    ret.push(char);
+  }
+
+  return reverse ? ret.reverse() : ret;
+}
+
+/**
+ * convert an integer to hex and add leading zeros
+ * @param {number} mNumber
+ * @returns {string}
+ */
+export const int2hex = mNumber => {
+  let h = mNumber.toString(16);
+  let val = h.length % 2 ? '0' + h : h;
+  return val;
+}
+
+/**
  * Converts a number to a hexstring of a suitable size
  * @param {number} num
  * @param {number} size - The required size in chars, eg 2 for Uint8, 4 for Uint16. Defaults to 2.

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,9 +36,8 @@ export const ab2hexstring = arr => {
  * @returns {string}
  */
 export const int2hex = mNumber => {
-  let h = mNumber.toString(16);
-  let val = h.length % 2 ? '0' + h : h;
-  return val;
+  let h = mNumber.toString(16)
+  return h.length % 2 ? '0' + h : h
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,17 +33,17 @@ export const ab2hexstring = arr => {
 /**
  * convert a hex string to a 'byte' array
  * @param {string} mString
- * @param {bool} reverse=false reverse order of bits
+ * @param {boolean} reverse=false reverse order of bits
  * @returns {*}
  */
 export const hex2bytes = (mString, reverse = false) => {
-  let ret = [];
+  let ret = []
   for (let i = 0; i < mString.length; i += 2) {
-    let char = mString[i] + "" + mString[i + 1];
-    ret.push(char);
+    let char = mString[i] + '' + mString[i + 1]
+    ret.push(char)
   }
 
-  return reverse ? ret.reverse() : ret;
+  return reverse ? ret.reverse() : ret
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,22 +31,6 @@ export const ab2hexstring = arr => {
 }
 
 /**
- * convert a hex string to a 'byte' array
- * @param {string} mString
- * @param {boolean} reverse=false reverse order of bits
- * @returns {*}
- */
-export const hex2bytes = (mString, reverse = false) => {
-  let ret = []
-  for (let i = 0; i < mString.length; i += 2) {
-    let char = mString[i] + '' + mString[i + 1]
-    ret.push(char)
-  }
-
-  return reverse ? ret.reverse() : ret
-}
-
-/**
  * convert an integer to hex and add leading zeros
  * @param {number} mNumber
  * @returns {string}

--- a/tests/sc/scriptBuilder.js
+++ b/tests/sc/scriptBuilder.js
@@ -33,6 +33,30 @@ describe('ScriptBuilder', function () {
       'args': 7
     }
   }
+
+  const integers = [
+    {
+      int: -1,
+      result: '4f'  // opCodes.PUSHM1 (0x4F)
+    },
+    {
+      int: 0,
+      result: '00'
+    },
+    {
+      int: 13,
+      result: (0x50 + 13).toString(16)
+    },
+    {
+      int: 500,
+      result: '02f401'  // prefixed with number of bytes following (02)
+    },
+    {
+      int: 65536,
+      result: '03000001'
+    }
+  ]
+
   it('emitAppCall', () => {
     Object.keys(data).map((key) => {
       let testcase = data[key]
@@ -40,5 +64,13 @@ describe('ScriptBuilder', function () {
       const script = sb.emitAppCall(testcase.scriptHash, testcase.operation, testcase.args).str
       script.should.equal(testcase.script)
     })
+  })
+
+  it('_emitNum', () => {
+    for (let i = 0; i < integers.length; i++) {
+      let sb = new ScriptBuilder()
+      const result = sb._emitNum(integers[i].int)
+      result.str.should.equal(integers[i].result)
+    }
   })
 })


### PR DESCRIPTION
_emitNum was returning invalid results i.e 500 would return 1f4 whereas the bytecode should be f401

* _emitNum() reversed order of hex bytes and ensured leading 0 added to msb (when applicable)
* added unit tests for -1, 0, 13, 500, 65536
* utils.js: hex2bytes() convert a hex string to an array and optionally reverse order
* utils.js:  int2hex() convert an integer to hex and add leading zeros
