### PR TITLE
Fix script lengths to use correct formatting

### DIFF
--- a/src/transactions/components.js
+++ b/src/transactions/components.js
@@ -85,8 +85,8 @@ export const deserializeTransactionAttribute = (stream) => {
  */
 
 export const serializeWitness = (witness) => {
-  const invoLength = (witness.invocationScript.length / 2).toString(16)
-  const veriLength = (witness.verificationScript.length / 2).toString(16)
+  const invoLength = num2hexstring(witness.invocationScript.length / 2)
+  const veriLength = num2hexstring(witness.verificationScript.length / 2)
   return invoLength + witness.invocationScript + veriLength + witness.verificationScript
 }
 


### PR DESCRIPTION
Script lengths should use standard uint8 / uint16 formatting. 
The current serialization breaks when the invocation script is of a small length (e.g. zero length gives `0` instead of `00`).
