### PR TITLE
[Fix] Fixed82num not accepting empty string as zero

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -119,7 +119,8 @@ export const num2fixed8 = (num, size = 16) => {
  */
 export const fixed82num = (fixed8hex) => {
   if (typeof fixed8hex !== 'string') throw new Error('fixed8hex must be a string')
-  if (!fixed8hex.length || fixed8hex.length % 2 !== 0) throw new Error('fixed8hex must be hex')
+  if (fixed8hex.length % 2 !== 0) throw new Error('fixed8hex must be hex')
+  if (fixed8hex === '') return 0
   return parseInt(reverseHex(fixed8hex), 16) / Math.pow(10, 8)
 }
 

--- a/tests/integration/api/nep5.js
+++ b/tests/integration/api/nep5.js
@@ -1,0 +1,19 @@
+import * as NEP5 from '../../../src/api/nep5'
+import { DEFAULT_RPC, CONTRACTS } from '../../../src/consts'
+import testKeys from '../../unit/testKeys.json'
+
+describe('Integration: API NEP5', function () {
+  describe('getToken', function () {
+    it('get info and balance', () => {
+      return NEP5.getToken(DEFAULT_RPC.TEST, CONTRACTS.TEST_LWTF, testKeys.c.address)
+        .then(result => {
+          result.should.have.keys(['name', 'symbol', 'decimals', 'totalSupply', 'balance'])
+          result.name.should.equal('LOCALTOKEN')
+          result.symbol.should.equal('LWTF')
+          result.decimals.should.equal(8)
+          result.totalSupply.should.least(1969000)
+          result.balance.should.be.above(0)
+        })
+    })
+  })
+})

--- a/tests/unit/api/mockData.json
+++ b/tests/unit/api/mockData.json
@@ -980,6 +980,47 @@
           ]
         }
       }
+    },
+    "getTokenZero": {
+      "url": "http://seed1.neo.org:20332",
+      "body": {
+        "jsonrpc": "2.0",
+        "method": "invokescript",
+        "params": [
+          "00046e616d656754a64cac1b1073e662933ef3e30b007cd98d67d7000673796d626f6c6754a64cac1b1073e662933ef3e30b007cd98d67d70008646563696d616c736754a64cac1b1073e662933ef3e30b007cd98d67d7000b746f74616c537570706c796754a64cac1b1073e662933ef3e30b007cd98d67d71435b20010db73bf86371075ddfba4e6596f1ff35d51c10962616c616e63654f666754a64cac1b1073e662933ef3e30b007cd98d67d7"
+        ],
+        "id": 1234
+      },
+      "response": {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "result": {
+          "state": "HALT, BREAK",
+          "gas_consumed": "1.34",
+          "stack": [
+            {
+              "type": "ByteArray",
+              "value": "4c4f43414c544f4b454e"
+            },
+            {
+              "type": "ByteArray",
+              "value": "4c575446"
+            },
+            {
+              "type": "Integer",
+              "value": "8"
+            },
+            {
+              "type": "ByteArray",
+              "value": "00305d8e74ce00"
+            },
+            {
+              "type": "ByteArray",
+              "value": ""
+            }
+          ]
+        }
+      }
     }
   },
   "core": {

--- a/tests/unit/api/nep5.js
+++ b/tests/unit/api/nep5.js
@@ -60,6 +60,18 @@ describe('NEP5', function () {
           result.balance.should.be.above(0)
         })
     })
+
+    it('get info and balance of zero', () => {
+      return NEP5.getToken(url, scriptHash, testKeys.b.address)
+        .then(result => {
+          result.should.have.keys(['name', 'symbol', 'decimals', 'totalSupply', 'balance'])
+          result.name.should.equal('LOCALTOKEN')
+          result.symbol.should.equal('LWTF')
+          result.decimals.should.equal(8)
+          result.totalSupply.should.least(1969000)
+          result.balance.should.equal(0)
+        })
+    })
   })
 
   it.skip('transfers tokens using neonDB', () => {

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -200,11 +200,13 @@ describe('Utils', () => {
     it('throws if not a string', () => {
       (() => fixed82num(1)).should.throw()
     })
-    it('throws if empty string', () => {
-      (() => fixed82num('')).should.throw()
-    })
     it('throws if non-hex string', () => {
       (() => fixed82num('xxx')).should.throw()
+    })
+    it('converts an empty string to zero', () => {
+      const actual = fixed82num('')
+      const expected = 0
+      actual.should.eql(expected)
     })
     it('converts a number to fixed8 hex', () => {
       const actual = fixed82num('00e1f50500000000')


### PR DESCRIPTION
Resolves #105 

- `fixed82num` now returns 0 when receiving empty string
- Add tests for `getToken` for zero balance
- Add a integration test for `getToken` to ensure data consistency