### PR TITLE
fix(tx): core.signTransaction to check for privateKey

### DIFF
--- a/src/transactions/core.js
+++ b/src/transactions/core.js
@@ -1,5 +1,5 @@
 import { num2VarInt, num2hexstring, StringStream, reverseHex, hash256 } from '../utils'
-import { generateSignature, getVerificationScriptFromPublicKey, getPublicKeyFromPrivateKey, getScriptHashFromAddress } from '../wallet'
+import { generateSignature, getVerificationScriptFromPublicKey, getPublicKeyFromPrivateKey, getScriptHashFromAddress, isPrivateKey } from '../wallet'
 import { serializeExclusive, deserializeExclusive } from './exclusive'
 import { ASSETS, ASSET_ID } from '../consts'
 import * as comp from './components'
@@ -133,6 +133,7 @@ export const deserializeTransaction = (data) => {
  * @return {Transaction} Signed transaction as an object.
  */
 export const signTransaction = (transaction, privateKey) => {
+  if (!isPrivateKey(privateKey)) throw new Error('Key provided does not look like a private key!')
   const invocationScript = '40' + generateSignature(serializeTransaction(transaction, false), privateKey)
   const verificationScript = getVerificationScriptFromPublicKey(getPublicKeyFromPrivateKey(privateKey))
   const witness = { invocationScript, verificationScript }

--- a/src/transactions/transaction.js
+++ b/src/transactions/transaction.js
@@ -1,4 +1,4 @@
-import { getScriptHashFromPublicKey, getScriptHashFromAddress, isAddress } from '../wallet'
+import { Account, getScriptHashFromPublicKey, getScriptHashFromAddress, isAddress } from '../wallet'
 import { TX_VERSION, ASSET_ID } from '../consts'
 import { createScript } from '../sc'
 import { str2hexstring, num2VarInt } from '../utils'
@@ -218,11 +218,14 @@ class Transaction {
 
   /**
    * Signs a transaction.
-   * @param {string} privateKey
+   * @param {Account|string} signer - Account, privateKey or WIF
    * @return {Transaction} this
    */
-  sign (privateKey) {
-    return core.signTransaction(this, privateKey)
+  sign (signer) {
+    if (typeof signer === 'string') {
+      signer = new Account(signer)
+    }
+    return core.signTransaction(this, signer.privateKey)
   }
 }
 

--- a/tests/integration/api/core.js
+++ b/tests/integration/api/core.js
@@ -4,7 +4,7 @@ import { ContractParam } from '../../../src/sc'
 import testKeys from '../../unit/testKeys.json'
 
 describe('Integration: API Core', function () {
-  this.timeout(20000)
+  this.timeout(30000)
   let mock
 
   const useNeonDB = () => {

--- a/tests/unit/transactions/transaction.js
+++ b/tests/unit/transactions/transaction.js
@@ -1,5 +1,5 @@
 import Tx from '../../../src/transactions/transaction'
-import { Balance } from '../../../src/wallet'
+import { Balance, Account } from '../../../src/wallet'
 import data from './data.json'
 import createData from './createData.json'
 import { ASSET_ID, CONTRACTS } from '../../../src/consts'
@@ -132,6 +132,31 @@ describe('Transaction', function () {
     Object.keys(data).map((k) => {
       const tx = new Tx(data[k].deserialized)
       tx.serialize().should.equal(data[k].serialized.stream)
+    })
+  })
+
+  describe('sign', function () {
+    it('with privateKey', () => {
+      const tx = new Tx(data[1].deserialized)
+      tx.scripts = []
+      tx.sign(data[1].privateKey)
+      tx.serialize().should.equal(data[1].serialized.stream)
+    })
+
+    it('with WIF', () => {
+      const tx = new Tx(data[1].deserialized)
+      tx.scripts = []
+      const acct = new Account(data[1].privateKey)
+      tx.sign(acct.WIF)
+      tx.serialize().should.equal(data[1].serialized.stream)
+    })
+
+    it('with Account', () => {
+      const tx = new Tx(data[1].deserialized)
+      tx.scripts = []
+      const acct = new Account(data[1].privateKey)
+      tx.sign(acct)
+      tx.serialize().should.equal(data[1].serialized.stream)
     })
   })
 })


### PR DESCRIPTION
- Implement a simple check for privateKey before signing. Encountered case where WIF was inserted instead and resulted in wrong signature.

- Expanded `Transaction.sign` to accept `Account` and `WIF`

- write tests for `Transaction.sign`