### PR TITLE
serializeWitness should use varint script lengths

### DIFF
--- a/src/transactions/components.js
+++ b/src/transactions/components.js
@@ -85,8 +85,8 @@ export const deserializeTransactionAttribute = (stream) => {
  */
 
 export const serializeWitness = (witness) => {
-  const invoLength = (witness.invocationScript.length / 2).toString(16)
-  const veriLength = (witness.verificationScript.length / 2).toString(16)
+  const invoLength = num2VarInt(witness.invocationScript.length / 2)
+  const veriLength = num2VarInt(witness.verificationScript.length / 2)
   return invoLength + witness.invocationScript + veriLength + witness.verificationScript
 }
 


### PR DESCRIPTION
Verified in the Neo source: https://git.io/vFWYR