### PR TITLE
[Fix] Transactions spend coins from Balance

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -136,6 +136,9 @@ export const sendTx = (config) => {
       // Parse result
       if (res.result === true) {
         res.txid = config.tx.hash
+        if (config.balance) {
+          config.balance.applyTx(config.tx, true)
+        }
       }
       return Object.assign(config, { response: res })
     })

--- a/src/transactions/transaction.js
+++ b/src/transactions/transaction.js
@@ -183,6 +183,7 @@ class Transaction {
     const { inputs, change } = core.calculateInputs(balance, this.outputs, this.gas)
     this.inputs = inputs
     this.outputs = this.outputs.concat(change)
+    balance.applyTx(this)
     return this
   }
 

--- a/src/transactions/transaction.js
+++ b/src/transactions/transaction.js
@@ -104,13 +104,13 @@ class Transaction {
    * @return {Transaction} Unsigned Transaction
    */
   static createContractTx (balances, intents, override = {}) {
+    if (intents === null) throw new Error(`Useless transaction!`)
     const txConfig = Object.assign({
       type: 128,
-      version: TX_VERSION.CONTRACT
+      version: TX_VERSION.CONTRACT,
+      outputs: intents
     }, override)
-    let { inputs, change } = core.calculateInputs(balances, intents)
-    const outputs = intents.concat(change)
-    return new Transaction(Object.assign(txConfig, { inputs, outputs }, override))
+    return new Transaction(txConfig).calculate(balances)
   }
 
   /**
@@ -126,15 +126,12 @@ class Transaction {
     if (intents === null) intents = []
     const txConfig = Object.assign({
       type: 209,
-      version: TX_VERSION.INVOCATION
-    }, override)
-    const { inputs, change } = core.calculateInputs(balances, intents, gasCost)
-    const outputs = intents.concat(change)
-    const exclusive = {
+      version: TX_VERSION.INVOCATION,
+      outputs: intents,
       script: typeof (invoke) === 'string' ? invoke : createScript(invoke),
       gas: gasCost
-    }
-    return new Transaction(Object.assign(txConfig, { inputs, outputs }, exclusive, override))
+    }, override)
+    return new Transaction(txConfig).calculate(balances)
   }
 
   /**

--- a/src/wallet/Balance.js
+++ b/src/wallet/Balance.js
@@ -33,11 +33,11 @@ class Balance {
     this.address = bal.address
     this.net = bal.net
     this.assetSymbols = bal.assetSymbols ? bal.assetSymbols : []
-    this.assets = bal.assets ? bal.assets : {}
+    this.assets = {}
     if (bal.assets) {
-      Object.keys(bal).map((key) => {
-        if (typeof bal[key] === 'object') {
-          this.addAsset(key, bal[key])
+      Object.keys(bal.assets).map((key) => {
+        if (typeof bal.assets[key] === 'object') {
+          this.addAsset(key, bal.assets[key])
         }
       })
     }

--- a/src/wallet/Balance.js
+++ b/src/wallet/Balance.js
@@ -104,6 +104,10 @@ class Balance {
       if (!assetBalance) this.addAsset(sym)
       const coin = { index: i, txid: hash, value: output.value }
       if (confirmed) {
+        let unconfirmedIndex = assetBalance.unconfirmed.findIndex((el) => el.txid === coin.txid && el.index === coin.index)
+        if (unconfirmedIndex >= 0) {
+          assetBalance.unconfirmed.splice(unconfirmedIndex, 1)
+        }
         assetBalance.balance += output.value
         if (!assetBalance.unspent) assetBalance.unspent = []
         assetBalance.unspent.push(coin)

--- a/src/wallet/Balance.js
+++ b/src/wallet/Balance.js
@@ -54,7 +54,7 @@ class Balance {
   addAsset (sym, assetBalance = { balance: 0, spent: [], unspent: [], unconfirmed: [] }) {
     sym = sym.toUpperCase()
     this.assetSymbols.push(sym)
-    const newBalance = Object.assign({}, { balance: 0, spent: [], unspent: [], unconfirmed: [] }, assetBalance)
+    const newBalance = Object.assign({ balance: 0, spent: [], unspent: [], unconfirmed: [] }, assetBalance)
     this.assets[sym] = JSON.parse(JSON.stringify(newBalance))
     return this
   }

--- a/tests/api/core.js
+++ b/tests/api/core.js
@@ -1,6 +1,7 @@
 import * as core from '../../src/api/core'
 import { neonDB, neoscan } from '../../src/api'
 import { Transaction, signTransaction } from '../../src/transactions'
+import { Balance } from '../../src/wallet'
 import testKeys from '../testKeys.json'
 import testData from '../testData.json'
 import axios from 'axios'
@@ -121,16 +122,19 @@ describe('Core API', function () {
   })
 
   describe('createTx', function () {
-    const config = Object.assign({}, baseConfig, {
-      balance: testData.a.balance,
-      claims: testData.a.claims,
-      intents: [{
-        assetId: '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7',
-        value: 1.1,
-        scriptHash: 'cef0c0fdcfe7838eff6ff104f9cdec2922297537'
-      }],
-      script: '001234567890',
-      gas: 0.1
+    let config
+    beforeEach(() => {
+      config = Object.assign({}, baseConfig, {
+        balance: new Balance(JSON.parse(JSON.stringify(testData.a.balance))),
+        claims: testData.a.claims,
+        intents: [{
+          assetId: '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7',
+          value: 1.1,
+          scriptHash: 'cef0c0fdcfe7838eff6ff104f9cdec2922297537'
+        }],
+        script: '001234567890',
+        gas: 0.1
+      })
     })
     it('claims', () => {
       return core.createTx(config, 'claim')

--- a/tests/api/nep5.js
+++ b/tests/api/nep5.js
@@ -1,7 +1,7 @@
 import * as NEP5 from '../../src/api/nep5'
 import testKeys from '../testKeys.json'
 
-describe.only('NEP5', function () {
+describe('NEP5', function () {
   this.timeout(10000)
   const net = 'http://seed3.neo.org:20332'
   const scriptHash = 'd7678dd97c000be3f33e9362e673101bac4ca654'

--- a/tests/transactions/transaction.js
+++ b/tests/transactions/transaction.js
@@ -1,4 +1,5 @@
 import Tx from '../../src/transactions/transaction'
+import { Balance } from '../../src/wallet'
 import data from './data.json'
 import createData from './createData.json'
 import { ASSET_ID, CONTRACTS } from '../../src/consts'
@@ -43,30 +44,35 @@ describe('Transaction', function () {
   })
 
   it('create ContractTx', () => {
+    const balance = new Balance(JSON.parse(JSON.stringify(createData.balance)))
     const intents = [{
       assetId: ASSET_ID['NEO'],
       value: 2,
       scriptHash: 'cef0c0fdcfe7838eff6ff104f9cdec2922297537'
     }]
-    const tx = Tx.createContractTx(createData.balance, intents)
+    const tx = Tx.createContractTx(balance, intents)
     tx.type.should.equal(128)
     tx.exclusiveData.should.eql({})
     tx.inputs.length.should.equal(2)
     tx.outputs.length.should.equal(2)
+    balance.assets.NEO.unconfirmed.length.should.equal(2)
+    balance.assets.NEO.spent.length.should.equal(2)
   })
 
   it('create InvocationTx', () => {
+    const balance = new Balance(JSON.parse(JSON.stringify(createData.balance)))
     const invoke = {
       scriptHash: CONTRACTS.TEST_RPX,
       operation: 'name'
     }
-    const tx = Tx.createInvocationTx(createData.balance, null, invoke, 0.001)
+    const tx = Tx.createInvocationTx(balance, null, invoke, 0.001)
     tx.type.should.equal(209)
     tx.exclusiveData.should.eql({
       gas: 0.001,
       script: '00046e616d656711c4d1f4fba619f2628870d36e3a9773e874705b'
     })
     tx.inputs.length.should.be.at.least(1)
+    balance.assets.GAS.unconfirmed.length.should.equal(1)
   })
 
   it('deserialize', () => {

--- a/tests/wallet/Balance.js
+++ b/tests/wallet/Balance.js
@@ -54,10 +54,9 @@ describe('Balance', function () {
         scriptHash: 'cef0c0fdcfe7838eff6ff104f9cdec2922297537'
       }
     ]
-    const tx = Transaction.createContractTx(testData.a.balance, intents)
 
     it('unconfirmed', () => {
-      bal.applyTx(tx, false)
+      Transaction.createContractTx(bal, intents)
       bal.assets.GAS.spent.length.should.equal(1)
       bal.assets.GAS.unspent.length.should.equal(1)
       bal.assets.GAS.unconfirmed.length.should.equal(2)
@@ -67,6 +66,7 @@ describe('Balance', function () {
     })
 
     it('confirmed', () => {
+      const tx = Transaction.createContractTx(bal, intents)
       bal.applyTx(tx, true)
       bal.assets.GAS.spent.length.should.equal(1)
       bal.assets.GAS.unspent.length.should.equal(3)

--- a/tests/wallet/Balance.js
+++ b/tests/wallet/Balance.js
@@ -1,6 +1,8 @@
 import Balance from '../../src/wallet/Balance'
 import testData from '../testData.json'
 import { Transaction } from '../../src/transactions'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
 
 describe('Balance', function () {
   let bal
@@ -77,11 +79,24 @@ describe('Balance', function () {
     })
   })
 
-  it('verifyAssets', () => {
-    return bal.verifyAssets('http://seed1.neo.org:20332')
-      .then((bal) => {
-        bal.assets.GAS.spent.length.should.least(1)
-        bal.assets.NEO.spent.length.should.least(1)
+  describe('verifyAssets', function () {
+    let mock
+    before(() => {
+      mock = new MockAdapter(axios)
+      mock.onPost().reply(200, {
+        'jsonrpc': '2.0',
+        'id': 1234,
+        'result': null
       })
+    })
+    after(() => mock.restore())
+
+    it('all spent', () => {
+      return bal.verifyAssets('http://seed1.neo.org:20332')
+        .then((bal) => {
+          bal.assets.GAS.spent.length.should.equal(2)
+          bal.assets.NEO.spent.length.should.equal(1)
+        })
+    })
   })
 })


### PR DESCRIPTION
Closes #83 

- Bugfix Balance constructor reading wrong object for assets.
- Transaction construction now alters the state of the provided Balance.
- ``api.core.sendTx`` now alters the state of the provided Balance (config.balance).