### PR TITLE
catch getTokenBalance error when using an address with no balance

### DIFF
--- a/src/api/nep5.js
+++ b/src/api/nep5.js
@@ -44,7 +44,11 @@ export const getTokenBalance = (net, scriptHash, address) => {
   const script = sb.emitAppCall(scriptHash, 'balanceOf', [addrScriptHash]).str
   return Query.invokeScript(script, false).execute(net)
     .then((res) => {
-      return fixed82num(res.result.stack[0].value)
+      try {
+        return fixed82num(res.result.stack[0].value)
+      } catch (error) {
+        return 0
+      }
     })
 }
 


### PR DESCRIPTION
the `stack[0].value` returns ‘’ when using an address with no balance
causing it to throw “fixed8hex must be hex” in `fixed82num()`.