### PR TITLE
Fixed promise rejection for decryptAsync

### DIFF
--- a/src/wallet/nep2.js
+++ b/src/wallet/nep2.js
@@ -149,7 +149,7 @@ export const decryptAsync = (encryptedKey, keyphrase, scryptParams = DEFAULT_SCR
         const privateKey = hexXor(decrypted.toString(), derived1)
         const account = new Account(privateKey)
         const newAddressHash = SHA256(SHA256(enc.Latin1.parse(account.address))).toString().slice(0, 8)
-        if (addressHash !== newAddressHash) throw new Error('Wrong Password!')
+        if (addressHash !== newAddressHash) reject(new Error('Wrong Password!'))
         log.info(`Successfully decrypted ${encryptedKey}`)
         resolve(account.WIF)
       }

--- a/test/unit/wallet/nep2.js
+++ b/test/unit/wallet/nep2.js
@@ -90,6 +90,12 @@ describe('NEP2', function () {
     thrower.should.throw()
   })
 
+  it('Errors on wrong password async', () => {
+    const encrypted = NEP2.encrypt(testKeys.a.wif, testKeys.a.passphrase, simpleScrypt)
+    const thrower = NEP2.decryptAsync(encrypted, 'wrongpassword', simpleScrypt)
+    return thrower.should.be.rejectedWith(Error, 'Wrong Password!')
+  })
+
   it('Errors on wrong scrypt params', () => {
     const thrower = () => NEP2.decrypt(testKeys.a.encryptedWif, testKeys.a.passphrase, simpleScrypt)
     thrower.should.throw()


### PR DESCRIPTION
This fixes an issue I ran into today with `decryptAsync`.  The function is throwing an error instead of rejecting.