### PR TITLE
Enable usage on private blockchain

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -51,7 +51,7 @@ export const allAssetIds = [neoId, gasId]
 
 /**
  * Perform a ClaimTransaction for all available GAS
- * @param {string} net - 'MainNet' or 'TestNet'.
+ * @param {string} net - 'MainNet', 'TestNet'.
  * @param {string} fromWif - WIF key of address you are claiming from.
  * @return {Promise<Response>} RPC response from sending transaction
  */
@@ -272,7 +272,7 @@ export const getClaimAmounts = (net, address) => {
  * @return {Promise<string>} The URL of the best performing node or the custom URL provided.
  */
 export const getRPCEndpoint = (net) => {
-  if (net !== 'TestNet' && net !== 'MainNet') return Promise.resolve(net)
+  // if (net !== 'TestNet' && net !== 'MainNet') return Promise.resolve(net)
   const apiEndpoint = getAPIEndpoint(net)
   return axios.get(apiEndpoint + '/v2/network/best_node').then((response) => {
     return response.data.node

--- a/src/api.js
+++ b/src/api.js
@@ -222,14 +222,17 @@ export const doSendTx = (net, transaction, id = 42) => {
 
 /**
  * API Switch for MainNet and TestNet
- * @param {string} net - 'MainNet' or 'TestNet'.
+ * @param {string} net - 'MainNet', 'TestNet', or custom neon-wallet-db URL.
  * @return {string} URL of API endpoint.
  */
 export const getAPIEndpoint = (net) => {
-  if (net === 'MainNet') {
-    return 'http://api.wallet.cityofzion.io'
-  } else {
-    return 'http://testnet-api.wallet.cityofzion.io'
+  switch (net) {
+    case 'MainNet':
+      return 'http://api.wallet.cityofzion.io'
+    case 'TestNet':
+      return 'http://testnet-api.wallet.cityofzion.io'
+    default:
+      return net
   }
 }
 

--- a/src/transactions/components.js
+++ b/src/transactions/components.js
@@ -85,8 +85,8 @@ export const deserializeTransactionAttribute = (stream) => {
  */
 
 export const serializeWitness = (witness) => {
-  const invoLength = (witness.invocationScript.length / 2).toString(16)
-  const veriLength = (witness.verificationScript.length / 2).toString(16)
+  const invoLength = num2VarInt(witness.invocationScript.length / 2)
+  const veriLength = num2VarInt(witness.verificationScript.length / 2)
   return invoLength + witness.invocationScript + veriLength + witness.verificationScript
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -173,6 +173,14 @@ describe('Wallet', function () {
         throw e
       })
   })
+
+  it('should allow custom API endpoint, i.e. for private net', done => {
+    const customEndpoint = 'http://localhost:5000'
+    const privNet = Neon.getAPIEndpoint(customEndpoint)
+    privNet.should.equal(customEndpoint)
+    done()
+  })
+  
   // this test passes, but cannot be run immediately following previous tests given state changes
   // it.skip('should send NEO and GAS', (done) => {
   //   return Neon.doSendAsset('TestNet', testKeys.b.address, testKeys.a.wif, { 'GAS': 1, 'NEO': 1 })


### PR DESCRIPTION
Includes test. Allows for usage like:

```JavaScript
const PrivNet = 'http://localhost:5000'

neon.getBalance(PrivNet, 'AP9GA3EVUbfLNMSWiZLu8fDZQs388Z1kVU').then(data => {
  console.log(data)
})
```