### PR TITLE
just reminding void return is ff00

### DIFF
--- a/src/sc/core.js
+++ b/src/sc/core.js
@@ -27,7 +27,7 @@ export const createScript = (...scriptIntents) => {
 /**
  * Generates script for deploying contract
  */
-export const generateDeployScript = ({ script, name, version, author, email, description, needsStorage = false, returnType = 'ff', parameterList = undefined }) => {
+export const generateDeployScript = ({ script, name, version, author, email, description, needsStorage = false, returnType = 'ff00', parameterList = undefined }) => {
   const sb = new ScriptBuilder()
   sb
     .emitPush(str2hexstring(description))


### PR DESCRIPTION
Fellows, it seems that return code for Void (ff) is not passed as `ff`, but as `ff00`, because it is its biginteger representation (see: https://github.com/neo-project/neo/pull/253). For regular types <= 16, it continues the same, a single hex, because it is the same as bigint representation.