### PR TITLE
Correct Query.getBlock reference in RPCClient

### DIFF
--- a/src/rpc/client.js
+++ b/src/rpc/client.js
@@ -91,7 +91,7 @@ class RPCClient {
    * @return {Promise<Object|string>}
    */
   getBlock (indexOrHash, verbose = 1) {
-    return this.execute(Query.getblock(indexOrHash, verbose))
+    return this.execute(Query.getBlock(indexOrHash, verbose))
       .then((res) => {
         return res.result
       })


### PR DESCRIPTION
This PR contains only the source code change, and not the build files.