### PR TITLE
[CI] Update CI image to latest Node LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,18 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:7.10
+    - image: circleci/node:8.9.3
 version: 2
 jobs:
   build:
     <<: *defaults
     steps:
+      - run:
+          name: "Versions"
+          command: |
+            node --version
+            npm --version
+            yarn --version
       - checkout
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           key: neon-{{ checksum "package.json" }}
-      - run: yarn install
+      - run: npm install
       - save_cache:
           key: neon-{{ checksum "package.json" }}
           paths:
@@ -33,14 +33,14 @@ jobs:
       - checkout
       - restore_cache:
           key: neon-{{ checksum "package.json" }}
-      - run: yarn test
+      - run: npm run test:integration
   unit-test:
     <<: *defaults
     steps:
       - checkout
       - restore_cache:
           key: neon-{{ checksum "package.json" }}
-      - run: yarn test:unit
+      - run: npm run test:unit
 
 workflows:
   version: 2


### PR DESCRIPTION
- Upgrade CI Image to Node 8.9.3 (includes latest security fix)
- Do a version check at the start