### PR TITLE
feat(util): Fixed8 class based off bignumber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -937,6 +937,11 @@
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
     },
+    "bignumber.js": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "types": "src/index.d.ts",
   "dependencies": {
     "axios": "^0.16.2",
+    "bignumber.js": "^5.0.0",
     "bs58": "^4.0.1",
     "bs58check": "^2.1.1",
     "crypto-js": "^3.1.9-1",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import { SHA256, RIPEMD160, enc } from 'crypto-js'
+import BN from 'bignumber.js'
 
 /**
  * @param {arrayBuffer} buf
@@ -284,4 +285,29 @@ export const sha256 = (hex) => {
   if (hex.length % 2 !== 0) throw new Error(`Incorrect Length: ${hex}`)
   let hexEncoded = enc.Hex.parse(hex)
   return SHA256(hexEncoded).toString()
+}
+
+/**
+ * @class Fixed8
+ * @classdesc A warpper around bignumber.js that adds on helper methods commonly used in neon-js
+ * @param {string|int} value
+ * @param {[number]} base
+ */
+export class Fixed8 extends BN {
+  toHex () {
+    const hexstring = this.mul(100000000).trunc().toString(16)
+    return '0'.repeat(16 - hexstring.length) + hexstring
+  }
+
+  toReverseHex () {
+    return reverseHex(this.toHex())
+  }
+
+  static fromHex (hex) {
+    return new Fixed8(hex, 16).div(100000000)
+  }
+
+  static fromReverseHex (hex) {
+    return this.fromHex(reverseHex(hex))
+  }
 }

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -14,7 +14,8 @@ import {
   reverseHex,
   sha256,
   str2ab,
-  str2hexstring
+  str2hexstring,
+  Fixed8
 } from '../../src/utils'
 
 describe('Utils', () => {
@@ -376,6 +377,43 @@ describe('Utils', () => {
       const again = sha256(expected)
       actual.should.eql(expected)
       again.should.eql(hash256(input))
+    })
+  })
+
+  describe('Fixed8', () => {
+    describe('constructor', () => {
+      it('number', () => {
+        let result = new Fixed8(1.23456789).toString()
+        result.should.eql('1.23456789')
+      })
+
+      it('hex', () => {
+        let result = new Fixed8('0000000005f5e100', 16).toNumber()
+        result.should.eql(100000000)
+      })
+
+      it('string', () => {
+        let result = new Fixed8('1.23456789').toNumber()
+        result.should.eql(1.23456789)
+      })
+    })
+    it('fromHex', () => {
+      let result = Fixed8.fromHex('0000000005f5e100').toNumber()
+      result.should.eql(1)
+    })
+
+    it('fromReverseHex', () => {
+      let result = Fixed8.fromReverseHex('00e1f50500000000').toNumber()
+      result.should.eql(1)
+    })
+    it('toHex', () => {
+      let result = new Fixed8(1).toHex()
+      result.should.eql('0000000005f5e100')
+    })
+
+    it('toReverseHex', () => {
+      let result = new Fixed8(1).toReverseHex()
+      result.should.eql('00e1f50500000000')
     })
   })
 })


### PR DESCRIPTION
This introduces the `Fixed8` util class extending `bignumber.js`. Basically I pinned on several methods for parsing hexstrings since it is used so often within `neon-js`.

 we want to move towards using this safer number types for storing value and this class would allow us to calculate and transform data safely and easily.