### PR TITLE
getVersion bugfix test

### DIFF
--- a/packages/neon-core/src/rpc/RPCClient.ts
+++ b/packages/neon-core/src/rpc/RPCClient.ts
@@ -239,8 +239,12 @@ export class RPCClient {
   public async getVersion(): Promise<string> {
     try {
       const response = await this.execute(Query.getVersion());
-      const newVersion = response.result.useragent.match(versionRegex)[1];
-      this.version = newVersion;
+      if (response && response.result && response.result.useragent) {
+        const newVersion = response.result.useragent.match(versionRegex)[1];
+        this.version = newVersion;
+      } else {
+        this.version = RPC_VERSION;
+      }
       return this.version;
     } catch (err) {
       if (err.message.includes("Method not found")) {


### PR DESCRIPTION
RPRClient getVersion() was not properly verifying a variable before access. I can't say I see why we need the version regex, but I've modified as-is.

The error that triggered this sequence of events:
```
node neon-js/cli/rpc/getversion.js -n http://seed2.neo.org:20332
(node:13603) UnhandledPromiseRejectionWarning: TypeError: Cannot read property '1' of null
    at /home/fet/nwd/phetter/neotools/node_modules/@cityofzion/neon-js/lib/index.js:36882:63
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
(node:13603) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:13603) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```