### PR TITLE
Chore(rpc client): fix getVersion 

### DIFF
--- a/packages/neon-core/__tests__/rpc/RPCClient.ts
+++ b/packages/neon-core/__tests__/rpc/RPCClient.ts
@@ -278,7 +278,7 @@ describe("RPC Methods", () => {
 
   describe("getVersion", () => {
     test("success", async () => {
-      const versionString = "NEO:1.2.3";
+      const versionString = "/NEO:1.2.3/";
       const expected = "1.2.3";
       Query.getVersion.mockImplementationOnce(() => ({
         req: { method: "" },

--- a/packages/neon-core/src/rpc/RPCClient.ts
+++ b/packages/neon-core/src/rpc/RPCClient.ts
@@ -236,21 +236,33 @@ export class RPCClient {
   /**
    * Gets the version of the NEO node. This method will never be blocked by version. This method will also update the current Client's version to the one received.
    */
-  public async getVersion(): Promise<string> {
-    try {
-      const response = await this.execute(Query.getVersion());
-      const newVersion = response.result.useragent.match(versionRegex)[1];
-      this.version = newVersion;
-      return this.version;
-    } catch (err) {
-      if (err.message.includes("Method not found")) {
-        this.version = RPC_VERSION;
-        return this.version;
-      } else {
-        throw err;
-      }
-    }
-  }
+   getVersion() {
+       return __awaiter(this, void 0, void 0, function* () {
+           try {
+               const response = yield this.execute(Query_1.default.getVersion());
+               if (response && response.result && response.result.useragent) {
+                 var version = response.result.useragent.split(':');
+                 version[0] = version[0].substring(1);
+                 version[1] = version[1].substring(0, version[1].length-1);
+                 const newVersion = version[1];
+                 this.version = newVersion;
+               }
+               else {
+                 throw new Error('Empty or unexpected version pattern');
+               }
+               return this.version;
+           }
+           catch (err) {
+               if (err.message.includes("Method not found")) {
+                   this.version = consts_1.RPC_VERSION;
+                   return this.version;
+               }
+               else {
+                   throw err;
+               }
+           }
+       });
+   }
 
   /**
    * Calls a smart contract with the given parameters. This method is a local invoke, results are not reflected on the blockchain.

--- a/packages/neon-core/src/rpc/RPCClient.ts
+++ b/packages/neon-core/src/rpc/RPCClient.ts
@@ -238,12 +238,12 @@ export class RPCClient {
    */
   public async getVersion(): Promise<string> {
     try {
-      const response = yield this.execute(Query_1.default.getVersion());
+      const response = await this.execute(Query.getVersion());
       if (response && response.result && response.result.useragent) {
-        var version = response.result.useragent.split(':');
-        version[0] = version[0].substring(1);
-        version[1] = version[1].substring(0, version[1].length-1);
-        const newVersion = version[1];
+        const useragent = response.result.useragent
+        const responseLength = useragent.length;
+        const strippedResponse = useragent.substring(1, responseLength-1);
+        const [header, newVersion] = strippedResponse.split(':');
         this.version = newVersion;
       }
       else {
@@ -253,7 +253,7 @@ export class RPCClient {
     }
     catch (err) {
       if (err.message.includes("Method not found")) {
-        this.version = consts_1.RPC_VERSION;
+        this.version = RPC_VERSION;
         return this.version;
       }
       else {

--- a/packages/neon-core/src/rpc/RPCClient.ts
+++ b/packages/neon-core/src/rpc/RPCClient.ts
@@ -236,33 +236,31 @@ export class RPCClient {
   /**
    * Gets the version of the NEO node. This method will never be blocked by version. This method will also update the current Client's version to the one received.
    */
-   getVersion() {
-       return __awaiter(this, void 0, void 0, function* () {
-           try {
-               const response = yield this.execute(Query_1.default.getVersion());
-               if (response && response.result && response.result.useragent) {
-                 var version = response.result.useragent.split(':');
-                 version[0] = version[0].substring(1);
-                 version[1] = version[1].substring(0, version[1].length-1);
-                 const newVersion = version[1];
-                 this.version = newVersion;
-               }
-               else {
-                 throw new Error('Empty or unexpected version pattern');
-               }
-               return this.version;
-           }
-           catch (err) {
-               if (err.message.includes("Method not found")) {
-                   this.version = consts_1.RPC_VERSION;
-                   return this.version;
-               }
-               else {
-                   throw err;
-               }
-           }
-       });
-   }
+  public async getVersion(): Promise<string> {
+    try {
+      const response = yield this.execute(Query_1.default.getVersion());
+      if (response && response.result && response.result.useragent) {
+        var version = response.result.useragent.split(':');
+        version[0] = version[0].substring(1);
+        version[1] = version[1].substring(0, version[1].length-1);
+        const newVersion = version[1];
+        this.version = newVersion;
+      }
+      else {
+        throw new Error('Empty or unexpected version pattern');
+      }
+      return this.version;
+    }
+    catch (err) {
+      if (err.message.includes("Method not found")) {
+        this.version = consts_1.RPC_VERSION;
+        return this.version;
+      }
+      else {
+        throw err;
+      }
+    }
+  }
 
   /**
    * Calls a smart contract with the given parameters. This method is a local invoke, results are not reflected on the blockchain.


### PR DESCRIPTION
getVersion wasn't properly handling version responses. 

I dropped the regex and went with a string split approach instead. 

I tested against test net and it is reporting versions properly. 