### PR TITLE
Fix API response declarations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -96,9 +96,9 @@ declare const semantic: {
       gasCost: number
     ) => Promise<RPCResponse>
   }
-  sendAsset: (config: apiConfig) => apiConfig
-  claimGas: (config: apiConfig) => apiConfig
-  doInvoke: (config: apiConfig) => apiConfig
+  sendAsset: (config: apiConfig) => Promise<apiConfig>
+  claimGas: (config: apiConfig) => Promise<apiConfig>
+  doInvoke: (config: apiConfig) => Promise<apiConfig>
 }
 
 export default semantic;


### PR DESCRIPTION
Couple of API methods are declared with incorrect response type, causing transpiler error when building in TypeScript.
