### PR TITLE
updates error handling api/core.js

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -43,7 +43,8 @@ export const sendAsset = config => {
         address: config.address,
         intents: config.intents,
         balance: config.balance,
-        tx: config.tx
+        tx: config.tx,
+        fees: config.fees
       }
       log.error(`sendAsset failed with: ${err.message}. Dumping config`, dump)
       throw err
@@ -69,7 +70,12 @@ export const claimGas = config => {
     .then(c => sendTx(c))
     .catch(err => {
       const dump = {
-        net: config.net, address: config.address, intents: config.intents, claims: config.claims, tx: config.tx
+        net: config.net,
+        address: config.address,
+        intents: config.intents,
+        balance: config.balance,
+        tx: config.tx,
+        claims: config.claims
       }
       log.error(`claimGas failed with ${err.message}. Dumping config`, dump)
       throw err
@@ -104,7 +110,14 @@ export const doInvoke = config => {
     .then(c => sendTx(c))
     .catch(err => {
       const dump = {
-        net: config.net, address: config.address, intents: config.intents, balance: config.balance, script: config.script, gas: config.gas, tx: config.tx
+        net: config.net,
+        address: config.address,
+        intents: config.intents,
+        balance: config.balance,
+        tx: config.tx,
+        script: config.script,
+        gas: config.gas,
+        fees: config.fees
       }
       log.error(`doInvoke failed with ${err.message}. Dumping config`, dump)
       throw err

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -73,7 +73,6 @@ export const claimGas = config => {
         net: config.net,
         address: config.address,
         intents: config.intents,
-        balance: config.balance,
         tx: config.tx,
         claims: config.claims
       }


### PR DESCRIPTION
When debugging locally for adding transaction fee functionality to `neon-wallet` I noticed fees were not being dumped as part of the error handling pattern. This PR adds that info.