### PR TITLE
chore(balance): prevent applyTx from being called twice for contracts & invocations

### DIFF
--- a/src/transactions/transaction.js
+++ b/src/transactions/transaction.js
@@ -223,7 +223,6 @@ class Transaction {
     const { inputs, change } = core.calculateInputs(balance, this.outputs, this.gas, strategy, fees)
     this.inputs = inputs
     this.outputs = this.outputs.concat(change)
-    balance.applyTx(this)
     log.info(`Calculated the inputs required for Transaction with Balance: ${balance.address}`)
     return this
   }

--- a/test/unit/transactions/transaction.js
+++ b/test/unit/transactions/transaction.js
@@ -56,8 +56,6 @@ describe('Transaction', function () {
     tx.exclusiveData.should.eql({})
     tx.inputs.length.should.equal(1)
     tx.outputs.length.should.equal(1)
-    balance.assets.NEO.unconfirmed.length.should.equal(1)
-    balance.assets.NEO.spent.length.should.equal(1)
   })
 
   it('create InvocationTx', () => {
@@ -73,7 +71,6 @@ describe('Transaction', function () {
       script: '00046e616d656711c4d1f4fba619f2628870d36e3a9773e874705b'
     })
     tx.inputs.length.should.be.at.least(1)
-    balance.assets.GAS.unconfirmed.length.should.equal(1)
   })
 
   it('create StateTx', () => {

--- a/test/unit/wallet/Balance.js
+++ b/test/unit/wallet/Balance.js
@@ -59,7 +59,8 @@ describe('Balance', function () {
     ]
 
     it('unconfirmed', () => {
-      Transaction.createContractTx(bal, intents)
+      const tx = Transaction.createContractTx(bal, intents)
+      bal.applyTx(tx, false)
       bal.assets.GAS.spent.length.should.equal(1)
       bal.assets.GAS.unspent.length.should.equal(1)
       bal.assets.GAS.unconfirmed.length.should.equal(2)


### PR DESCRIPTION
This fixes an issue I discovered with transactions being double-applied to balances for "contract" and "invocation" transactions.  When using `api.sendAsset` or `api.doInvoke`, the `balance.applyTx` function was effectively being called twice:

**For sendAsset:**

1. via `createTx` → `createContractTx` → `Transaction.calculate` → `Balance.applyTx`
2. via `sendTx` → `applyTx`

**For doInvoke:**

1. via `createTx` → `createInvocationTx` → `Transaction.calculate` → `Balance.applyTx`
2. via `sendTx` → `applyTx`

This removes the call for `Balance.applyTx` from `Transaction.calculate`, leaving it as part of the core api flow.