### PR TITLE
feat(all): JS Object constructors

### DIFF
--- a/src/api/coinmarketcap.js
+++ b/src/api/coinmarketcap.js
@@ -26,8 +26,8 @@ export const getPrice = (coin = 'NEO', currency = 'usd') => {
 
 /**
  * Returns a mapping of the symbol for a coin to its price
- * @param {Array<string>} coins - Coin names. NEO or GAS.
- * @param {string} currency - Three letter currency symbol.
+ * @param {string[]} [coins] - Coin names. NEO or GAS.
+ * @param {string} [currency] - Three letter currency symbol.
  * @return {Promise<object>} object mapping symbol to price
  */
 export const getPrices = (coins = ['NEO'], currency = 'usd') => {

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -26,13 +26,17 @@ export const setSwitchFreeze = (newSetting) => {
 }
 
 const increaseNeoscanWeight = () => {
-  log.info(`core API Switch increasing weight towards neoscan`)
-  if (!switchFrozen && apiSwitch > 0) apiSwitch -= 0.2
+  if (!switchFrozen && apiSwitch > 0) {
+    apiSwitch -= 0.2
+    log.info(`core API Switch increasing weight towards neoscan`)
+  }
 }
 
 const increaseNeonDBWeight = () => {
-  log.info(`core API Switch increasing weight towards neonDB`)
-  if (!switchFrozen && apiSwitch < 1) apiSwitch += 0.2
+  if (!switchFrozen && apiSwitch < 1) {
+    apiSwitch += 0.2
+    log.info(`core API Switch increasing weight towards neonDB`)
+  }
 }
 const loadBalance = (func, config) => {
   if (Math.random() > apiSwitch) {

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -16,10 +16,20 @@ const log = logger('api')
 */
 var apiSwitch = 1
 var switchFrozen = true
+
+/**
+ * Sets the API switch to the provided value
+ * @param {number} netSetting - The new value between 0 and 1 inclusive.
+ */
 export const setApiSwitch = (newSetting) => {
   if (newSetting >= 0 && newSetting <= 1) apiSwitch = newSetting
 }
 
+/**
+ * Sets the freeze setting for the API switch. A frozen switch will not dynamically shift towards the other provider when the main provider fails.
+ *  This does not mean that we do not use the other provider. This only means that we will not change our preference for the main provider.
+ * @param {bool} newSetting - The new setting for freeze.
+ */
 export const setSwitchFreeze = (newSetting) => {
   switchFrozen = !!newSetting
   log.info(`core/setSwitchFreeze API switch is frozen: ${switchFrozen}`)
@@ -63,22 +73,17 @@ const loadBalance = (func, config) => {
 }
 
 /**
- * Check that properties are defined in obj.
- * @param {object} obj - Object to check.
- * @param {string[]}  props - List of properties to check.
+ * The core API methods are series of methods defined to aid conducting core functionality while making it easy to modify any parts of it.
+ * The core functionality are sendAsset, claimGas and doInvoke.
+ * These methods are designed to be modular in nature and intended for developers to create their own custom methods.
+ * The methods revolve around a configuration object in which everything is placed. Each method will take in the configuration object, check for its required fields and perform its operations, adding its results to the configuration object and returning it.
+ * For example, the getBalanceFrom function requires net and address fields and appends the url and balance fields to the object.
  */
-const checkProperty = (obj, ...props) => {
-  for (const prop of props) {
-    if (!obj.hasOwnProperty(prop)) {
-      throw new ReferenceError(`Property not found: ${prop}`)
-    }
-  }
-}
 
 /**
  * Helper method to retrieve balance and URL from an endpoint. If URL is provided, it is not overriden.
  * @param {object} config - Configuration object.
- * @param {string} config.net - 'MainNet', 'TestNet' or a neon-wallet-db URL.
+ * @param {string} config.net - 'MainNet' or 'TestNet'
  * @param {string} config.address - Wallet address
  * @param {object} api - The endpoint API object. eg, neonDB or Neoscan.
  * @return {object} Configuration object + url + balance
@@ -104,7 +109,7 @@ export const getBalanceFrom = (config, api) => {
 /**
  * Helper method to retrieve claims and URL from an endpoint.
  * @param {object} config - Configuration object.
- * @param {string} config.net - 'MainNet', 'TestNet' or a neon-wallet-db URL.
+ * @param {string} config.net - 'MainNet', 'TestNet'
  * @param {string} config.address - Wallet address
  * @param {object} api - The endpoint APi object. eg, neonDB or Neoscan.
  * @return {object} Configuration object + url + balance
@@ -359,4 +364,17 @@ const attachInvokedContractForMintToken = (config) => {
       })
   }
   return config
+}
+
+/**
+ * Check that properties are defined in obj.
+ * @param {object} obj - Object to check.
+ * @param {string[]}  props - List of properties to check.
+ */
+const checkProperty = (obj, ...props) => {
+  for (const prop of props) {
+    if (!obj.hasOwnProperty(prop)) {
+      throw new ReferenceError(`Property not found: ${prop}`)
+    }
+  }
 }

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -40,7 +40,7 @@ declare module '@cityofzion/neon-js' {
     //coinmarketcap
     export namespace cmc {
       export function getPrice(coin?: string, currency?: string): Promise<number>
-      export function getPrices(coin?: Array<string>, currency?: string): Promise<Prices>
+      export function getPrices(coin?: string[], currency?: string): Promise<Prices>
     }
 
 
@@ -61,7 +61,7 @@ declare module '@cityofzion/neon-js' {
     export namespace neonDB {
       export function getAPIEndpoint(net: string): string
       export function getBalance(net: string, address: string): Promise<Balance>
-      export function getClaims(net: string, address: string): Promise<Claim>
+      export function getClaims(net: string, address: string): Promise<Claims>
       export function getRPCEndpoint(net: string): Promise<string>
       export function getTransactionHistory(net: string, address: string): Promise<History>
       export function getWalletDBHeight(net: string): Promise<number>
@@ -112,7 +112,7 @@ declare module '@cityofzion/neon-js' {
       export function getAPIEndpoint(net: string): string
       export function getRPCEndpoint(net: string): Promise<string>
       export function getBalance(net: string, address: string): Promise<Balance>
-      export function getClaims(net: string, address: string): Promise<Claim>
+      export function getClaims(net: string, address: string): Promise<Claims>
     }
 
     //nep5
@@ -134,7 +134,7 @@ declare module '@cityofzion/neon-js' {
   export interface semantic {
     get: {
       price: (coin?: string, currency?: string) => Promise<number>
-      prices: (coins?: Array<string>, currency?: string) => Promise<object>
+      prices: (coins?: string[], currency?: string) => Promise<object>
       balance: (net: string, address: string) => Promise<Balance>
       claims: (net: string, address: string) => Promise<Claim>
       transactionHistory: (net: string, address: string) => Promise<History>

--- a/src/api/neonDB.js
+++ b/src/api/neonDB.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { Account, Balance } from '../wallet'
+import { Account, Balance, Claims } from '../wallet'
 import { Transaction, TxAttrUsage } from '../transactions'
 import { Query } from '../rpc'
 import { ASSET_ID } from '../consts'
@@ -55,17 +55,18 @@ export const getBalance = (net, address) => {
 export const getClaims = (net, address) => {
   const apiEndpoint = getAPIEndpoint(net)
   return axios.get(apiEndpoint + '/v2/address/claims/' + address).then((res) => {
-    const claims = res.data
-    claims.claims = claims.claims.map(c => {
+    const claimData = res.data
+    claimData.claims = claimData.claims.map(c => {
       return {
         claim: new Fixed8(c.claim).div(100000000),
         index: c.index,
+        txid: c.txid,
         start: new Fixed8(c.start),
         end: new Fixed8(c.end),
-        txid: c.txid
+        value: c.value
       }
     })
-    return claims
+    return new Claims(claimData)
   })
 }
 

--- a/src/api/neoscan.js
+++ b/src/api/neoscan.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { Balance } from '../wallet'
+import { Balance, Claims } from '../wallet'
 import { Fixed8 } from '../utils'
 import logger from '../logging'
 
@@ -86,7 +86,7 @@ export const getClaims = (net, address) => {
     .then((res) => {
       const claims = parseClaims(res.data.claimable)
       log.info(`Retrieved Balance for ${address} from neoscan ${net}`)
-      return { net, address: res.data.address, claims }
+      return new Claims({ net, address: res.data.address, claims })
     })
 }
 

--- a/src/sc/index.d.ts
+++ b/src/sc/index.d.ts
@@ -75,7 +75,7 @@ declare module '@cityofzion/neon-js' {
   export interface semantic {
     create: {
       contractParam: (args: any) => sc.ContractParam
-      script: ({ scriptHash, operation, args, useTailCall }: sc.scriptParams) => string
+      script: ({ scriptHash, operation, args, useTailCall }: scriptParams) => string
       scriptBuilder: (args: any) => sc.ScriptBuilder
       deployScript: (any) => string
     }

--- a/src/transactions/index.d.ts
+++ b/src/transactions/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="../utils.d.ts" />
+/// <reference path="../wallet/index.d.ts" />
 declare module '@cityofzion/neon-js' {
   export interface Transaction {
     type: number
@@ -21,38 +23,12 @@ declare module '@cityofzion/neon-js' {
   export interface TransactionOutput {
     assetId: string
     scriptHash: string
-    value: Fixed8
+    value: u.Fixed8
   }
 
   export interface Witness {
     invocationScript: string
     verificationScript: string
-  }
-
-  export interface Balance {
-    GAS: TokenBalance
-    NEO: TokenBalance
-    address: string
-    net: 'MainNet' | 'TestNet'
-  }
-
-  export interface Claim {
-    claim: number
-    index: number
-    txid: string
-  }
-
-  interface ClaimData {
-    claims: Claim[]
-  }
-
-  interface txConfig {
-    type: number,
-    version: number,
-    attributes: TransactionAttribute[]
-    inputs: TransactionInput[]
-    outputs: TransactionOutput[]
-    scripts: Witness[]
   }
 
   export module tx {
@@ -62,14 +38,14 @@ declare module '@cityofzion/neon-js' {
     export function TransactionOutput(input: object): TransactionOutput
     export function serializeTransactionOutput(output: TransactionOutput): string
     export function deserializeTransactionOutput(stream: u.StringStream): TransactionOutput
-    export function createTransactionOutput(assetSym: string, value: number|Fixed8, address: string): TransactionOutput
+    export function createTransactionOutput(assetSym: string, value: number|u.Fixed8, address: string): TransactionOutput
     export function serializeTransactionAttribute(attr: TransactionAttribute): string
     export function deserializeTransactionAttribute(stream: u.StringStream): TransactionAttribute
     export function serializeWitness(witness: Witness): string
     export function deserializeWitness(stream: u.StringStream): Witness
 
     //core
-    export function calculateInputs(balances: Balance, intents: TransactionOutput[], gasCost?: number): { inputs: TransactionInput[], change: TransactionOutput[] }
+    export function calculateInputs(balances: wallet.Balance, intents: TransactionOutput[], gasCost?: number): { inputs: TransactionInput[], change: TransactionOutput[] }
     export function serializeTransaction(tx: Transaction, signed?: boolean): string
     export function deserializeTransaction(data: string): Transaction
     export function signTransaction(transaction: Transaction, privateKey: string): Transaction
@@ -103,25 +79,25 @@ declare module '@cityofzion/neon-js' {
       public outputs: TransactionOutput[]
       public scripts: Witness[]
 
-      constructor(TxConfig)
+      constructor(tx: Transaction)
 
       exclusiveData(): object
       hash(): string
 
-      static createClaimTx(publicKeyOrAddress: string, claimData: Claim, override: object): Transaction
-      static createContractTx(balances: Balance, intents: TransactionOutput[], override: object): Transaction
-      static createInvocationTx(balance: Balance, intents: TransactionOutput[], invoke: object | string, gasCost: number, override: object): Transaction
+      static createClaimTx(publicKeyOrAddress: string, claimData:wallet. Claims, override: object): Transaction
+      static createContractTx(balances: wallet.Balance, intents: TransactionOutput[], override: object): Transaction
+      static createInvocationTx(balance: wallet.Balance, intents: TransactionOutput[], invoke: object | string, gasCost: number, override: object): Transaction
     }
-
+    //txAttrUsage
     export enum TxAttrUsage {}
   }
 
   export interface semantic {
     create: {
       tx: (args: any[]) => Transaction
-      claimTx: (publicKeyOrAddress: string, claimData: Claim, override: object) => Transaction
-      contractTx: (balances: Balance, intents: TransactionOutput[], override: object) => Transaction
-      invocationTx: (balance: Balance, intents: TransactionOutput[], invoke: object | string, gasCost: number, override: object) => Transaction
+      claimTx: (publicKeyOrAddress: string, claimData: wallet.Claims, override: object) => Transaction
+      contractTx: (balances: wallet.Balance, intents: TransactionOutput[], override: object) => Transaction
+      invocationTx: (balance: wallet.Balance, intents: TransactionOutput[], invoke: object | string, gasCost: number, override: object) => Transaction
     }
     serialize: {
       attribute: (attr: TransactionAttribute) => string
@@ -131,11 +107,11 @@ declare module '@cityofzion/neon-js' {
       tx: (tx: Transaction) => string
     }
     deserialize: {
-      attribute: (stream: StringStream) => TransactionAttribute
-      input: (stream: StringStream) => TransactionInput
-      output: (stream: StringStream) => TransactionOutput
+      attribute: (stream: u.StringStream) => TransactionAttribute
+      input: (stream: u.StringStream) => TransactionInput
+      output: (stream: u.StringStream) => TransactionOutput
       exclusiveData: object
-      tx: (stream: StringStream) => Transaction
+      tx: (stream: u.StringStream) => Transaction
     }
     get: {
       transactionHash: (transaction: Transaction) => string

--- a/src/transactions/transaction.js
+++ b/src/transactions/transaction.js
@@ -1,4 +1,4 @@
-import { Account, getScriptHashFromPublicKey, getScriptHashFromAddress, isAddress } from '../wallet'
+import { Account } from '../wallet'
 import { TX_VERSION, ASSET_ID } from '../consts'
 import { createScript } from '../sc'
 import { Fixed8, str2hexstring, num2VarInt } from '../utils'

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -13,7 +13,7 @@ declare module '@cityofzion/neon-js' {
     export function fixed82num(fixed8: string): number
     export function num2VarInt(num: number): string
     export function hexXor(str1: string, str2: string): string
-    export function reverseArray(arr: Array): Uint8Array
+    export function reverseArray(arr: Array<number>): Uint8Array
     export function reverseHex(hex: string): string
 
     export class StringStream {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import { SHA256, RIPEMD160, enc } from 'crypto-js'
 import BN from 'bignumber.js'
+import util from 'util'
 
 /**
  * @param {arrayBuffer} buf
@@ -308,7 +309,7 @@ export class Fixed8 extends BN {
     return reverseHex(this.toHex())
   }
 
-  inspect (depth, opts) {
+  [util.inspect.custom] (depth, opts) {
     return this.toFixed(8)
   }
 

--- a/src/wallet/Account.js
+++ b/src/wallet/Account.js
@@ -1,6 +1,7 @@
 import * as core from './core'
 import { isPrivateKey, isPublicKey, isWIF, isAddress, isNEP2 } from './verify'
 import { encrypt, decrypt } from './nep2'
+import util from 'util'
 
 /**
  * @class Account
@@ -172,6 +173,10 @@ class Account {
       contract: this.contract,
       extra: this.extra
     }
+  }
+
+  [util.inspect.custom] (depth, opts) {
+    return `[Account: ${this.label}]`
   }
 }
 

--- a/src/wallet/Balance.js
+++ b/src/wallet/Balance.js
@@ -1,39 +1,8 @@
+import { AssetBalance } from './components'
 import { Transaction } from '../transactions'
 import { ASSETS } from '../consts'
 import { Fixed8 } from '../utils'
 import { Query } from '../rpc'
-
-/**
- * @typedef AssetBalance
- * @property {Fixed8} balance - The total balance in this AssetBalance
- * @property {Coin[]} unspent - Unspent coins
- * @property {Coin[]} spent - Spent coins
- * @property {Coin[]} unconfirmed - Unconfirmed coins
- */
-
-/**
-* @typedef Coin
-* @property {number} index - Index in list.
-* @property {string} txid - Transaction ID which produced this coin.
-* @property {Fixed8} value - Value of this coin.
-*/
-
-const cleanAssetBalance = (assetBalance) => {
-  return {
-    balance: new Fixed8(assetBalance.balance),
-    unspent: assetBalance.unspent ? assetBalance.unspent.map(coin => cleanCoin(coin)) : [],
-    spent: assetBalance.spent ? assetBalance.spent.map(coin => cleanCoin(coin)) : [],
-    unconfirmed: assetBalance.unconfirmed ? assetBalance.unconfirmed.map(coin => cleanCoin(coin)) : []
-  }
-}
-
-const cleanCoin = (coin) => {
-  return {
-    index: coin.index,
-    txid: coin.txid,
-    value: new Fixed8(coin.value)
-  }
-}
 
 /**
  * @class Balance
@@ -79,10 +48,10 @@ class Balance {
    * @param {AssetBalance} [assetBalance] - The assetBalance if initialized. Default is a zero balance object.
    * @return this
    */
-  addAsset (sym, assetBalance = { balance: new Fixed8(0), spent: [], unspent: [], unconfirmed: [] }) {
+  addAsset (sym, assetBalance = AssetBalance()) {
     sym = sym.toUpperCase()
     this.assetSymbols.push(sym)
-    const cleanedAssetBalance = cleanAssetBalance(assetBalance)
+    const cleanedAssetBalance = AssetBalance(assetBalance)
     this.assets[sym] = cleanedAssetBalance
     return this
   }

--- a/src/wallet/Balance.js
+++ b/src/wallet/Balance.js
@@ -16,9 +16,9 @@ import { Query } from '../rpc'
  * @param {object} bal.tokens - The collection of tokens in this Balance
  */
 class Balance {
-  constructor (bal) {
-    this.address = bal.address
-    this.net = bal.net
+  constructor (bal = {}) {
+    this.address = bal.address || ''
+    this.net = bal.net || 'NoNet'
     this.assetSymbols = bal.assetSymbols ? bal.assetSymbols : []
     this.assets = {}
     if (bal.assets) {

--- a/src/wallet/Balance.js
+++ b/src/wallet/Balance.js
@@ -160,7 +160,7 @@ class Balance {
  * @param {AssetBalance} assetBalance
  * @return {Promise<AssetBalance>} Returns a new AssetBalance
  */
-export const verifyAssetBalance = (url, assetBalance) => {
+const verifyAssetBalance = (url, assetBalance) => {
   let newAssetBalance = { balance: new Fixed8(0), spent: [], unspent: [], unconfirmed: [] }
   return verifyCoins(url, assetBalance.unspent)
     .then((values) => {
@@ -184,7 +184,7 @@ export const verifyAssetBalance = (url, assetBalance) => {
  * @param {Coin[]} coinArr
  * @return {Promise<Coin[]>}
  */
-export const verifyCoins = (url, coinArr) => {
+const verifyCoins = (url, coinArr) => {
   const promises = []
   for (const coin of coinArr) {
     const promise = Query.getTxOut(coin.txid, coin.index)

--- a/src/wallet/Claims.js
+++ b/src/wallet/Claims.js
@@ -2,10 +2,10 @@ import { ClaimItem } from './components'
 import util from 'util'
 
 export default class Claims {
-  constructor (config) {
-    this.address = config.address
-    this.net = config.net
-    this.claims = config.claims.map(c => ClaimItem(c))
+  constructor (config = {}) {
+    this.address = config.address || ''
+    this.net = config.net || 'NoNet'
+    this.claims = config.claims ? config.claims.map(c => ClaimItem(c)) : []
   }
 
   [util.inspect.custom] (depth, opts) {

--- a/src/wallet/Claims.js
+++ b/src/wallet/Claims.js
@@ -1,19 +1,17 @@
-import { Fixed8 } from '../utils'
+import { ClaimItem } from './components'
+import util from 'util'
 
 export default class Claims {
   constructor (config) {
     this.address = config.address
     this.net = config.net
-    this.claims = config.claims.map(c => parseClaimItem(c))
+    this.claims = config.claims.map(c => ClaimItem(c))
   }
-}
 
-const parseClaimItem = (c) => {
-  return {
-    claim: new Fixed8(c.claim),
-    start: new Fixed8(c.start),
-    end: new Fixed8(c.end),
-    index: c.index,
-    txid: c.txid
+  [util.inspect.custom] (depth, opts) {
+    const claimsDump = this.claims.map(c => {
+      return `${c.txid} <${c.index}>: ${c.claim.toString()}`
+    })
+    return `[Claims(${this.net}): ${this.address}]\n${JSON.stringify(claimsDump, null, 2)}`
   }
 }

--- a/src/wallet/Wallet.js
+++ b/src/wallet/Wallet.js
@@ -103,16 +103,16 @@ class Wallet {
    * @return {number} Index position of Account in array.
    */
   addAccount (acct) {
+    const index = this.accounts.length
+    if (!(acct instanceof Account)) {
+      acct = new Account(acct)
+    }
+    this.accounts.push(acct)
     try {
       const address = acct.address
+      log.info(`Added Account: ${address} to Wallet ${this.name}`)
     } catch (err) {
-      log.warn(`Encrypted account added to Wallet. You will not be able to export this wallet without first decrypting this account`)
-    }
-    const index = this.accounts.length
-    if (acct instanceof Account) {
-      this.accounts.push(acct)
-    } else {
-      this.accounts.push(new Account(acct))
+      log.warn(`Encrypted account added to Wallet ${this.name}. You will not be able to export this wallet without first decrypting this account`)
     }
     return index
   }

--- a/src/wallet/components.js
+++ b/src/wallet/components.js
@@ -1,0 +1,51 @@
+import { Fixed8 } from '../utils'
+
+/**
+ * @typedef AssetBalance
+ * @property {Fixed8} balance - The total balance in this AssetBalance
+ * @property {Coin[]} unspent - Unspent coins
+ * @property {Coin[]} spent - Spent coins
+ * @property {Coin[]} unconfirmed - Unconfirmed coins
+ */
+export const AssetBalance = (assetBalance = {}) => {
+  return {
+    balance: assetBalance.balance ? new Fixed8(assetBalance.balance) : new Fixed8(0),
+    unspent: assetBalance.unspent ? assetBalance.unspent.map(coin => Coin(coin)) : [],
+    spent: assetBalance.spent ? assetBalance.spent.map(coin => Coin(coin)) : [],
+    unconfirmed: assetBalance.unconfirmed ? assetBalance.unconfirmed.map(coin => Coin(coin)) : []
+  }
+}
+
+/**
+* @typedef Coin
+* @property {number} index - Index in list.
+* @property {string} txid - Transaction ID which produced this coin.
+* @property {Fixed8} value - Value of this coin.
+*/
+export const Coin = (coin = {}) => {
+  return {
+    index: coin.index || 0,
+    txid: coin.txid || '',
+    value: coin.value ? new Fixed8(coin.value) : new Fixed8(0)
+  }
+}
+
+/**
+ * @typedef ClaimItem
+ * @property {Fixed8} value - Amt of gas claimable
+ * @property {string} txid - Transaction hash of the originaating coin
+ * @property {number} index - Index of coin in the output array
+ * @property {number} value - Amount of NEO involved.
+ * @property {Fixed8} [start] - Starting block. Optional.
+ * @property {Fixed8} [end] - Ending block. Optional.
+ */
+export const ClaimItem = (claimItem = {}) => {
+  return {
+    claim: claimItem.claim ? new Fixed8(claimItem.claim) : new Fixed8(0),
+    txid: claimItem.txid || '',
+    index: claimItem.index || 0,
+    value: claimItem.value || 0,
+    start: claimItem.start ? new Fixed8(claimItem.start) : new Fixed8(0),
+    end: claimItem.end ? new Fixed8(claimItem.end) : new Fixed8(0)
+  }
+}

--- a/src/wallet/components.js
+++ b/src/wallet/components.js
@@ -45,7 +45,7 @@ export const ClaimItem = (claimItem = {}) => {
     txid: claimItem.txid || '',
     index: claimItem.index || 0,
     value: claimItem.value || 0,
-    start: claimItem.start ? new Fixed8(claimItem.start) : new Fixed8(0),
-    end: claimItem.end ? new Fixed8(claimItem.end) : new Fixed8(0)
+    start: claimItem.start ? new Fixed8(claimItem.start) : null,
+    end: claimItem.end ? new Fixed8(claimItem.end) : null
   }
 }

--- a/src/wallet/components.js
+++ b/src/wallet/components.js
@@ -32,7 +32,7 @@ export const Coin = (coin = {}) => {
 
 /**
  * @typedef ClaimItem
- * @property {Fixed8} value - Amt of gas claimable
+ * @property {Fixed8} claim - Amt of gas claimable
  * @property {string} txid - Transaction hash of the originaating coin
  * @property {number} index - Index of coin in the output array
  * @property {number} value - Amount of NEO involved.

--- a/src/wallet/index.d.ts
+++ b/src/wallet/index.d.ts
@@ -11,13 +11,22 @@ declare module '@cityofzion/neon-js' {
     balance: Fixed8
     unspent: Coin[]
     spent: Coin[]
-    uncofirmed: Coin[]
+    unconfirmed: Coin[]
   }
 
   export interface Coin {
     index: number
     txid: string
     value: Fixed8
+  }
+
+  export interface ClaimItem {
+    claim: Fixed8
+    txid: string
+    index: number
+    value: number
+    start?: Fixed8
+    end?: Fixed8
   }
 
   export interface ScryptParams {
@@ -61,11 +70,14 @@ declare module '@cityofzion/neon-js' {
       address: string
 
       getPublicKey(encoded: boolean): string
+      encrypt(keyphrase: string, scryptParams?: ScryptParams): Account
+      decrypt(keyphrase: string, scryptParams?: ScryptParams): Account
+      export(): WalletAccount
     }
 
     //Balance
     export class Balance {
-      constructor(bal: object)
+      constructor(bal?: Balance)
 
       address: string
       net: NEO_NETWORK
@@ -77,11 +89,25 @@ declare module '@cityofzion/neon-js' {
       static import(jsonString: string): Balance
 
       addAsset(sym: string, assetBalance?: AssetBalance): this
-      addToken(sym: string, tokenBalance?: number|Fixed8): this
+      addToken(sym: string, tokenBalance?: number | Fixed8): this
       applyTx(tx: Transaction, confirmed?: boolean): this
       export(): string
       verifyAssets(url: string): Promise<Balance>
     }
+
+    //Claims
+    export class Claims {
+      constructor(claims?: Claims)
+
+      address: string
+      net: string
+      claims: ClaimItem[]
+    }
+
+    //components
+    export function AssetBalance(assetBalance?: AssetBalance): AssetBalance
+    export function Coin(coin?: Coin): Coin
+    export function ClaimItem(claimItem?: ClaimItem): ClaimItem
 
     //core
     export function getPublicKeyEncoded(publicKey: string): string

--- a/src/wallet/index.d.ts
+++ b/src/wallet/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="../utils.d.ts" />
 declare module '@cityofzion/neon-js' {
   export interface Account {
     WIF: string
@@ -8,7 +9,7 @@ declare module '@cityofzion/neon-js' {
   }
 
   export interface AssetBalance {
-    balance: Fixed8
+    balance: u.Fixed8
     unspent: Coin[]
     spent: Coin[]
     unconfirmed: Coin[]
@@ -17,16 +18,16 @@ declare module '@cityofzion/neon-js' {
   export interface Coin {
     index: number
     txid: string
-    value: Fixed8
+    value: u.Fixed8
   }
 
   export interface ClaimItem {
-    claim: Fixed8
+    claim: u.Fixed8
     txid: string
     index: number
     value: number
-    start?: Fixed8
-    end?: Fixed8
+    start?: u.Fixed8
+    end?: u.Fixed8
   }
 
   export interface ScryptParams {
@@ -80,7 +81,7 @@ declare module '@cityofzion/neon-js' {
       constructor(bal?: Balance)
 
       address: string
-      net: NEO_NETWORK
+      net: 'MainNet' | 'TestNet'
       assetSymbols: string[]
       assets: { [index: string]: AssetBalance }
       tokenSymbols: string[]
@@ -89,7 +90,7 @@ declare module '@cityofzion/neon-js' {
       static import(jsonString: string): Balance
 
       addAsset(sym: string, assetBalance?: AssetBalance): this
-      addToken(sym: string, tokenBalance?: number | Fixed8): this
+      addToken(sym: string, tokenBalance?: number | u.Fixed8): this
       applyTx(tx: Transaction, confirmed?: boolean): this
       export(): string
       verifyAssets(url: string): Promise<Balance>
@@ -166,7 +167,7 @@ declare module '@cityofzion/neon-js' {
       account: (k: any) => Account
       privateKey: () => string
       signature: (tx: string, privateKey: string) => string
-      wallet: (k: any) => Wallet
+      wallet: (k: any) => wallet.Wallet
     }
     is: {
       address: (address: string) => boolean

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -41,4 +41,5 @@ export default {
 export * from './core'
 export * from './verify'
 export * from './nep2'
+export * from './components'
 export { Account, Balance, Wallet, Claims }

--- a/tests/unit/api/neonDB.js
+++ b/tests/unit/api/neonDB.js
@@ -1,5 +1,5 @@
 import * as neonDB from '../../../src/api/neonDB'
-import Balance from '../../../src/wallet/Balance'
+import {Balance, Claims} from '../../../src/wallet'
 import testKeys from '../testKeys.json'
 import mockData from './mockData.json'
 
@@ -31,6 +31,7 @@ describe('NeonDB', function () {
   it('getClaims returns Claims object', () => {
     return neonDB.getClaims('TestNet', testKeys.a.address)
       .then((response) => {
+        (response instanceof Claims).should.equal(true)
         response.net.should.equal('TestNet')
         response.address.should.equal(testKeys.a.address)
         response.claims.should.be.an('array')

--- a/tests/unit/api/neoscan.js
+++ b/tests/unit/api/neoscan.js
@@ -1,5 +1,5 @@
 import * as neoscan from '../../../src/api/neoscan'
-import Balance from '../../../src/wallet/Balance'
+import { Balance, Claims } from '../../../src/wallet'
 import testKeys from '../testKeys.json'
 import mockData from './mockData.json'
 
@@ -31,6 +31,7 @@ describe('Neoscan', function () {
   it('getClaims returns Claims object', () => {
     return neoscan.getClaims('TestNet', testKeys.a.address)
       .then((response) => {
+        (response instanceof Claims).should.equal(true)
         response.net.should.equal('TestNet')
         response.address.should.equal(testKeys.a.address)
         response.claims.should.be.an('array')

--- a/tests/unit/wallet/Claims.js
+++ b/tests/unit/wallet/Claims.js
@@ -1,0 +1,51 @@
+import Claims from '../../../src/wallet/Claims'
+describe.only('Claims', function () {
+  const claimsLike = {
+    address: 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW',
+    net: 'TestNet',
+    claims: [
+      {
+        txid: '0ba525af5817b01314ef4e4bc9823986ca7e30871178ce2aa7b86d23d7937768',
+        index: 0,
+        claim: 0.02455600
+      },
+      {
+        txid: '27341b5fffa9b0c74e454cb73481b9d50cc9fb5856b9a468a7bb7dc4d518628d',
+        index: 1,
+        claim: 0.05267460
+      }
+    ]
+  }
+
+  describe('constructor', function () {
+    it('default', () => {
+      const expected = {
+        address: '',
+        net: 'NoNet',
+        claims: []
+      }
+      const result = new Claims()
+      result.should.eql(expected)
+    })
+
+    it('CLaims-like', () => {
+      const result = new Claims(claimsLike)
+
+      result.address.should.equal(claimsLike.address)
+      result.net.should.equal(claimsLike.net)
+      result.claims.length.should.equal(2)
+      for (var i; i < claimsLike.claims.length; i++) {
+        result.claims[i].txid.should.equal(claimsLike.claims[i].txid)
+        result.claims[i].index.should.equal(claimsLike.claims[i].index)
+        result.claims[i].claim.toNumber().should.equal(claimsLike.claims[i].claim)
+      }
+    })
+
+    it('Claims', () => {
+      const claims1 = new Claims(claimsLike)
+      const claims2 = new Claims(claims1)
+      claims1.should.eql(claims2);
+      (claims1 === claims2).should.equal(false)
+    })
+  })
+})

--- a/tests/unit/wallet/Claims.js
+++ b/tests/unit/wallet/Claims.js
@@ -1,5 +1,6 @@
 import Claims from '../../../src/wallet/Claims'
-describe.only('Claims', function () {
+
+describe('Claims', function () {
   const claimsLike = {
     address: 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW',
     net: 'TestNet',

--- a/tests/unit/wallet/components.js
+++ b/tests/unit/wallet/components.js
@@ -1,0 +1,98 @@
+import * as comp from '../../../src/wallet/components'
+import { Fixed8 } from '../../../src/utils'
+
+describe('Wallet Components', function () {
+  describe('AssetBalance', function () {
+    it('default', () => {
+      const expected = {
+        balance: new Fixed8(0),
+        unspent: [],
+        spent: [],
+        unconfirmed: []
+      }
+      const result = comp.AssetBalance()
+      result.should.eql(expected)
+    })
+
+    it('AssetBalanceLike', () => {
+      const assetBalanceLike = {
+        balance: 20,
+        unspent: [
+          { index: 0, txid: 'abc', value: 7 },
+          { index: 1, txid: 'def', value: 13 }
+        ],
+        spent: [
+          { index: 2, txid: 'ghi', value: 1.24 }
+        ]
+      }
+
+      const result = comp.AssetBalance(assetBalanceLike)
+      result.balance.toNumber().should.equal(assetBalanceLike.balance)
+      result.unconfirmed.should.eql([])
+      for (var i = 0; i < assetBalanceLike.unspent.length; i++) {
+        result.unspent[i].index.should.equal(assetBalanceLike.unspent[i].index)
+        result.unspent[i].txid.should.equal(assetBalanceLike.unspent[i].txid)
+        result.unspent[i].value.toNumber().should.equal(assetBalanceLike.unspent[i].value)
+      }
+      for (i = 0; i < assetBalanceLike.spent.length; i++) {
+        result.spent[i].index.should.equal(assetBalanceLike.spent[i].index)
+        result.spent[i].txid.should.equal(assetBalanceLike.spent[i].txid)
+        result.spent[i].value.toNumber().should.equal(assetBalanceLike.spent[i].value)
+      }
+    })
+  })
+
+  describe('Coin', function () {
+    it('default', () => {
+      const expected = { index: 0, txid: '', value: new Fixed8(0) }
+
+      const result = comp.Coin()
+      result.should.eql(expected)
+    })
+
+    it('CoinLike', () => {
+      const coinLike = { index: 1, txid: 'abc', value: 1.2345 }
+
+      const result = comp.Coin(coinLike)
+      result.index.should.equal(coinLike.index)
+      result.txid.should.equal(coinLike.txid)
+      result.value.toNumber().should.equal(coinLike.value)
+    })
+  })
+
+  describe('ClaimItem', function () {
+    it('default', () => {
+      const expected = {
+        claim: new Fixed8(0),
+        txid: '',
+        index: 0,
+        value: 0,
+        start: null,
+        end: null
+      }
+
+      const result = comp.ClaimItem()
+      result.should.eql(expected)
+    })
+
+    it('ClaimItemLike', () => {
+      const claimItemLike = {
+        claim: 123,
+        txid: 'abc',
+        index: 1,
+        value: 1,
+        start: 12345,
+        end: 23456
+      }
+
+      const result = comp.ClaimItem(claimItemLike)
+
+      result.claim.toNumber().should.equal(claimItemLike.claim)
+      result.txid.should.equal(claimItemLike.txid)
+      result.index.should.equal(claimItemLike.index)
+      result.value.should.equal(claimItemLike.value)
+      result.start.toNumber().should.equal(claimItemLike.start)
+      result.end.toNumber().should.equal(claimItemLike.end)
+    })
+  })
+})


### PR DESCRIPTION
With the introduction of Fixed8, it becomes increasingly more difficult to use `neon-js` because there are too many native classes required. For example, many things will fail if we just merely pass in a JS object of a similar structure due to the nature of Fixed8.
This PR addresses the issue by:
- Having constructors for the relevant objects take in the JS objects of the accepted shape and spitting out the native `neon-js` equivalent. (`Balance`, `Claims`)
- Having helper methods for constructing the smaller components that are not promoted to its own class (eg. `Coin`, `AssetBalance`)

- There are some experimentation with customizing the printing of objects to aid debugging. These are implementation with the `util.inspect.custom` symbol.
- Clean up typings and docstrings.
- Unexport `verifyAssetBalance` and `verifyCoins`. These are not used often on the surface and we should not be over zealous in exporting them. Prefer to use the native Balance verify function instead.