### PR TITLE
feat(api): Support sending assets from contract

### DIFF
--- a/docs/tutorial/basic-sendasset.rst
+++ b/docs/tutorial/basic-sendasset.rst
@@ -69,4 +69,4 @@ Notes
 -----
 
 - The ``sendAsset`` method is found under the ``api`` module for named imports.
-- This method only accepts one source of assets to send from. This does not support using multiple sources or multi-sig addresses.
+- This method only accepts one source of assets to send from. It supports sending assets from a contract by setting the ``address`` field to the contract's address and signing with a private key that is allowed to send from the contract. This does not support using multiple sources or multi-sig addresses.

--- a/docs/tutorial/basic-sendasset.rst
+++ b/docs/tutorial/basic-sendasset.rst
@@ -69,4 +69,5 @@ Notes
 -----
 
 - The ``sendAsset`` method is found under the ``api`` module for named imports.
-- This method only accepts one source of assets to send from. It supports sending assets from a contract by setting the ``address`` field to the contract's address and signing with a private key that is allowed to send from the contract. This does not support using multiple sources or multi-sig addresses.
+- This method only accepts one source of assets to send from. This does not support using multiple sources or multi-sig addresses.
+- This supports sending assets from a smart contract by setting the ``address`` field to the contract's address, signing with a private key that is allowed to send from the contract and setting ``sendingFromSmartContract`` to true.

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -25,6 +25,7 @@ const log = logger('api')
  * @param {function} [config.signingFunction] - An external signing function to sign with. Either this or privateKey is required.
  * @param {string} [config.publicKey] - A public key for the singing function. Either this or privateKey is required.
  * @param {TransactionOutput[]} config.intents - Intents.
