### PR TITLE
fix(neon-api): Add check for empty claims in fillClaims

### DIFF
--- a/packages/neon-api/__integration__/funcs/main.ts
+++ b/packages/neon-api/__integration__/funcs/main.ts
@@ -63,6 +63,16 @@ describe("sendAsset", () => {
 });
 
 describe("claimGas", () => {
+  test("claimGas throws if no claims found", async () => {
+    const config = {
+      api: provider,
+      account: new neonJs.wallet.Account(testKeys.a.privateKey),
+      claims: new neonJs.wallet.Claims()
+    };
+
+    expect(api.claimGas(config)).rejects.toThrow("No Claims found");
+  });
+
   test(
     "claimGas for a",
     async () => {

--- a/packages/neon-api/__tests__/func/fill.ts
+++ b/packages/neon-api/__tests__/func/fill.ts
@@ -28,9 +28,8 @@ describe("fillUrl", () => {
     const config = {
       api: {
         getRPCEndpoint: jest.fn().mockImplementationOnce(() => expectedUrl)
-      } as any,
-      address: ""
-    } as SendAssetConfig;
+      } as any
+    } as any;
 
     const result = await fill.fillUrl(config);
 
@@ -112,7 +111,9 @@ describe("fillSigningFunction", () => {
 
 describe("fillClaims", () => {
   test("skips if claims present", async () => {
-    const expectedClaims = new wallet.Claims();
+    const expectedClaims = new wallet.Claims({
+      claims: [new wallet.ClaimItem()]
+    });
     const config = {
       claims: expectedClaims
     } as ClaimGasConfig;
@@ -122,7 +123,9 @@ describe("fillClaims", () => {
   });
 
   test("fills if claims not present", async () => {
-    const expectedClaims = new wallet.Claims();
+    const expectedClaims = new wallet.Claims({
+      claims: [new wallet.ClaimItem()]
+    });
     const config = {
       net: "UnitTestNet",
       account: {
@@ -136,5 +139,20 @@ describe("fillClaims", () => {
     const result = await fill.fillClaims(config);
     expect(result.claims).toBe(expectedClaims);
     expect(config.api.getClaims).toBeCalledWith(config.account.address);
+  });
+
+  test("throws if claims not present and api returned no claims", async () => {
+    const expectedClaims = new wallet.Claims();
+    const config = {
+      net: "UnitTestNet",
+      account: {
+        address: jest.fn()
+      },
+      api: {
+        getClaims: jest.fn().mockImplementationOnce(() => expectedClaims)
+      } as any
+    } as any;
+
+    expect(fill.fillClaims(config)).rejects.toThrow("No Claims found");
   });
 });

--- a/packages/neon-api/src/funcs/fill.ts
+++ b/packages/neon-api/src/funcs/fill.ts
@@ -70,5 +70,8 @@ export async function fillClaims<
   if (!(config.claims instanceof wallet.Claims)) {
     config.claims = await config.api.getClaims(config.account!.address);
   }
+  if (!config.claims.claims || config.claims.claims.length === 0) {
+    throw new Error(`No Claims found`);
+  }
   return config;
 }


### PR DESCRIPTION
`claimGas` was not checking if the claims was empty, resulting in the rpc node rejecting with a invalid format message. This adds the check to `fillClaims` so that we can exit early with a better message.