### PR TITLE
fix(api): cache rpc endpoint for getRPCEndpoint

### DIFF
--- a/src/api/neonDB.js
+++ b/src/api/neonDB.js
@@ -4,7 +4,7 @@ import { Transaction, TxAttrUsage } from '../transactions'
 import { RPCClient, Query } from '../rpc'
 import { ASSET_ID } from '../consts'
 import { Fixed8, reverseHex } from '../utils'
-import { networks, httpsOnly } from '../settings'
+import { networks, httpsOnly, timeout } from '../settings'
 import logger from '../logging'
 
 const log = logger('api')
@@ -105,7 +105,13 @@ export const getRPCEndpoint = net => {
       }
       if (nodes.length === 0) throw new Error('No eligible nodes found!')
       var urls = nodes.map(n => n.url)
-      if (urls.includes(cachedRPC)) return cachedRPC
+      if (urls.includes(cachedRPC)) {
+        return new RPCClient(cachedRPC).ping().then(num => {
+          if (num <= timeout.ping) return cachedRPC
+          cachedRPC = null
+          return getRPCEndpoint(net)
+        })
+      }
       var clients = urls.map(u => new RPCClient(u))
       return Promise.race(clients.map(c => c.ping().then(_ => c.net)))
     })

--- a/src/api/neonDB.js
+++ b/src/api/neonDB.js
@@ -9,6 +9,8 @@ import logger from '../logging'
 
 const log = logger('api')
 export const name = 'neonDB'
+
+var cachedRPC = null
 /**
  * API Switch for MainNet and TestNet
  * @param {string} net - 'MainNet', 'TestNet', or custom neon-wallet-db URL.
@@ -102,8 +104,14 @@ export const getRPCEndpoint = net => {
         }
       }
       if (nodes.length === 0) throw new Error('No eligible nodes found!')
-      var clients = nodes.map(n => new RPCClient(n.url))
+      var urls = nodes.map(n => n.url)
+      if (urls.includes(cachedRPC)) return cachedRPC
+      var clients = urls.map(u => new RPCClient(u))
       return Promise.race(clients.map(c => c.ping().then(_ => c.net)))
+    })
+    .then(fastestUrl => {
+      cachedRPC = fastestUrl
+      return fastestUrl
     })
 }
 

--- a/src/api/neoscan.js
+++ b/src/api/neoscan.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { Balance, Claims } from '../wallet'
 import { ASSET_ID } from '../consts'
 import { Fixed8 } from '../utils'
-import { networks, httpsOnly } from '../settings'
+import { networks, httpsOnly, timeout } from '../settings'
 import logger from '../logging'
 import RPCClient from '../rpc/client'
 
@@ -42,7 +42,13 @@ export const getRPCEndpoint = net => {
     }
     if (nodes.length === 0) throw new Error('No eligible nodes found!')
     var urls = nodes.map(n => n.url)
-    if (urls.includes(cachedRPC)) return cachedRPC
+    if (urls.includes(cachedRPC)) {
+      return new RPCClient(cachedRPC).ping().then(num => {
+        if (num <= timeout.ping) return cachedRPC
+        cachedRPC = null
+        return getRPCEndpoint(net)
+      })
+    }
     var clients = urls.map(u => new RPCClient(u))
     return Promise.race(clients.map(c => c.ping().then(_ => c.net)))
   })

--- a/src/api/neoscan.js
+++ b/src/api/neoscan.js
@@ -9,6 +9,8 @@ import RPCClient from '../rpc/client'
 const log = logger('api')
 export const name = 'neoscan'
 
+var cachedRPC = null
+
 /**
  * Returns the appropriate NeoScan endpoint.
  * @param {string} net - 'MainNet', 'TestNet' or a custom NeoScan-like url.
@@ -39,9 +41,15 @@ export const getRPCEndpoint = net => {
       }
     }
     if (nodes.length === 0) throw new Error('No eligible nodes found!')
-    var clients = nodes.map(n => new RPCClient(n.url))
+    var urls = nodes.map(n => n.url)
+    if (urls.includes(cachedRPC)) return cachedRPC
+    var clients = urls.map(u => new RPCClient(u))
     return Promise.race(clients.map(c => c.ping().then(_ => c.net)))
   })
+    .then(fastestUrl => {
+      cachedRPC = fastestUrl
+      return fastestUrl
+    })
 }
 
 /**


### PR DESCRIPTION
This is a primitive implementation of a cache so that we don't spam every node for a getBlockCount.

For the call `getRPCEndpoint`, it will still continue to request for a list of best nodes. However, upon compiling the list of best nodes, if the previous best node address is found within the list, it will only ping check the cached node.
