### PR TITLE
feat(tx): Attachable fees for transactions

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -167,6 +167,7 @@ export const fillClaims = config => {
 export const createTx = (config, txType) => {
   if (config.tx) return config
   if (typeof txType === 'string') txType = txType.toLowerCase()
+  if (!config.fees) config.fees = 0
   let tx
   switch (txType) {
     case 'claim':
@@ -177,13 +178,13 @@ export const createTx = (config, txType) => {
     case 'contract':
     case 128:
       checkProperty(config, 'balance', 'intents')
-      tx = Transaction.createContractTx(config.balance, config.intents, config.override)
+      tx = Transaction.createContractTx(config.balance, config.intents, config.override, config.fees)
       break
     case 'invocation':
     case 209:
       checkProperty(config, 'balance', 'gas', 'script')
       if (!config.intents) config.intents = []
-      tx = Transaction.createInvocationTx(config.balance, config.intents, config.script, config.gas, config.override)
+      tx = Transaction.createInvocationTx(config.balance, config.intents, config.script, config.gas, config.override, config.fees)
       break
     default:
       return Promise.reject(new Error(`Tx Type not found: ${txType}`))

--- a/src/transactions/core.js
+++ b/src/transactions/core.js
@@ -12,24 +12,25 @@ const log = logger('tx')
  * Calculate the inputs required given the intents and gasCost. gasCost has to be seperate because it will not be reflected as an TransactionOutput.
  * @param {Balance} balances - Balance of all assets available.
  * @param {TransactionOutput[]} intents - All sending intents
- * @param {number|Fixed8} gasCost - gasCost required for the transaction.
+ * @param {number|Fixed8} extraCost - gasCost required for the transaction.
  * @param {function} strategy
+ * @param {number|Fixed8} fees
  * @return {object} {inputs: TransactionInput[], change: TransactionOutput[] }
  */
-export const calculateInputs = (balances, intents, gasCost = 0, strategy = null) => {
+export const calculateInputs = (balances, intents, extraCost = 0, strategy = null, fees = 0) => {
   if (intents === null) intents = []
   if (strategy === null) strategy = defaultCalculationStrategy
   const requiredAssets = intents.reduce((assets, intent) => {
     assets[intent.assetId] ? assets[intent.assetId] = assets[intent.assetId].add(intent.value) : assets[intent.assetId] = intent.value
     return assets
   }, {})
-  // Add GAS cost in
-  gasCost = new Fixed8(gasCost)
-  if (gasCost.gt(0)) {
+  // Add GAS cost and fees in
+  extraCost = new Fixed8(extraCost).add(fees)
+  if (extraCost.gt(0)) {
     if (requiredAssets[ASSET_ID.GAS]) {
-      requiredAssets[ASSET_ID.GAS] = requiredAssets[ASSET_ID.GAS].add(gasCost)
+      requiredAssets[ASSET_ID.GAS] = requiredAssets[ASSET_ID.GAS].add(extraCost)
     } else {
-      requiredAssets[ASSET_ID.GAS] = gasCost
+      requiredAssets[ASSET_ID.GAS] = extraCost
     }
   }
   const inputsAndChange = Object.keys(requiredAssets).map((assetId) => {

--- a/test/integration/api/core.js
+++ b/test/integration/api/core.js
@@ -29,7 +29,7 @@ describe('Integration: API Core', function () {
     if (mock) mock.restore()
   })
   describe('sendAsset', function () {
-    it('NeonDB', () => {
+    it.skip('NeonDB', () => {
       useNeonDB()
 
       const intent1 = core.makeIntent({ NEO: 1 }, testKeys.a.address)
@@ -54,7 +54,8 @@ describe('Integration: API Core', function () {
         net: NEO_NETWORK.TEST,
         address: testKeys.a.address,
         privateKey: testKeys.a.privateKey,
-        intents: intent2
+        intents: intent2,
+        fees: 0.00000001
       }
       return core.sendAsset(config2)
         .then((c) => {
@@ -65,7 +66,7 @@ describe('Integration: API Core', function () {
   })
 
   describe('claimGas', function () {
-    it('neonDB', () => {
+    it.skip('neonDB', () => {
       useNeonDB()
 
       const config = {
@@ -97,7 +98,7 @@ describe('Integration: API Core', function () {
   })
 
   describe('doInvoke', function () {
-    it('neonDB', () => {
+    it.skip('neonDB', () => {
       useNeonDB()
 
       const config = {


### PR DESCRIPTION
Added a new `fees` param for calculating transactions. This allows for fees to be attached to transactions.

```
// using API managed methods
config = {
...
fees = 0.00001
}

doInvoke(config).then(...)

// or using direct tx
new Transaction().calculate(balance, strategy, fees)
```

How it works is that you just send GAS to the void. This means that the sum of inputs > sum of outputs for GAS. The excess is considered as fees to the network. First, system fees will be deducted from this excess amount. The current system fees is zero for all transactions so there is no deductions. The remaining amount is considered as network fees and will be used to prioritise transaction picking when it comes to block forming.

This PR also disables the neonDB tests because the testnet neonDB endpoint has dropped behind so much its pretty much dead at the moment. Seeing that support for it will drop, I don't foresee the tests being useful.

Reference transaction: https://neoscan-testnet.io/transaction/e5c9b142d2a6c0bf48fffbbac50698cc4be34ac006313611283d49de68298444