### PR TITLE
fix(sc): Fix getValidators method

### DIFF
--- a/src/rpc/client.js
+++ b/src/rpc/client.js
@@ -373,7 +373,7 @@ class RPCClient {
   }
 
   getValidators () {
-    return this.execute(Query.getValidators)
+    return this.execute(Query.getValidators())
       .then((res) => {
         return res.result
       })


### PR DESCRIPTION
I was trying to use this method, however it throwed an error because `this.execute` expects a query instance to be passed. (it got a reference)