### PR TITLE
Fixed neoscan.getMaxClaimAmount for invalid addresses

### DIFF
--- a/src/api/neoscan.js
+++ b/src/api/neoscan.js
@@ -94,7 +94,7 @@ export const getMaxClaimAmount = (net, address) => {
     log.info(
       `Retrieved maximum amount of gas claimable after spending all NEO for ${address} from neoscan ${net}`
     )
-    return new Fixed8(res.data.unclaimed)
+    return new Fixed8(res.data.unclaimed || 0)
   })
 }
 


### PR DESCRIPTION
NOTE: This PR's into `dev`, but let me know if I should change it to `master`.

This fixes a bug for addresses that don't exist according to neoscan.  For example, a call to https://api.neoscan.io/api/main_net/v1/get_claimable/fake-address returns:

<img width="208" alt="screen shot 2018-02-25 at 5 51 35 pm" src="https://user-images.githubusercontent.com/169093/36648186-90d6f832-1a55-11e8-93ad-2cfb3bd09e71.png">

This causes neon-js to call `new Fixed8(undefined)`, which throws an error:

<img width="534" alt="screen shot 2018-02-25 at 5 46 55 pm" src="https://user-images.githubusercontent.com/169093/36648194-a1c70efc-1a55-11e8-868a-9c73562afda2.png">

This is only an issue with neoscan; neonDB returns 0 for invalid addresses such as https://testnet-api.neonwallet.com/v2/address/claims/fake-address.