### PR TITLE
feat(tx): Claims using Fixed8 

### DIFF
--- a/src/api/neonDB.js
+++ b/src/api/neonDB.js
@@ -3,7 +3,7 @@ import { Account, Balance } from '../wallet'
 import { Transaction, TxAttrUsage } from '../transactions'
 import { Query } from '../rpc'
 import { ASSET_ID } from '../consts'
-import { reverseHex } from '../utils'
+import { Fixed8, reverseHex } from '../utils'
 import logger from '../logging'
 
 const log = logger('api')
@@ -55,8 +55,17 @@ export const getBalance = (net, address) => {
 export const getClaims = (net, address) => {
   const apiEndpoint = getAPIEndpoint(net)
   return axios.get(apiEndpoint + '/v2/address/claims/' + address).then((res) => {
-    log.info(`Retrieved Claims for ${address} from neonDB ${net}`)
-    return res.data
+    const claims = res.data
+    claims.claims = claims.claims.map(c => {
+      return {
+        claim: new Fixed8(c.claim).div(100000000),
+        index: c.index,
+        start: new Fixed8(c.start),
+        end: new Fixed8(c.end),
+        txid: c.txid
+      }
+    })
+    return claims
   })
 }
 

--- a/src/api/neoscan.js
+++ b/src/api/neoscan.js
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { Balance } from '../wallet'
 import { Fixed8 } from '../utils'
+import logger from '../logging'
 
 const log = logger('api')
 export const name = 'neoscan'
@@ -103,7 +104,7 @@ const parseClaims = (claimArr) => {
   return claimArr.map((c) => {
     return {
       start: new Fixed8(c.start_height),
-      end: new Fixed8(c.ed_height),
+      end: new Fixed8(c.end_height),
       index: c.n,
       claim: new Fixed8(c.unclaimed),
       txid: c.txid,

--- a/src/api/neoscan.js
+++ b/src/api/neoscan.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import { Balance } from '../wallet'
-import logger from '../logging'
+import { Fixed8 } from '../utils'
 
 const log = logger('api')
 export const name = 'neoscan'
@@ -102,10 +102,10 @@ const parseUnspent = (unspentArr) => {
 const parseClaims = (claimArr) => {
   return claimArr.map((c) => {
     return {
-      start: c.start_height,
-      end: c.ed_height,
+      start: new Fixed8(c.start_height),
+      end: new Fixed8(c.ed_height),
       index: c.n,
-      claim: Math.round(c.unclaimed * 100000000),
+      claim: new Fixed8(c.unclaimed),
       txid: c.txid,
       value: c.value
     }

--- a/src/transactions/transaction.js
+++ b/src/transactions/transaction.js
@@ -85,7 +85,7 @@ class Transaction {
     txConfig.outputs = [{
       assetId: ASSET_ID.GAS,
       value: totalClaim,
-      scriptHash: new Account(publicKeyOrAddress).acct.scriptHash
+      scriptHash: new Account(publicKeyOrAddress).scriptHash
     }]
     return new Transaction(Object.assign(txConfig, override))
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -300,7 +300,7 @@ export class Fixed8 extends BN {
   }
 
   toHex () {
-    const hexstring = this.mul(100000000).trunc().toString(16)
+    const hexstring = this.mul(100000000).round().toString(16)
     return '0'.repeat(16 - hexstring.length) + hexstring
   }
 

--- a/src/wallet/Claims.js
+++ b/src/wallet/Claims.js
@@ -1,0 +1,19 @@
+import { Fixed8 } from '../utils'
+
+export default class Claims {
+  constructor (config) {
+    this.address = config.address
+    this.net = config.net
+    this.claims = config.claims.map(c => parseClaimItem(c))
+  }
+}
+
+const parseClaimItem = (c) => {
+  return {
+    claim: new Fixed8(c.claim),
+    start: new Fixed8(c.start),
+    end: new Fixed8(c.end),
+    index: c.index,
+    txid: c.txid
+  }
+}

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -6,6 +6,7 @@ import * as nep2 from './nep2'
 import Account from './Account'
 import Balance from './Balance'
 import Wallet from './Wallet'
+import Claims from './Claims'
 
 export default {
   create: {
@@ -40,4 +41,4 @@ export default {
 export * from './core'
 export * from './verify'
 export * from './nep2'
-export { Account, Balance, Wallet }
+export { Account, Balance, Wallet, Claims }

--- a/tests/unit/transactions/createData.json
+++ b/tests/unit/transactions/createData.json
@@ -3,7 +3,7 @@
     "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
     "claims": [
       {
-        "claim": 1485205,
+        "claim": 0.01485205,
         "end": 532342,
         "index": 0,
         "start": 530504,
@@ -12,7 +12,7 @@
         "value": 101
       },
       {
-        "claim": 186400,
+        "claim": 0.00186400,
         "end": 532575,
         "index": 1,
         "start": 532342,
@@ -21,7 +21,7 @@
         "value": 100
       },
       {
-        "claim": 54648,
+        "claim": 0.00054648,
         "end": 532644,
         "index": 1,
         "start": 532575,
@@ -30,7 +30,7 @@
         "value": 99
       },
       {
-        "claim": 257152,
+        "claim": 0.00257152,
         "end": 532972,
         "index": 1,
         "start": 532644,

--- a/tests/unit/transactions/transaction.js
+++ b/tests/unit/transactions/transaction.js
@@ -1,5 +1,5 @@
 import Tx from '../../../src/transactions/transaction'
-import { Balance, Account } from '../../../src/wallet'
+import { Balance, Account, Claims } from '../../../src/wallet'
 import data from './data.json'
 import createData from './createData.json'
 import { ASSET_ID, CONTRACTS } from '../../../src/consts'
@@ -33,7 +33,7 @@ describe('Transaction', function () {
   })
 
   it('create ClaimTx', () => {
-    const tx = Tx.createClaimTx(createData.claim.address, createData.claim)
+    const tx = Tx.createClaimTx(createData.claim.address, new Claims(createData.claim))
     tx.type.should.equal(2)
     tx.claims.length.should.equal(4)
     tx.outputs.length.should.equal(1)
@@ -79,7 +79,7 @@ describe('Transaction', function () {
   it('deserialize', () => {
     Object.keys(data).map((k) => {
       const tx = Tx.deserialize(data[k].serialized.stream)
-      tx.should.eql(data[k].deserialized)
+      tx.should.eql(new Tx(data[k].deserialized))
     })
   })
 


### PR DESCRIPTION
- `claimGas` to fully use Fixed8
- Changed how we parse neoscan and neonDB input to return Fixed8 numbers
- created a `Claims` class in `wallet` as a simple way to make a native `Claims` object with a Claims-like JS object.
- Updated Fixed8 to use `round` instead of `trunc`. `round` should be safer for numbers that are already affected by JS floating point issue.