### PR TITLE
Update param.value validation logic to accept 0 and empty string

### DIFF
--- a/src/sc/ScriptBuilder.js
+++ b/src/sc/ScriptBuilder.js
@@ -82,7 +82,7 @@ class ScriptBuilder extends StringStream {
    */
   _emitParam (param) {
     if (!param.type) throw new Error('No type available!')
-    if (!param.value) throw new Error('No value available!')
+    if (!this._isValidValue(param.value)) throw new Error('Invalid value provided!')
     switch (param.type) {
       case 'String':
         return this._emitString(str2hexstring(param.value))
@@ -97,6 +97,17 @@ class ScriptBuilder extends StringStream {
       case 'Hash160':
         return this._emitString(reverseHex(param.value))
     }
+  }
+
+  _isValidValue (value) {
+    if (value) {
+      return true
+    } else if (value === 0) {
+      return true
+    } else if (value === '') {
+      return true
+    }
+    return false
   }
 
   /**

--- a/src/sc/ScriptBuilder.js
+++ b/src/sc/ScriptBuilder.js
@@ -82,7 +82,7 @@ class ScriptBuilder extends StringStream {
    */
   _emitParam (param) {
     if (!param.type) throw new Error('No type available!')
-    if (!this._isValidValue(param.value)) throw new Error('Invalid value provided!')
+    if (!isValidValue(param.value)) throw new Error('Invalid value provided!')
     switch (param.type) {
       case 'String':
         return this._emitString(str2hexstring(param.value))
@@ -97,17 +97,6 @@ class ScriptBuilder extends StringStream {
       case 'Hash160':
         return this._emitString(reverseHex(param.value))
     }
-  }
-
-  _isValidValue (value) {
-    if (value) {
-      return true
-    } else if (value === 0) {
-      return true
-    } else if (value === '') {
-      return true
-    }
-    return false
   }
 
   /**
@@ -183,6 +172,17 @@ class ScriptBuilder extends StringStream {
         throw new Error()
     }
   }
+}
+
+const isValidValue = (value) => {
+  if (value) {
+    return true
+  } else if (value === 0) {
+    return true
+  } else if (value === '') {
+    return true
+  }
+  return false
 }
 
 export default ScriptBuilder


### PR DESCRIPTION
Take the following for example:

```
const props = {
  scriptHash: 'CONTRACT_HASH',
  operation: 'do_stuff',
  args: [
    { "type": "String", "value": '' },
    { "type": "Integer", "value": 0 }
  ],
}
const script = Neon.sc.createScript(props)
```

Supplied intents meant to be valid but are blocked by `_emitParam` due to its validation check.

I've create a separate private method `_isValidValue()` that will allow us to expand on this logic in the future if needed while keeping `_emitParam()` readable.
