### PR TITLE
Fix(api): Update core typings

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -404,7 +404,7 @@ export const getRPCEndpointFrom = (config, api) => {
  * @param {string} config.net - 'MainNet', 'TestNet' or a custom URL.
  * @param {string} config.address - Wallet address
  * @param {object} api - The endpoint API object. eg, neonDB or Neoscan.
- * @return {Promise<string>} - Transaction history
+ * @return {Promise<History>} - Transaction history
  */
 export const getTransactionHistoryFrom = (config, api) => {
   return new Promise((resolve) => {
@@ -422,7 +422,7 @@ export const getTransactionHistoryFrom = (config, api) => {
  * @param {object} config - Configuration object.
  * @param {string} config.net - 'MainNet', 'TestNet' or a custom URL.
  * @param {object} api - The endpoint API object. eg, neonDB or Neoscan.
- * @return {Promise<string>} - URL
+ * @return {Promise<number>} Current height.
  */
 export const getWalletDBHeightFrom = (config, api) => {
   return new Promise((resolve) => {

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -4,13 +4,14 @@ import { RPCResponse } from '../rpc'
 import { Fixed8 } from '../utils'
 
 interface apiConfig {
-  net: net,
-  address: string,
-  privateKey?: string,
-  publicKey?: string,
-  url?: string,
-  balance?: Balance,
+  net: net
+  address: string
+  privateKey?: string
+  publicKey?: string
+  url?: string
+  balance?: Balance
   response?: string
+  intents?: TransactionOutput[]
 }
 
 interface AssetAmounts {

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -3,11 +3,15 @@ import { Transaction, TransactionOutput } from '../transactions'
 import { RPCResponse } from '../rpc'
 import { Fixed8 } from '../utils'
 
+export type net = 'MainNet' | 'TestNet' | string;
+export type signingFunction = (unsigned: Transaction, publicKey: string) => Transaction
+
 interface apiConfig {
   net: net
   address: string
   privateKey?: string
   publicKey?: string
+  signingFunction?: signingFunction
   url?: string
   balance?: Balance
   response?: string
@@ -18,8 +22,6 @@ interface AssetAmounts {
   GAS?: number
   NEO?: number
 }
-
-export type net = 'MainNet' | 'TestNet' | string;
 
 interface History {
   address: string
@@ -78,7 +80,7 @@ export namespace neonDB {
   export function doClaimAllGas(
     net: net,
     publicKey: string,
-    signingFunction: (unsigned: Transaction, publicKey: string) => Transaction
+    signingFunction: signingFunction
   ): Promise<RPCResponse>
 
   export function doMintTokens(
@@ -94,7 +96,7 @@ export namespace neonDB {
     publicKey: string,
     neo: number,
     gasCost: number,
-    signingFunction: (unsigned: Transaction, publicKey: string) => Transaction
+    signingFunction: signingFunction
   ): Promise<RPCResponse>
 
   export function doSendAsset(
@@ -108,7 +110,7 @@ export namespace neonDB {
     toAddress: string,
     publicKey: string,
     assetAmounts: AssetAmounts,
-    signingFunction: (unsigned: Transaction, publicKey: string) => Transaction
+    signingFunction: signingFunction
   ): Promise<RPCResponse>
 }
 
@@ -135,7 +137,7 @@ export namespace nep5 {
     toAddress: string,
     transferAmount: number,
     gasCost?: number,
-    signingFunction?: (unsigned: Transaction, publicKey: string) => Transaction
+    signingFunction?: signingFunction
   ): Promise<RPCResponse>
 }
 

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -4,12 +4,13 @@ import { RPCResponse } from '../rpc'
 import { Fixed8 } from '../utils'
 
 interface apiConfig {
-  net: string,
+  net: net,
   address: string,
   privateKey?: string,
   publicKey?: string,
   url?: string,
-  balance?: Balance
+  balance?: Balance,
+  response?: string
 }
 
 interface AssetAmounts {
@@ -17,11 +18,13 @@ interface AssetAmounts {
   NEO?: number
 }
 
+export type net = 'MainNet' | 'TestNet' | string;
+
 interface History {
   address: string
   history: PastTransaction[]
   name: string
-  net: 'MainNet' | 'TestNet' | string
+  net: net
 }
 
 interface PastTransaction {
@@ -44,48 +47,48 @@ export namespace cmc {
 
 
 //core
-export function getBalanceFrom(config: apiConfig, api: object): apiConfig
-export function getClaimsFrom(config: apiConfig, api: object): apiConfig
-export function getRPCEndpointFrom(config: apiConfig, api: object): apiConfig
-export function getTransactionHistoryFrom(config: apiConfig, api: object): apiConfig
-export function getWalletDBHeightFrom(config: apiConfig, api: object): apiConfig
-export function getMaxClaimAmountFrom(config: apiConfig, api: object): apiConfig
-export function createTx(config: apiConfig, txType: string): apiConfig
-export function signTx(config: apiConfig): apiConfig
-export function sendTx(config: apiConfig): apiConfig
+export function getBalanceFrom(config: apiConfig, api: object): Promise<apiConfig>
+export function getClaimsFrom(config: apiConfig, api: object): Promise<apiConfig>
+export function getRPCEndpointFrom(config: apiConfig, api: object): Promise<string>
+export function getTransactionHistoryFrom(config: apiConfig, api: object): Promise<History>
+export function getWalletDBHeightFrom(config: apiConfig, api: object): Promise<number>
+export function getMaxClaimAmountFrom(config: apiConfig, api: object): Promise<Fixed8>
+export function createTx(config: apiConfig, txType: string): Promise<apiConfig>
+export function signTx(config: apiConfig): Promise<apiConfig>
+export function sendTx(config: apiConfig): Promise<apiConfig>
 export function makeIntent(assetAmts: AssetAmounts, address: string): TransactionOutput[]
-export function sendAsset(config: apiConfig): apiConfig
-export function claimGas(config: apiConfig): apiConfig
-export function doInvoke(config: apiConfig): apiConfig
+export function sendAsset(config: apiConfig): Promise<apiConfig>
+export function claimGas(config: apiConfig): Promise<apiConfig>
+export function doInvoke(config: apiConfig): Promise<apiConfig>
 
 //neonDB
 export namespace neonDB {
-  export function getAPIEndpoint(net: string): string
-  export function getBalance(net: string, address: string): Promise<Balance>
-  export function getClaims(net: string, address: string): Promise<Claims>
-  export function getRPCEndpoint(net: string): Promise<string>
-  export function getTransactionHistory(net: string, address: string): Promise<History>
-  export function getWalletDBHeight(net: string): Promise<number>
+  export function getAPIEndpoint(net: net): string
+  export function getBalance(net: net, address: string): Promise<Balance>
+  export function getClaims(net: net, address: string): Promise<Claims>
+  export function getRPCEndpoint(net: net): Promise<string>
+  export function getTransactionHistory(net: net, address: string): Promise<History>
+  export function getWalletDBHeight(net: net): Promise<number>
 
   export function doClaimAllGas(
-    net: string,
+    net: net,
     privateKey: string
   ): Promise<RPCResponse>
   export function doClaimAllGas(
-    net: string,
+    net: net,
     publicKey: string,
     signingFunction: (unsigned: Transaction, publicKey: string) => Transaction
   ): Promise<RPCResponse>
 
   export function doMintTokens(
-    net: string,
+    net: net,
     scriptHash: string,
     fromWif: string,
     neo: number,
     gasCost: number
   ): Promise<RPCResponse>
   export function doMintTokens(
-    net: string,
+    net: net,
     scriptHash: string,
     publicKey: string,
     neo: number,
@@ -94,13 +97,13 @@ export namespace neonDB {
   ): Promise<RPCResponse>
 
   export function doSendAsset(
-    net: string,
+    net: net,
     toAddress: string,
     from: string,
     assetAmounts: AssetAmounts
   ): Promise<RPCResponse>
   export function doSendAsset(
-    net: string,
+    net: net,
     toAddress: string,
     publicKey: string,
     assetAmounts: AssetAmounts,
@@ -110,13 +113,13 @@ export namespace neonDB {
 
 //neoscan
 export namespace neoscan {
-  export function getAPIEndpoint(net: string): string
-  export function getRPCEndpoint(net: string): Promise<string>
-  export function getBalance(net: string, address: string): Promise<Balance>
-  export function getClaims(net: string, address: string): Promise<Claims>
-  export function getMaxClaimAmount(net: string, address: string): Promise<Fixed8>
-  export function getWalletDBHeight(net: string): Promise<number>
-  export function getTransactionHistory(net: string, address: string): Promise<History>
+  export function getAPIEndpoint(net: net): string
+  export function getRPCEndpoint(net: net): Promise<string>
+  export function getBalance(net: net, address: string): Promise<Balance>
+  export function getClaims(net: net, address: string): Promise<Claims>
+  export function getMaxClaimAmount(net: net, address: string): Promise<Fixed8>
+  export function getWalletDBHeight(net: net): Promise<number>
+  export function getTransactionHistory(net: net, address: string): Promise<History>
 }
 
 //nep5
@@ -125,7 +128,7 @@ export namespace nep5 {
   export function getTokenBalance(url: string, scriptHash: string, address: string): Promise<number>
   export function getToken(url: string, scriptHash: string, address?: string): Promise<object>
   export function doTransferToken(
-    net: string,
+    net: net,
     scriptHash: string,
     fromWif: string,
     toAddress: string,

--- a/src/rpc/client.js
+++ b/src/rpc/client.js
@@ -108,7 +108,7 @@ class RPCClient {
    * @param {number} index
    * @return {Promise<string>}
    */
-  getBlockHash(index) {
+  getBlockHash (index) {
     return this.execute(Query.getBlockHash(index))
       .then((res) => {
         return res.result

--- a/src/sc/ScriptBuilder.js
+++ b/src/sc/ScriptBuilder.js
@@ -1,4 +1,4 @@
-import { StringStream, num2hexstring, reverseHex, isHex, ensureHex, int2hex, str2ab, ab2hexstring, str2hexstring } from '../utils.js'
+import { StringStream, num2hexstring, reverseHex, ensureHex, int2hex, str2ab, ab2hexstring, str2hexstring } from '../utils.js'
 import OpCode from './opCode.js'
 
 /**


### PR DESCRIPTION
All of the core typings were returning `apiConfig`, but in their actual implementation, they were actually returning promises, with various subsequent return types. Updated to reflect accurate return types.

Upon running lint in compliance with the contribution guidelines, it seems there were some existing lint errors. Added those fixes as well.