### PR TITLE
Fix(api): Add missing typing for api.fillUrl

### DIFF
--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -70,6 +70,7 @@ export function makeIntent(assetAmts: AssetAmounts, address: string): Transactio
 export function sendAsset(config: apiConfig): Promise<apiConfig>
 export function claimGas(config: apiConfig): Promise<apiConfig>
 export function doInvoke(config: apiConfig): Promise<apiConfig>
+export function fillUrl(config: apiConfig): Promise<apiConfig>
 export function fillKeys(config: apiConfig): Promise<apiConfig>
 export function fillBalance(config: apiConfig):Promise<apiConfig>
 


### PR DESCRIPTION
api.fillUrl was missing from the typing, so it's currently showing as not existing on the exported api object.