+ * @param {bool} [config.sendingFromSmartContract] - Optionally specify that the source address is a smart contract that doesn't correspond to the private key.
  * @return {object} Configuration object.
  */
 export const sendAsset = config => {
@@ -86,6 +87,7 @@ export const claimGas = config => {
  * @param {object} [config.intents] - Intents
  * @param {string} config.script - VM script. Must include empty args parameter even if no args are present
  * @param {number} config.gas - gasCost of VM script.
+ * @param {bool} [config.sendingFromSmartContract] - Optionally specify that the source address is a smart contract that doesn't correspond to the private key.
  * @return {object} Configuration object.
  */
 export const doInvoke = config => {
@@ -147,6 +149,7 @@ export const createTx = (config, txType) => {
  * @param {string} [config.privateKey] - private key to sign with.
  * @param {string} [config.publicKey] - public key. Required if using signingFunction.
  * @param {function} [config.signingFunction] - External signing function. Requires publicKey.
+ * @param {bool} [config.sendingFromSmartContract] - Optionally specify that the source address is a smart contract that doesn't correspond to the private key.
  * @return {Promise<object>} Configuration object.
  */
 export const signTx = config => {
@@ -157,7 +160,7 @@ export const signTx = config => {
     promise = config.signingFunction(config.tx, acct.publicKey)
   } else if (config.privateKey) {
     let acct = new Account(config.privateKey)
-    if (config.address !== acct.address && !sendingAddressIsSmartContract(config)) {
+    if (config.address !== acct.address && !config.sendingFromSmartContract) {
       return Promise.reject(
         new Error('Private Key and Balance address does not match!')
       )
@@ -271,23 +274,6 @@ const attachInvokedContractForMintToken = config => {
 }
 
 /**
- * Helper method to check if we're sending assets from the contract's balance
- * @param {object} config - Configuration object.
- * @param {object} config.script - VM script object (string not supported).
- * @return {bool} If it's from the contract or not
- */
-const sendingAddressIsSmartContract = config => {
-  if (typeof config.script === 'object' && config.script.scriptHash) {
-    const sendingAddressScriptHash = getScriptHashFromAddress(config.address)
-    if (sendingAddressScriptHash === config.script.scriptHash) {
-      return true
-    }
-  }
-
-  return false
-}
-
-/**
  * Adds attributes to the override object for mintTokens invocations.
  * @param {object} config - Configuration object.
  * @return {object} Configuration object.
@@ -295,7 +281,7 @@ const sendingAddressIsSmartContract = config => {
 const addAttributesIfExecutingAsSmartContract = config => {
   if (!config.override) config.override = {}
 
-  if (sendingAddressIsSmartContract(config)) {
+  if (config.sendingFromSmartContract) {
     const acct = config.privateKey ? new Account(config.privateKey) : new Account(config.publicKey)
     config.override.attributes = [
       {
@@ -314,8 +300,10 @@ const addAttributesIfExecutingAsSmartContract = config => {
  * @return {object} Configuration object.
  */
 const attachContractIfExecutingAsSmartContract = config => {
-  if (sendingAddressIsSmartContract(config)) {
-    return Query.getContractState(config.script.scriptHash)
+  if (config.sendingFromSmartContract) {
+    const smartContractScriptHash = getScriptHashFromAddress(config.address)
+
+    return Query.getContractState(smartContractScriptHash)
       .execute(config.url)
       .then(contractState => {
         const { parameters, script } = contractState.result
@@ -326,8 +314,7 @@ const attachContractIfExecutingAsSmartContract = config => {
 
         // We need to order this for the VM.
         const acct = config.privateKey ? new Account(config.privateKey) : new Account(config.publicKey)
-        const sendingAddressScriptHash = getScriptHashFromAddress(config.address)
-        if (parseInt(sendingAddressScriptHash, 16) > parseInt(acct.scriptHash, 16)) {
+        if (parseInt(smartContractScriptHash, 16) > parseInt(acct.scriptHash, 16)) {
           config.tx.scripts.push(attachInvokedContract)
         } else {
           config.tx.scripts.unshift(attachInvokedContract)

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -230,7 +230,7 @@ export const makeIntent = (assetAmts, address) => {
 const sendingAddressIsContract = config => {
   if (typeof config.script === 'object' && config.script.scriptHash) {
     const sendingAddressScriptHash = getScriptHashFromAddress(config.address)
-    if (sendingAddressScriptHash == config.script.scriptHash) {
+    if (sendingAddressScriptHash === config.script.scriptHash) {
       return true
     }
   }

--- a/test/unit/api/core.js
+++ b/test/unit/api/core.js
@@ -157,6 +157,33 @@ describe('Core API', function () {
         })
     })
 
+    it('sign for contract assets', () => {
+      return core.signTx({
+        tx,
+        address: 'AXhgHZtAYC8ZztJo8B1LV2kLyeMrXr39La',
+        privateKey: testKeys.a.privateKey,
+        script: {
+          scriptHash: 'a3d29a3bfe0e0fc00928847d3e4db82b78ddb6ae'
+        }
+      })
+        .then((conf) => {
+          conf.tx.scripts.length.should.equal(1)
+          conf.tx.scripts[0].should.eql(signature)
+        })
+    })
+
+    it('cannot sign for contract assets with address that does not match', () => {
+      const config = {
+        tx,
+        address: 'AXhgHZtAYC8ZztJo8B1LV2kLyeMrXr39La',
+        privateKey: testKeys.a.privateKey,
+        script: {
+          scriptHash: testKeys.a.scriptHash
+        }
+      }
+      return core.signTx(config).should.be.rejectedWith(Error)
+    })
+
     it('sign with signingFunction', () => {
       const signingFunction = (tx, publicKey) => {
         return Promise.resolve(signTransaction(tx, testKeys.a.privateKey))

--- a/test/unit/api/core.js
+++ b/test/unit/api/core.js
@@ -157,13 +157,16 @@ describe('Core API', function () {
         })
     })
 
-    it('sign for contract assets', () => {
+    it('sign for smart contract assets', () => {
+      const testSmartContractAddress = 'AXhgHZtAYC8ZztJo8B1LV2kLyeMrXr39La'
+      const testSmartContractScriptAddress = 'a3d29a3bfe0e0fc00928847d3e4db82b78ddb6ae'
+
       return core.signTx({
         tx,
-        address: 'AXhgHZtAYC8ZztJo8B1LV2kLyeMrXr39La',
+        address: testSmartContractAddress,
         privateKey: testKeys.a.privateKey,
         script: {
-          scriptHash: 'a3d29a3bfe0e0fc00928847d3e4db82b78ddb6ae'
+          scriptHash: testSmartContractScriptAddress
         }
       })
         .then((conf) => {
@@ -172,10 +175,12 @@ describe('Core API', function () {
         })
     })
 
-    it('cannot sign for contract assets with address that does not match', () => {
+    it('cannot sign for smart contract assets with address that does not match', () => {
+      const testSmartContractAddress = 'AXhgHZtAYC8ZztJo8B1LV2kLyeMrXr39La'
+
       const config = {
         tx,
-        address: 'AXhgHZtAYC8ZztJo8B1LV2kLyeMrXr39La',
+        address: testSmartContractAddress,
         privateKey: testKeys.a.privateKey,
         script: {
           scriptHash: testKeys.a.scriptHash

--- a/test/unit/api/core.js
+++ b/test/unit/api/core.js
@@ -157,17 +157,27 @@ describe('Core API', function () {
         })
     })
 
+    it('cannot sign for assets on address mismatch', () => {
+      return core.signTx({
+        tx,
+        address,
+        privateKey: testKeys.b.privateKey
+      })
+        .then((conf) => {
+          conf.tx.scripts.length.should.equal(1)
+          conf.tx.scripts[0].should.eql(signature)
+        })
+        .should.be.rejectedWith(Error)
+    })
+
     it('sign for smart contract assets', () => {
       const testSmartContractAddress = 'AXhgHZtAYC8ZztJo8B1LV2kLyeMrXr39La'
-      const testSmartContractScriptAddress = 'a3d29a3bfe0e0fc00928847d3e4db82b78ddb6ae'
 
       return core.signTx({
         tx,
         address: testSmartContractAddress,
         privateKey: testKeys.a.privateKey,
-        script: {
-          scriptHash: testSmartContractScriptAddress
-        }
+        sendingFromSmartContract: true
       })
         .then((conf) => {
           conf.tx.scripts.length.should.equal(1)
@@ -175,16 +185,13 @@ describe('Core API', function () {
         })
     })
 
-    it('cannot sign for smart contract assets with address that does not match', () => {
+    it('cannot sign for smart contract assets without option', () => {
       const testSmartContractAddress = 'AXhgHZtAYC8ZztJo8B1LV2kLyeMrXr39La'
 
       const config = {
         tx,
         address: testSmartContractAddress,
-        privateKey: testKeys.a.privateKey,
-        script: {
-          scriptHash: testKeys.a.scriptHash
-        }
+        privateKey: testKeys.a.privateKey
       }
       return core.signTx(config).should.be.rejectedWith(Error)
     })


### PR DESCRIPTION
Solves https://github.com/CityOfZion/neon-js/issues/147

This PR allows you to send assets from a contract. It supports Contract and Invocation transactions (which are used in neo-boa examples such as https://github.com/CityOfZion/neo-boa/blob/master/boa/tests/src/WithdrawTest.py#L100).

I saw very similar functionality for mintTokens. I'm unsure how mintTokens was being used in this case. If we need it to work as before, is there a way to test it? It will be easy to add back in the exact same way as before if needed.

For my implementation I set `invocationScript` to '00' * number of contract parameters which is what the mintTokens version was doing. I did not append the main script's `invocationScript` as the issue says as this does not seem to be needed. The original mintToken implementation was using the contract's script hash in the attribute and I needed to use the sender's. Again, it wasn't clear to me how mintToken was working. What we have here is much more like how neo-python works with `--from-addr` when sending.

Here is some testing code:
https://gist.github.com/slipo/c1542c087bff7e17a067e903f0b24540

Here's a resulting transaction:
https://gist.github.com/slipo/6b2815058652fce6b386267f1b880639



