### PR TITLE
Made GAS and NEO in AssetAmounts nullable, so it is possible to…

### DIFF
--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -12,8 +12,8 @@ declare module '@cityofzion/neon-js' {
   }
 
   interface AssetAmounts {
-    GAS: number
-    NEO: number
+    GAS?: number
+    NEO?: number
   }
 
   interface History {


### PR DESCRIPTION
… send only GAS or NEO without dirty casting tricks.

Stackoverflow Question: https://neo.stackexchange.com/questions/166/neon-js-cannot-send-only-gas-with-sendasset