### PR TITLE
[WIP] Updated sendAssets to support NEP5 tokens

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -166,9 +166,9 @@ export const makeIntent = (assetAmts, address) => {
  * @param {object} config - Configuration object.
  * @param {string} config.net - 'MainNet', 'TestNet' or a neon-wallet-db URL.
  * @param {string} config.address - Wallet address
- * @param {string} [privateKey] - private key to sign with. Either this or signingFunction is required.
- * @param {function} [signingFunction] - An external signing function to sign with. Either this or privateKey is required.
- * @param {TransactionOutput[]} intents - Intents.
+ * @param {string} [config.privateKey] - private key to sign with. Either this or signingFunction is required.
+ * @param {function} [config.signingFunction] - An external signing function to sign with. Either this or privateKey is required.
+ * @param {TransactionOutput[]} config.intents - Intents.
  * @return {object} Configuration object.
  */
 export const sendAsset = (config) => {
@@ -187,8 +187,8 @@ export const sendAsset = (config) => {
  * @param {object} config - Configuration object.
  * @param {string} config.net - 'MainNet', 'TestNet' or a neon-wallet-db URL.
  * @param {string} config.address - Wallet address
- * @param {string} [privateKey] - private key to sign with. Either this or signingFunction is required.
- * @param {function} [signingFunction] - An external signing function to sign with. Either this or privateKey is required.
+ * @param {string} [config.privateKey] - private key to sign with. Either this or signingFunction is required.
+ * @param {function} [config.signingFunction] - An external signing function to sign with. Either this or privateKey is required.
  * @return {object} Configuration object.
  */
 export const claimGas = (config) => {
@@ -243,9 +243,9 @@ const attachInvokedContract = (config) => {
  * @param {object} config - Configuration object.
  * @param {string} config.net - 'MainNet', 'TestNet' or a neon-wallet-db URL.
  * @param {string} config.address - Wallet address
- * @param {string} [privateKey] - private key to sign with. Either this or signingFunction is required.
- * @param {function} [signingFunction] - An external signing function to sign with. Either this or privateKey is required.
- * @param {object} [intents] - Intents
+ * @param {string} [config.privateKey] - private key to sign with. Either this or signingFunction is required.
+ * @param {function} [config.signingFunction] - An external signing function to sign with. Either this or privateKey is required.
+ * @param {object} [config.intents] - Intents
  * @param {string} config.script - VM script. Must include empty args parameter even if no args are present
  * @param {number} config.gas - gasCost of VM script.
  * @return {object} Configuration object.

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -204,6 +204,21 @@ const createTransferScript = (transfers) => {
 }
 
 /**
+ * Create an invocation transaction for token transfers or a contract transaction for asset transfers.
+ * @param {object} config - Configuration object.
+ * @param {ScriptOutput[]} config.transfers - Transfers.
+ * @return {string} Configuration object.
+ */
+const createTransferTx = (config) => {
+  if (config.transfers) {
+    config.script = createTransferScript(config.transfers)
+    return createTx(config, 'invocation')
+  } else {
+    return createTx(config, 'contract')
+  }
+}
+
+/**
  * Function to construct and execute a ContractTransaction.
  * @param {object} config - Configuration object.
  * @param {string} config.net - 'MainNet', 'TestNet' or a neon-wallet-db URL.
@@ -217,14 +232,7 @@ const createTransferScript = (transfers) => {
 export const sendAsset = (config) => {
   return getBalanceFrom(config, neonDB)
     .catch(() => getBalanceFrom(config, neoscan))
-    .then((c) => {
-      if (c.transfers) {
-        c.script = createTransferScript(c.transfers)
-        return createTx(c, 'invocation')
-      } else {
-        return createTx(c, 'contract')
-      }
-    })
+    .then((c) => createTransferTx(c))
     .then((c) => signTx(c))
     .then((c) => sendTx(c))
 }

--- a/tests/unit/api/core.js
+++ b/tests/unit/api/core.js
@@ -80,6 +80,25 @@ describe('Core API', function () {
       )
   })
 
+  it('makeTransfer', () => {
+    const RPX = 'ecc6b20d3ccac1ee9ef109af5a7cdb85706b1df9'
+    const DBC = 'b951ecbbc5fe37a9c280a76cb0ce0014827294cf'
+
+    core.makeTransfer({ [RPX]: 5100, [DBC]: 19250 }, 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW', 'AP4AswDCgRCRF7Z6oMQMrFBzTuRgbeiQNF')
+      .should.deep.include.members([
+        {
+          scriptHash: RPX,
+          operation: 'transfer',
+          args: ['4fddeb8f2560ab19f6b1cc484125b84a0e0ca021', 'cef0c0fdcfe7838eff6ff104f9cdec2922297537', 5100]
+        },
+        {
+          scriptHash: DBC,
+          operation: 'transfer',
+          args: ['4fddeb8f2560ab19f6b1cc484125b84a0e0ca021', 'cef0c0fdcfe7838eff6ff104f9cdec2922297537', 19250]
+        }
+      ])
+  })
+
   describe('getBalanceFrom', function () {
     it('Retrieves information properly', () => {
       const config = Object.assign({}, baseConfig)


### PR DESCRIPTION
This updates the existing `sendAssets` core API function to accepts a new `config.transfers` array for sending tokens in addition to assets.  It also exposes a new `makeTransfer` helper function (similar to `makeIntent`) for creating the transfer script outputs needed to generate the invocation script.

Example:

```js
const fromAddress = 'AP4AswDCgRCRF7Z6oMQMrFBzTuRgbeiQNF'
const toAddress = 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW'
const RPX = 'ecc6b20d3ccac1ee9ef109af5a7cdb85706b1df9'
const DBC = 'b951ecbbc5fe37a9c280a76cb0ce0014827294cf'

sendAsset({
  net: 'MainNet',
  address: fromAddress
  privateKey: 'foo',
  transfers: [
    makeTransfer({ [RPX]: 1500 }, toAddress, fromAddress),
    makeTransfer({ [RPX]: 1500, [DBC]: 9750 }, toAddress, fromAddress),
  ],
  intents: [
    makeIntent({ NEO: 5, GAS: 0.1 }, toAddress)
  ]
})
```