### PR TITLE
handle decimal sizes other than 8 when converting to ByteArray

### DIFF
--- a/src/sc/ContractParam.js
+++ b/src/sc/ContractParam.js
@@ -64,11 +64,19 @@ class ContractParam {
    * @param {string} format - The format that this value represents. Different formats are parsed differently.
    * @return {ContractParam}
    */
-  static byteArray (value, format) {
+  static byteArray (value, format, decimals = 8) {
     if (format) format = format.toLowerCase()
     if (format === 'address') {
       return new ContractParam('ByteArray', reverseHex(getScriptHashFromAddress(value)))
     } else if (format === 'fixed8') {
+      if (!isFinite(value)) throw new Error(`Input should be number!`)
+      var e = 1, p = 0
+      while (Math.round(value * e) / e !== value) { 
+        e *= 10
+        p++ 
+      }
+      if (p > decimals) throw new Error(`Input value exceeds maximum precision!`)
+      value = value / Math.pow(10, 8 - decimals)
       return new ContractParam('ByteArray', num2fixed8(value))
     } else {
       return new ContractParam('ByteArray', value)

--- a/src/sc/ContractParam.js
+++ b/src/sc/ContractParam.js
@@ -1,4 +1,4 @@
-import { num2fixed8, reverseHex, Fixed8 } from '../utils'
+import { reverseHex, Fixed8 } from '../utils'
 import { getScriptHashFromAddress, isAddress } from '../wallet'
 
 /**
@@ -75,17 +75,13 @@ class ContractParam {
         decimals = args[0]
       }
       if (!isFinite(value)) throw new Error(`Input should be number!`)
-      var e = 1
-      var p = 0
-      while (Math.round(value * e) / e !== value) {
-        e *= 10
-        p++
-      }
-      if (p > decimals) throw new Error(`Input value exceeds maximum precision!`)
-      value = new Fixed8(value)
-      let divisor = new Fixed8(Math.pow(10, 8 - decimals))
-      value /= divisor
-      return new ContractParam('ByteArray', num2fixed8(value))
+      const divisor = new Fixed8(Math.pow(10, 8 - decimals))
+      const fixed8Value = new Fixed8(value)
+      const adjustedValue = fixed8Value.times(divisor)
+      const modValue = adjustedValue.mod(1)
+      if (!modValue.isZero()) throw new Error(`wrong precision`)
+      value = fixed8Value.div(divisor)
+      return new ContractParam('ByteArray', value.toReverseHex().slice(0, 16))
     } else {
       return new ContractParam('ByteArray', value)
     }

--- a/test/unit/sc/ContractParam.js
+++ b/test/unit/sc/ContractParam.js
@@ -58,8 +58,14 @@ describe('ContractParam', function () {
     })
 
     it('fixed8 with four decimals', () => {
-      const cp = ContractParam.byteArray(222, 'fixed8', 4)
-      cp.should.eql({ type: 'ByteArray', value: 'e0df210000000000' })
+      const cp = ContractParam.byteArray(222.1234, 'fixed8', 4)
+      cp.should.eql({ type: 'ByteArray', value: 'b2e4210000000000' })
+    })
+
+    it('exceeds allowed precision', () => {
+      ; (function () {
+      const cp = ContractParam.byteArray(222.12345, 'fixed8', 4)
+      }.should.throw(Error, 'wrong precision'))
     })
   })
 

--- a/test/unit/sc/ContractParam.js
+++ b/test/unit/sc/ContractParam.js
@@ -51,6 +51,16 @@ describe('ContractParam', function () {
       const cp = ContractParam.byteArray(1000, 'fixed8')
       cp.should.eql({ type: 'ByteArray', value: '00e8764817000000' })
     })
+
+    it('fixed8 with zero decimals', () => {
+      const cp = ContractParam.byteArray(1, 'fixed8', 0)
+      cp.should.eql({ type: 'ByteArray', value: '0100000000000000' })
+    })
+
+    it('fixed8 with four decimals', () => {
+      const cp = ContractParam.byteArray(222, 'fixed8', 4)
+      cp.should.eql({ type: 'ByteArray', value: 'e0df210000000000' })
+    })
   })
 
   it('Array', () => {


### PR DESCRIPTION
neon-js currently does not properly handle sending tokens with decimal sizes other than 8. For example, when sending 1 RHT (a zero-decimal token), neon-js assumes a fixed8 size and converts the number "1" to "100000000" when creating the byte array to add to the contract invocation script. The current workaround for wallets using neon-js is for the user to send 0.00000001 RHT for every 1 RHT intended, a less-than-ideal situation

This fix adds a decimal argument to the byteArray function (this argument is already passed to the function by the latest neon-wallet versions) and pre-divides the value according to the number of decimals before it is passed to num2fixed8 at the end of the function, the end result being a byte array with the correct integer value in fixed8 format.

This fix also checks the precision of the value being sent to enforce that no more than the allowed number of decimals are specified, throwing an error (for example, if someone tries to send fractional values of RHT) instead of simply rounding the value to the allowed precision (which could lead to confusion and unexpected loss of funds if users do not know the token's decimals).
