### PR TITLE
Fixed default values for invocation exclusive config

### DIFF
--- a/src/transactions/exclusive.js
+++ b/src/transactions/exclusive.js
@@ -86,7 +86,7 @@ const serializeInvocationExclusive = (tx) => {
 }
 
 const getInvocationExclusive = (tx) => {
-  return Object.assign({ script: '', gas: 0 }, { script: tx.script, gas: tx.gas })
+  return { script: tx.script || '', gas: tx.gas || 0 }
 }
 
 export const serializeExclusive = {


### PR DESCRIPTION
This fixes the setting of default values for the invocation script.  Without this, the default values can be overridden by `null` or `undefined` if the key is not set on the transaction config, which I don't believe is the intention.