### PR TITLE
[Fix] Fix transferToken tests

### DIFF
--- a/debug/tokenBalance.js
+++ b/debug/tokenBalance.js
@@ -1,0 +1,22 @@
+const Neon = require('../lib/index.js')
+const testKeys = require('../tests/unit/testKeys.json')
+
+const url = Neon.CONST.DEFAULT_RPC.TEST
+
+const printTokenBalances = function (scriptHash) {
+  return Neon.api.nep5.getTokenInfo(url, scriptHash)
+    .then(({ symbol }) => {
+      console.log(`=== ${symbol} ===`)
+    })
+    .then(() => {
+      const balances = Object.keys(testKeys).map((key) => {
+        const addr = testKeys[key].address
+        return Neon.api.nep5.getToken(url, scriptHash, addr)
+          .then((res) => console.log(`${key}: ${res.balance}`))
+      })
+      return Promise.all(balances)
+    })
+}
+
+printTokenBalances(Neon.CONST.CONTRACTS.TEST_LWTF)
+  .then(() => printTokenBalances(Neon.CONST.CONTRACTS.TEST_RPX))

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha --compilers js:babel-core/register --require ./tests/common.js --recursive ./tests",
-    "test:unit":"./node_modules/.bin/mocha --compilers js:babel-core/register --require ./tests/common.js --recursive ./tests/unit",
-    "test:integration":"./node_modules/.bin/mocha --compilers js:babel-core/register --require ./tests/common.js --recursive ./tests/integration",
+    "test:unit": "./node_modules/.bin/mocha --compilers js:babel-core/register --require ./tests/common.js --recursive ./tests/unit",
+    "test:integration": "./node_modules/.bin/mocha --compilers js:babel-core/register --require ./tests/common.js --recursive ./tests/integration",
     "lint": "./node_modules/.bin/eslint ./src/**/*.js ./tests/**/*.js",
     "build:dev": "./node_modules/.bin/webpack --env.dev",
     "build:prod": "./node_modules/.bin/webpack --env.prod",
@@ -50,7 +50,7 @@
     "build:docs": "cd source && sphinx-versioning -g ../ -l ./conf.py build source ../docs",
     "deploy:docs": "cd source && sphinx-versioning -g ../ -l ./conf.py push source gh-pages .",
     "rebuild": "rm -rf ./node_modules && npm install && ./node_modules/.bin/webpack",
-    "prepublish": "npm run lint && npm run build:prod"
+    "prepublishOnly": "npm run lint && npm run build:prod"
   },
   "repository": {
     "type": "git",
@@ -67,5 +67,9 @@
   "bugs": {
     "url": "https://github.com/CityOfZion/neon-js/issues"
   },
-  "homepage": "https://github.com/CityOfZion/neon-js#readme"
+  "homepage": "https://github.com/CityOfZion/neon-js#readme",
+  "files": [
+    "lib/",
+    "src/"
+  ]
 }

