### PR TITLE
feat(api): Implement fillKeys and fillBalance

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -95,7 +95,8 @@ export const claimGas = config => {
 export const doInvoke = config => {
   return loadBalance(getRPCEndpointFrom, config)
     .then(url => Object.assign(config, { url }))
-    .then(c => loadBalance(getBalanceFrom, config))
+    .then(fillKeys)
+    .then(fillBalance)
     .then(c => createTx(c, 'invocation'))
     .then(c => addAttributesIfExecutingAsSmartContract(c))
     .then(c => addAttributesForMintToken(c))
@@ -132,8 +133,8 @@ export const fillKeys = config => {
     if (!config.address) config.address = config.account.address
     if (!config.privateKey && !config.signingFunction) config.privateKey = config.account.privateKey
     if (!config.publicKey && config.signingFunction) config.publicKey = config.account.publicKey
-    return Promise.resolve(config)
   }
+  return Promise.resolve(config)
 }
 /**
  * Creates a transaction with the given config and txType.

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -31,7 +31,8 @@ const log = logger('api')
 export const sendAsset = config => {
   return loadBalance(getRPCEndpointFrom, config)
     .then(url => Object.assign(config, { url }))
-    .then(c => loadBalance(getBalanceFrom, config))
+    .then(fillKeys)
+    .then(fillBalance)
     .then(c => createTx(c, 'contract'))
     .then(c => addAttributesIfExecutingAsSmartContract(c))
     .then(c => signTx(c))
@@ -63,6 +64,7 @@ export const sendAsset = config => {
 export const claimGas = config => {
   return loadBalance(getRPCEndpointFrom, config)
     .then(url => Object.assign(config, { url }))
+    .then(fillKeys)
     .then(c => loadBalance(getClaimsFrom, config))
     .then(c => createTx(c, 'claim'))
     .then(c => signTx(c))
@@ -110,6 +112,29 @@ export const doInvoke = config => {
     })
 }
 
+/**
+ * Retrieves Balance if no balance has been attached
+ * @param {object} config
+ * @return {Promise<object>} Configuration object.
+ */
+export const fillBalance = config => {
+  if (config.balance) return Promise.resolve(config)
+  return loadBalance(getBalanceFrom, config)
+}
+
+/**
+ * Fills the relevant key fields if account has been attached.
+ * @param {object} config
+ * @return {Promise<object>} Configuration object.
+ */
+export const fillKeys = config => {
+  if (config.account) {
+    if (!config.address) config.address = config.account.address
+    if (!config.privateKey && !config.signingFunction) config.privateKey = config.account.privateKey
+    if (!config.publicKey && config.signingFunction) config.publicKey = config.account.publicKey
+    return Promise.resolve(config)
+  }
+}
 /**
  * Creates a transaction with the given config and txType.
  * @param {object} config - Configuration object.
@@ -196,7 +221,7 @@ export const sendTx = config => {
       if (res.result === true) {
         res.txid = config.tx.hash
         if (config.balance) {
-          config.balance.applyTx(config.tx, true)
+          config.balance.applyTx(config.tx, false)
         }
       } else {
         const dump = {

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -63,6 +63,8 @@ export function makeIntent(assetAmts: AssetAmounts, address: string): Transactio
 export function sendAsset(config: apiConfig): Promise<apiConfig>
 export function claimGas(config: apiConfig): Promise<apiConfig>
 export function doInvoke(config: apiConfig): Promise<apiConfig>
+export function fillKeys(config: apiConfig): Promise<apiConfig>
+export function fillBalance(config: apiConfig):Promise<apiConfig>
 
 //neonDB
 export namespace neonDB {

--- a/test/integration/api/core.js
+++ b/test/integration/api/core.js
@@ -2,6 +2,7 @@ import * as core from '../../../src/api/core'
 import * as APIswitch from '../../../src/api/switch'
 import { CONTRACTS, NEO_NETWORK, TEST_NXT_ADDRESS } from '../../../src/consts'
 import { ContractParam } from '../../../src/sc'
+import { Account } from '../../../src/wallet'
 import testKeys from '../../unit/testKeys.json'
 
 describe('Integration: API Core', function () {
@@ -34,8 +35,7 @@ describe('Integration: API Core', function () {
       const intent1 = core.makeIntent({ NEO: 1 }, testKeys.a.address)
       const config1 = {
         net: NEO_NETWORK.TEST,
-        address: testKeys.b.address,
-        privateKey: testKeys.b.privateKey,
+        account: new Account(testKeys.b.privateKey),
         intents: intent1
       }
 

--- a/test/integration/rpc/query.js
+++ b/test/integration/rpc/query.js
@@ -222,7 +222,6 @@ describe('Query', function () {
       return Query.getVersion()
         .execute(DEFAULT_RPC.TEST)
         .then((res) => {
-          console.log(res)
           res.result.should.have.all.keys(['port', 'nonce', 'useragent'])
           res.result.useragent.should.match(/NEO:(\d+\.\d+\.\d+)/)
         })

--- a/test/unit/api/core.js
+++ b/test/unit/api/core.js
@@ -1,7 +1,7 @@
 import * as core from '../../../src/api/core'
 import { neonDB, neoscan } from '../../../src/api'
 import { Transaction, signTransaction, getTransactionHash } from '../../../src/transactions'
-import { Balance } from '../../../src/wallet'
+import { Account, Balance } from '../../../src/wallet'
 import { DEFAULT_RPC } from '../../../src/consts'
 import { Fixed8 } from '../../../src/utils'
 import testKeys from '../testKeys.json'
@@ -219,6 +219,60 @@ describe('Core API', function () {
           conf.response.should.be.an('object')
           conf.response.result.should.equal(true)
           conf.response.txid.should.equal(getTransactionHash(config.tx))
+        })
+    })
+  })
+
+  describe('fillKeys', function () {
+    it('fill address and privateKey', () => {
+      const config = {
+        account: new Account(testKeys.a.privateKey)
+      }
+
+      return core.fillKeys(config)
+        .then((conf) => {
+          conf.address.should.equal(testKeys.a.address)
+          conf.privateKey.should.equal(testKeys.a.privateKey)
+        })
+    })
+
+    it('fill address and publicKey when using signingFunction', () => {
+      const config = {
+        account: new Account(testKeys.a.publicKey),
+        signingFunction: () => true
+      }
+
+      return core.fillKeys(config)
+        .then(conf => {
+          conf.address.should.equal(testKeys.a.address)
+          conf.publicKey.should.equal(testKeys.a.publicKey)
+        })
+    })
+  })
+
+  describe('fillBalance', function () {
+    it('does not call getBalance when balance exists', () => {
+      const expectedBalance = new Balance()
+      const config = {
+        net: 'RandomNet',
+        address: testKeys.b.address,
+        balance: expectedBalance
+      }
+      return core.fillBalance(config)
+        .then(conf => {
+          conf.balance.should.equal(expectedBalance)
+        })
+    })
+
+    it('calls getBalance when balance is not available', () => {
+      const config = Object.assign({}, baseConfig)
+      return core.fillBalance(config)
+        .then(conf => {
+          conf.should.have.keys([
+            'net',
+            'address',
+            'balance'
+          ])
         })
     })
   })


### PR DESCRIPTION
`fillKeys`: By attaching an `Account` to `config.account`, this will fill up the corresponding fields `address`, `publicKey`, `privateKey` using the Account provided.

`fillBalance`: Allows us to attach a previously used balance instead of relying always on an API call for a fresh balance.