### PR TITLE
chore(wallet): fixed balance calculation when marking as confirmed

### DIFF
--- a/src/wallet/Balance.js
+++ b/src/wallet/Balance.js
@@ -134,7 +134,9 @@ class Balance {
    */
   confirm () {
     for (const sym of this.assetSymbols) {
-      let assetBalance = this.assets[sym]
+      const assetBalance = this.assets[sym]
+      const difference = assetBalance.unconfirmed.reduce((sum, coin) => sum.add(coin.value), new Fixed8(0))
+      assetBalance.balance = assetBalance.balance.add(difference)
       assetBalance.unspent = assetBalance.unspent.concat(assetBalance.unconfirmed)
       assetBalance.unconfirmed = []
     }

--- a/test/unit/wallet/Balance.js
+++ b/test/unit/wallet/Balance.js
@@ -80,11 +80,20 @@ describe('Balance', function () {
     })
   })
 
-  it('confirm', () => {
-    bal.assets.NEO.unconfirmed = [{ txid: 'abc', index: 0, value: 1 }]
-    const unspentLength = bal.assets.NEO.unspent.length
-    bal.confirm()
-    bal.assets.NEO.unspent.length.should.equal(unspentLength + 1)
+  describe('confirm', function () {
+    it('moves unconfirmed coins to unspent', () => {
+      bal.assets.NEO.unconfirmed = [{ txid: 'abc', index: 0, value: 1 }]
+      const unspentLength = bal.assets.NEO.unspent.length
+      bal.confirm()
+      bal.assets.NEO.unspent.length.should.equal(unspentLength + 1)
+    })
+
+    it('recalculates balance', () => {
+      bal.assets.NEO.unconfirmed = [{ txid: 'abc', index: 0, value: 1 }]
+      const expectedBalance = bal.assets.NEO.balance.add(1)
+      bal.confirm()
+      bal.assets.NEO.balance.eq(expectedBalance).should.equal(true)
+    })
   })
 
   describe('verifyAssets', function () {


### PR DESCRIPTION
This fixes an issue where calling `balance.confirm()` doesn't update the balance in the same sense that `balance.applyTx(tx, true)` does.

I'm not sure if you're taking fixes for the v3 branch, so if not, please let me know.