--- a/src/api/nep5.js
+++ b/src/api/nep5.js
@@ -110,11 +110,11 @@ export const doTransferToken = (net, scriptHash, fromWif, toAddress, transferAmo
       endpt = values[0]
       const balances = values[1]
       const fromAddrScriptHash = getScriptHashFromAddress(account.address)
+      const toAddrScriptHash = reverseHex(getScriptHashFromAddress(toAddress))
       const intents = [
         { assetId: ASSET_ID.GAS, value: 0.00000001, scriptHash: fromAddrScriptHash }
       ]
-      const toAddrScriptHash = reverseHex(getScriptHashFromAddress(toAddress))
-      const invoke = { scriptHash, operation: 'transfer', args: [fromAddrScriptHash, toAddrScriptHash, transferAmount] }
+      const invoke = { scriptHash, operation: 'transfer', args: [reverseHex(fromAddrScriptHash), toAddrScriptHash, transferAmount] }
       const unsignedTx = Transaction.createInvocationTx(balances, intents, invoke, gasCost, { version: 1 })
       if (signingFunction) {
         return signingFunction(unsignedTx, account.publicKey)

--- a/tests/integration/api/core.js
+++ b/tests/integration/api/core.js
@@ -1,4 +1,7 @@
 import * as core from '../../../src/api/core'
+import { CONTRACTS } from '../../../src/consts'
+import { ContractParam } from '../../../src/sc'
+import testKeys from '../../unit/testKeys.json'
 
 describe('Integration: API Core', function () {
   this.timeout(20000)
@@ -9,11 +12,11 @@ describe('Integration: API Core', function () {
   })
   describe('sendAsset', function () {
     it('NeonDB', () => {
-      const intent1 = core.makeIntent({ NEO: 1 }, 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW')
+      const intent1 = core.makeIntent({ NEO: 1 }, testKeys.a.address)
       const config1 = {
         net: 'TestNet',
-        address: 'ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s',
-        privateKey: '9ab7e154840daca3a2efadaf0df93cd3a5b51768c632f5433f86909d9b994a69',
+        address: testKeys.b.address,
+        privateKey: testKeys.b.privateKey,
         intents: intent1
       }
 
@@ -29,11 +32,11 @@ describe('Integration: API Core', function () {
       mock.onGet(/testnet-api.wallet/).timeout()
       mock.onAny().passThrough()
 
-      const intent2 = core.makeIntent({ NEO: 1 }, 'ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s')
+      const intent2 = core.makeIntent({ NEO: 1 }, testKeys.b.address)
       const config2 = {
         net: 'TestNet',
-        address: 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW',
-        privateKey: '7d128a6d096f0c14c3a25a2b0c41cf79661bfcb4a8cc95aaaea28bde4d732344',
+        address: testKeys.a.address,
+        privateKey: testKeys.a.privateKey,
         intents: intent2
       }
       return core.sendAsset(config2)
@@ -48,8 +51,8 @@ describe('Integration: API Core', function () {
     it('neonDB', () => {
       const config = {
         net: 'TestNet',
-        address: 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW',
-        privateKey: '7d128a6d096f0c14c3a25a2b0c41cf79661bfcb4a8cc95aaaea28bde4d732344'
+        address: testKeys.a.address,
+        privateKey: testKeys.a.privateKey
       }
       return core.claimGas(config)
         .then((c) => {
@@ -65,8 +68,8 @@ describe('Integration: API Core', function () {
 
       const config2 = {
         net: 'TestNet',
-        address: 'ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s',
-        privateKey: '9ab7e154840daca3a2efadaf0df93cd3a5b51768c632f5433f86909d9b994a69'
+        address: testKeys.b.address,
+        privateKey: testKeys.b.privateKey
       }
       return core.claimGas(config2)
         .then((c) => {
@@ -80,9 +83,9 @@ describe('Integration: API Core', function () {
     it('neonDB', () => {
       const config = {
         net: 'TestNet',
-        address: 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW',
-        privateKey: '7d128a6d096f0c14c3a25a2b0c41cf79661bfcb4a8cc95aaaea28bde4d732344',
-        intents: core.makeIntent({ GAS: 0.1 }, 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW'),
+        address: testKeys.a.address,
+        privateKey: testKeys.a.privateKey,
+        intents: core.makeIntent({ GAS: 0.1 }, testKeys.a.address),
         script: '00c1046e616d65675f0e5a86edd8e1f62b68d2b3f7c0a761fc5a67dc',
         gas: 0
       }

--- a/tests/integration/api/core.js
+++ b/tests/integration/api/core.js
@@ -97,16 +97,24 @@ describe('Integration: API Core', function () {
     })
 
     it('neoscan', () => {
+      // This does a transferToken
       mock = setupMock()
       mock.onGet(/testnet-api.wallet/).timeout()
       mock.onAny().passThrough()
-
+      const fromAddrScriptHash = ContractParam.byteArray(testKeys.b.address, 'address')
+      const toAddrScriptHash = ContractParam.byteArray(testKeys.c.address, 'address')
+      const transferAmount = ContractParam.byteArray(0.00000001, 'fixed8')
+      const script = {
+        scriptHash: CONTRACTS.TEST_LWTF,
+        operation: 'transfer',
+        args: ContractParam.array(fromAddrScriptHash, toAddrScriptHash, transferAmount)
+      }
       const config2 = {
         net: 'TestNet',
-        address: 'ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s',
-        privateKey: '9ab7e154840daca3a2efadaf0df93cd3a5b51768c632f5433f86909d9b994a69',
-        intents: core.makeIntent({ GAS: 0.1 }, 'ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s'),
-        script: '00c1046e616d65675f0e5a86edd8e1f62b68d2b3f7c0a761fc5a67dc',
+        address: testKeys.b.address,
+        privateKey: testKeys.b.privateKey,
+        intents: core.makeIntent({ GAS: 0.1 }, testKeys.b.address),
+        script,
         gas: 0
       }
       return core.doInvoke(config2)

--- a/tests/integration/api/nep5.js
+++ b/tests/integration/api/nep5.js
@@ -3,9 +3,12 @@ import { DEFAULT_RPC, CONTRACTS } from '../../../src/consts'
 import testKeys from '../../unit/testKeys.json'
 
 describe('Integration: API NEP5', function () {
+  this.timeout(20000)
+  const scriptHash = CONTRACTS.TEST_LWTF
+
   describe('getToken', function () {
     it('get info and balance', () => {
-      return NEP5.getToken(DEFAULT_RPC.TEST, CONTRACTS.TEST_LWTF, testKeys.c.address)
+      return NEP5.getToken(DEFAULT_RPC.TEST, scriptHash, testKeys.c.address)
         .then(result => {
           result.should.have.keys(['name', 'symbol', 'decimals', 'totalSupply', 'balance'])
           result.name.should.equal('LOCALTOKEN')
@@ -15,5 +18,16 @@ describe('Integration: API NEP5', function () {
           result.balance.should.be.above(0)
         })
     })
+  })
+
+  it('doTransferToken', () => {
+    const testNet = 'TestNet'
+    const transferAmount = 1
+    const gasCost = 0
+    return NEP5.doTransferToken(testNet, scriptHash, testKeys.c.wif, testKeys.b.address, transferAmount, gasCost)
+      .then(({ result, txid }) => {
+        result.should.equal(true)
+        console.log(txid)
+      })
   })
 })


### PR DESCRIPTION
- Fix transferTokens test
- Clean up integration tests, all to use testKeys instead of strings
- `doInvoke neoscan` is now a token transfer test
- use package.json to whitelist files for publishing