### PR TITLE
NEP5: getToken + better VM parsing 

### DIFF
--- a/source/api/index.rst
+++ b/source/api/index.rst
@@ -83,7 +83,7 @@ Neoscan
 
 The Neoscan API serves as a backup in case NeonDB fails. It is not exposed in semantic exports. Instead, use named exports::
 
-  import {api} from 'neon-js
+  import {api} from 'neon-js'
   api.neoscan.getBalance('TestNet', address)
   api.neoscan.getClaims('MainNet', address)
 
@@ -114,11 +114,13 @@ This set of methods rely on the NEO node having version >= 2.3.3. The method use
 
   import Neon from 'neon-js'
   const rpxScriptHash = Neon.CONST.CONTRACTS.TEST_RPX
-  Neon.get.tokenInfo(rpxScriptHash)
-  Neon.get.tokenBalance(rpxScriptHash, address)
+  Neon.get.tokenInfo('http://seed1.neo.org:20332', rpxScriptHash)
+  Neon.get.tokenBalance('http://seed1.neo.org:20332', rpxScriptHash, address)
 
   import { api } from 'neon-js'
-  api.nep5.getTokenInfo(rpxScriptHash)
-  api.nep5.getTokenBalance(rpxScriptHash)
+  api.nep5.getTokenInfo('http://seed1.neo.org:20332', rpxScriptHash)
+  api.nep5.getTokenBalance('http://seed1.neo.org:20332', rpxScriptHash)
+  // This is a combination of both info and balance within a single call
+  api.nep5.getToken('http://seed1.neo.org:20332', rpxScriptHash, address)
 
 .. _neon-wallet-db: https://github.com/CityOfZion/neon-wallet-db

--- a/source/reference/api.rst
+++ b/source/reference/api.rst
@@ -65,6 +65,10 @@ CoinMarketCap
 NEP5
 -----
 
+.. autofunction:: doTransferToken
+
+.. autofunction:: getToken
+
 .. autofunction:: getTokenInfo
 
 .. autofunction:: getTokenBalance

--- a/source/utility.rst
+++ b/source/utility.rst
@@ -14,7 +14,7 @@ The utility module contains:
 
 - Format manipulation methods
 - Hashing methods
-- utility classes
+- Utility classes
 
 Format
 -------

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -28,7 +28,8 @@ export default {
     claims: neonDB.getClaims,
     transactionHistory: neonDB.getTransactionHistory,
     tokenBalance: nep5.getTokenBalance,
-    tokenInfo: nep5.getTokenInfo
+    tokenInfo: nep5.getTokenInfo,
+    token: nep5.getToken
   },
   do: {
     sendAsset: neonDB.doSendAsset,

--- a/src/rpc/parse.js
+++ b/src/rpc/parse.js
@@ -27,3 +27,15 @@ export const VMExtractor = (res) => {
   const stack = res.result.stack
   return stack.map((item) => item.value)
 }
+
+/**
+ * Extracts the VM stack into an array and zips it with the provided array of parsing functions.
+ * @param {function[]} funcs - An array of parsing functions.
+ * @return {(res) => any[]} A parser function
+ */
+export const VMZip = (funcs) => {
+  return (res) => {
+    const stack = res.result.stack
+    return stack.map((item, i) => funcs[i](item.value))
+  }
+}

--- a/src/rpc/parse.js
+++ b/src/rpc/parse.js
@@ -33,9 +33,10 @@ export const VMExtractor = (res) => {
  * @param {function[]} funcs - An array of parsing functions.
  * @return {(res) => any[]} A parser function
  */
-export const VMZip = (funcs) => {
+export const VMZip = (...args) => {
   return (res) => {
     const stack = res.result.stack
-    return stack.map((item, i) => funcs[i](item.value))
+    if (stack.length !== args.length) throw new RangeError(`Invalid results length! Expected ${args.length} but got ${stack.length}`)
+    return stack.map((item, i) => args[i](item.value))
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,6 +66,12 @@ export const ab2hexstring = arr => {
 export const str2hexstring = str => ab2hexstring(str2ab(str))
 
 /**
+ * @param {string} hexstring - HEX string
+ * @returns {string} ASCII string
+ */
+export const hexstring2str = hexstring => ab2str(hexstring2ab(hexstring))
+
+/**
  * convert an integer to big endian hex and add leading zeros
  * @param {number} num
  * @returns {string}

--- a/tests/api/nep5.js
+++ b/tests/api/nep5.js
@@ -1,7 +1,7 @@
 import * as NEP5 from '../../src/api/nep5'
 import testKeys from '../testKeys.json'
 
-describe('NEP5', function () {
+describe.only('NEP5', function () {
   this.timeout(10000)
   const net = 'http://seed3.neo.org:20332'
   const scriptHash = 'd7678dd97c000be3f33e9362e673101bac4ca654'
@@ -19,6 +19,7 @@ describe('NEP5', function () {
         throw e
       })
   })
+
   it('get balance', () => {
     return NEP5.getTokenBalance(net, scriptHash, testKeys.c.address)
       .then(result => {
@@ -29,6 +30,32 @@ describe('NEP5', function () {
         throw e
       })
   })
+
+  describe('getToken', function () {
+    it('get info only', () => {
+      return NEP5.getToken(net, scriptHash)
+        .then(result => {
+          result.should.have.keys(['name', 'symbol', 'decimals', 'totalSupply', 'balance'])
+          result.name.should.equal('LOCALTOKEN')
+          result.symbol.should.equal('LWTF')
+          result.decimals.should.equal(8)
+          result.totalSupply.should.least(1969000)
+        })
+    })
+
+    it('get info and balance', () => {
+      return NEP5.getToken(net, scriptHash, testKeys.c.address)
+        .then(result => {
+          result.should.have.keys(['name', 'symbol', 'decimals', 'totalSupply', 'balance'])
+          result.name.should.equal('LOCALTOKEN')
+          result.symbol.should.equal('LWTF')
+          result.decimals.should.equal(8)
+          result.totalSupply.should.least(1969000)
+          result.balance.should.be.above(0)
+        })
+    })
+  })
+
   it('transfers tokens', () => {
     const testNet = 'TestNet'
     const fromWif = 'L5FzBMGSG2d7HVJL5vWuXfxUKsrkX5irFhtw1L5zU4NAvNuXzd8a'


### PR DESCRIPTION
- Adds `api.nep5.getToken` which is a combination of both `getTokenInfo` and `getTokenBalance`. It returns an object with all the information of both calls inside. This method is also exposed semantically as `get.token`.

- Add a `VMZip` method which zips the VM results with a array of parsing functions, allowing for custom parsing of each result. This is useful as a returned ByteArray can be interpreted differently, thus we require customizable parsers for each result. Do look at nep5 methods for how it is used.

