### PR TITLE
Updated neoscan getMaxClaimAmount to use get_unclaimed endpoint

### DIFF
--- a/src/api/neoscan.js
+++ b/src/api/neoscan.js
@@ -90,7 +90,7 @@ export const getClaims = (net, address) => {
  */
 export const getMaxClaimAmount = (net, address) => {
   const apiEndpoint = getAPIEndpoint(net)
-  return axios.get(apiEndpoint + '/v1/get_claimable/' + address).then(res => {
+  return axios.get(apiEndpoint + '/v1/get_unclaimed/' + address).then(res => {
     log.info(
       `Retrieved maximum amount of gas claimable after spending all NEO for ${address} from neoscan ${net}`
     )

--- a/test/unit/api/mockData.json
+++ b/test/unit/api/mockData.json
@@ -521,6 +521,13 @@
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW"
       }
     },
+    "claimsB": {
+      "url": "https://neoscan-testnet.io/api/test_net/v1/get_unclaimed/ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+      "response": {
+        "unclaimed": 0.03455555,
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW"
+      }
+    },
     "claimsInvalid": {
       "url": "https://neoscan-testnet.io/api/test_net/v1/get_claimable/invalidAddress",
       "response": {


### PR DESCRIPTION
This updates the `getMaxClaimAmount` function for the neoscan API to use the preferred v1/get_unclaimed endpoint.