### PR TITLE
chore(balance): fix balance confirm() calculation

### DIFF
--- a/src/wallet/Balance.js
+++ b/src/wallet/Balance.js
@@ -135,9 +135,8 @@ class Balance {
   confirm () {
     for (const sym of this.assetSymbols) {
       const assetBalance = this.assets[sym]
-      const difference = assetBalance.unconfirmed.reduce((sum, coin) => sum.add(coin.value), new Fixed8(0))
-      assetBalance.balance = assetBalance.balance.add(difference)
       assetBalance.unspent = assetBalance.unspent.concat(assetBalance.unconfirmed)
+      assetBalance.balance = assetBalance.unspent.reduce((sum, coin) => sum.add(coin.value), new Fixed8(0))
       assetBalance.unconfirmed = []
     }
     return this


### PR DESCRIPTION
This fixes an issue with the calculations from [my previous PR](https://github.com/CityOfZion/neon-js/pull/324).  I discovered the calculation issue as a result of working on a fix for #329.

In summary, I was initially subtracting `spent` to get the right balance, but that was only necessary because `unconfirmed` had duplicate coins due to `Balance.applyTx` being called twice in my use case.