### PR TITLE
feat(api): Api switch to toggle between neonDB and neoscan

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -13,13 +13,22 @@ import { txAttrUsage } from '../transactions/txAttrUsage'
 * This is ensure that we do not always hit the failing endpoint.
 */
 var apiSwitch = 0
-
+var switchFrozen = false
 export const setApiSwitch = (newSetting) => {
   if (newSetting >= 0 && newSetting <= 1) apiSwitch = newSetting
 }
-const increaseNeoscanWeight = () => { apiSwitch > 0 ? apiSwitch -= 0.2 : null }
 
-const increaseNeonDBWeight = () => { apiSwitch < 1 ? apiSwitch += 0.2 : null }
+export const setSwitchFreeze = (newSetting) => {
+  switchFrozen = !!newSetting
+}
+
+const increaseNeoscanWeight = () => {
+  if (!switchFrozen && apiSwitch > 0) apiSwitch -= 0.2
+}
+
+const increaseNeonDBWeight = () => {
+  if (!switchFrozen && apiSwitch < 1) apiSwitch += 0.2
+}
 const loadBalance = (func, config) => {
   if (Math.random() > apiSwitch) {
     return func(config, neoscan)

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -209,11 +209,7 @@ export const makeIntent = (assetAmts, address) => {
  * @return {object} Configuration object.
  */
 export const sendAsset = (config) => {
-  return getBalanceFrom(config, neonDB)
-    .then(
-    (c) => c,
-    () => getBalanceFrom(config, neoscan)
-    )
+  return loadBalance(getBalanceFrom, config)
     .then((c) => createTx(c, 'contract'))
     .then((c) => signTx(c))
     .then((c) => sendTx(c))
@@ -229,50 +225,10 @@ export const sendAsset = (config) => {
  * @return {object} Configuration object.
  */
 export const claimGas = (config) => {
-  return getClaimsFrom(config, neonDB)
-    .then(
-    (c) => c,
-    () => getClaimsFrom(config, neoscan)
-    )
+  return loadBalance(getClaimsFrom, config)
     .then((c) => createTx(c, 'claim'))
     .then((c) => signTx(c))
     .then((c) => sendTx(c))
-}
-
-/**
- * Adds attributes to the override object for mintTokens invocations.
- * @param {object} config - Configuration object.
- * @return {object} Configuration object.
- */
-const addAttributes = (config) => {
-  if (!config.override) config.override = {}
-  if ((typeof config.script === 'object') && config.script.operation === 'mintTokens' && config.script.scriptHash) {
-    config.override.attributes = [{
-      data: reverseHex(config.script.scriptHash),
-      usage: txAttrUsage.Script
-    }]
-  }
-  return config
-}
-
-/**
- * Adds the contractState to mintTokens invocations.
- * @param {object} config - Configuration object.
- * @return {object} Configuration object.
- */
-const attachInvokedContract = (config) => {
-  if ((typeof config.script === 'object') && config.script.operation === 'mintTokens' && config.script.scriptHash) {
-    return Query.getContractState(config.script.scriptHash).execute(config.url)
-      .then((contractState) => {
-        const attachInvokedContract = {
-          invocationScript: '0000',
-          verificationScript: contractState.result.script
-        }
-        config.tx.scripts.unshift(attachInvokedContract)
-        return config
-      })
-  }
-  return config
 }
 
 /**
@@ -288,14 +244,46 @@ const attachInvokedContract = (config) => {
  * @return {object} Configuration object.
  */
 export const doInvoke = (config) => {
-  return getBalanceFrom(config, neonDB)
-    .then(
-    (c) => c,
-    () => getBalanceFrom(config, neoscan)
-    )
-    .then((c) => addAttributes(c))
+  return loadBalance(getBalanceFrom, config)
+    .then((c) => addAttributesForMintToken(c))
     .then((c) => createTx(c, 'invocation'))
     .then((c) => signTx(c))
-    .then((c) => attachInvokedContract(c))
+    .then((c) => attachInvokedContractForMintToken(c))
     .then((c) => sendTx(c))
+}
+
+/**
+ * Adds attributes to the override object for mintTokens invocations.
+ * @param {object} config - Configuration object.
+ * @return {object} Configuration object.
+ */
+const addAttributesForMintToken = (config) => {
+  if (!config.override) config.override = {}
+  if ((typeof config.script === 'object') && config.script.operation === 'mintTokens' && config.script.scriptHash) {
+    config.override.attributes = [{
+      data: reverseHex(config.script.scriptHash),
+      usage: txAttrUsage.Script
+    }]
+  }
+  return config
+}
+
+/**
+ * Adds the contractState to mintTokens invocations.
+ * @param {object} config - Configuration object.
+ * @return {object} Configuration object.
+ */
+const attachInvokedContractForMintToken = (config) => {
+  if ((typeof config.script === 'object') && config.script.operation === 'mintTokens' && config.script.scriptHash) {
+    return Query.getContractState(config.script.scriptHash).execute(config.url)
+      .then((contractState) => {
+        const attachInvokedContract = {
+          invocationScript: '0000',
+          verificationScript: contractState.result.script
+        }
+        config.tx.scripts.unshift(attachInvokedContract)
+        return config
+      })
+  }
+  return config
 }

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -40,6 +40,8 @@ declare module '@cityofzion/neon-js' {
 
 
     //core
+    export function setApiSwitch(newSetting: number): void
+    export function setSwitchFreeze(newSetting: boolean): void
     export function getBalanceFrom(config: apiConfig, api: object): apiConfig
     export function getClaimsFrom(config: apiConfig, api: object): apiConfig
     export function createTx(config: apiConfig, txType: string): apiConfig

--- a/tests/integration/api/core.js
+++ b/tests/integration/api/core.js
@@ -7,11 +7,25 @@ describe('Integration: API Core', function () {
   this.timeout(20000)
   let mock
 
+  const useNeonDB = () => {
+    mock = setupMock()
+    mock.onGet(/neoscan/).timeout()
+    mock.onAny().passThrough()
+  }
+
+  const useNeoscan = () => {
+    mock = setupMock()
+    mock.onGet(/testnet-api.wallet/).timeout()
+    mock.onAny().passThrough()
+  }
   afterEach(() => {
+    core.setApiSwitch(0)
     if (mock) mock.restore()
   })
   describe('sendAsset', function () {
     it('NeonDB', () => {
+      useNeonDB()
+
       const intent1 = core.makeIntent({ NEO: 1 }, testKeys.a.address)
       const config1 = {
         net: NEO_NETWORK.TEST,
@@ -28,9 +42,7 @@ describe('Integration: API Core', function () {
     })
 
     it('Neoscan', () => {
-      mock = setupMock()
-      mock.onGet(/testnet-api.wallet/).timeout()
-      mock.onAny().passThrough()
+      useNeoscan()
 
       const intent2 = core.makeIntent({ NEO: 1 }, testKeys.b.address)
       const config2 = {
@@ -49,6 +61,8 @@ describe('Integration: API Core', function () {
 
   describe('claimGas', function () {
     it('neonDB', () => {
+      useNeonDB()
+
       const config = {
         net: NEO_NETWORK.TEST,
         address: testKeys.a.address,
@@ -62,9 +76,7 @@ describe('Integration: API Core', function () {
     })
 
     it('neoscan', () => {
-      mock = setupMock()
-      mock.onGet(/testnet-api.wallet/).timeout()
-      mock.onAny().passThrough()
+      useNeoscan()
 
       const config2 = {
         net: NEO_NETWORK.TEST,
@@ -81,6 +93,8 @@ describe('Integration: API Core', function () {
 
   describe('doInvoke', function () {
     it('neonDB', () => {
+      useNeonDB()
+
       const config = {
         net: NEO_NETWORK.TEST,
         address: testKeys.a.address,
@@ -96,11 +110,9 @@ describe('Integration: API Core', function () {
         })
     })
 
-    it('transfers tokens', () => {
+    it('neoscan: transfer tokens', () => {
       // This does a transferToken
-      mock = setupMock()
-      mock.onGet(/testnet-api.wallet/).timeout()
-      mock.onAny().passThrough()
+      useNeoscan()
       const fromAddrScriptHash = ContractParam.byteArray(testKeys.b.address, 'address')
       const toAddrScriptHash = ContractParam.byteArray(testKeys.c.address, 'address')
       const transferAmount = ContractParam.byteArray(0.00000001, 'fixed8')
@@ -126,9 +138,7 @@ describe('Integration: API Core', function () {
 
     it.skip('mints tokens', () => {
       // This does a mint tokens call
-      mock = setupMock()
-      mock.onGet(/testnet-api.wallet/).timeout()
-      mock.onAny().passThrough()
+      useNeoscan()
       const script = {
         scriptHash: CONTRACTS.TEST_NXT,
         operation: 'mintTokens',


### PR DESCRIPTION
An API switch variable that allows toggling between neonDB and neoscan.

This allows us to load balance and ensure we don't keep hitting an endpoint when its down.

Methods:

`api.core.setApiSwitch`: set the apiSwitch to a predetermined number. 0 for 100% neoscan, 1 for 100% neonDB.

`api.core.setSwitchFreeze`: set the switch to freeze or not. Frozen switch will not dynamically react to failing endpoints.