### PR TITLE
feat(neon-nep5): added getTokens functionality

### DIFF
--- a/packages/neon-nep5/__integration__/main.ts
+++ b/packages/neon-nep5/__integration__/main.ts
@@ -107,13 +107,8 @@ describe("getTokens", () => {
   test("without balance", async () => {
     const info = await getTokens(TESTNET_URL, [
       CONST.CONTRACTS.TEST_RPX,
-      // CONST.CONTRACTS.TEST_RHTT4,
       CONST.CONTRACTS.TEST_LWTF,
       CONST.CONTRACTS.TEST_NXT
-      // CONST.CONTRACTS.TEST_RPX,
-      // CONST.CONTRACTS.TEST_RHTT4,
-      // CONST.CONTRACTS.TEST_LWTF,
-      // CONST.CONTRACTS.TEST_NXT
     ]);
 
     expect(Object.keys(info).map(key => info[key])).toEqual(
@@ -141,53 +136,28 @@ describe("getTokens", () => {
   });
 
   test("with balance", async () => {
-    const info = await getTokens(
+    const tokensInfo = await getTokens(
       TESTNET_URL,
       [
         CONST.CONTRACTS.TEST_RPX,
-        // CONST.CONTRACTS.TEST_RHTT4,
         CONST.CONTRACTS.TEST_LWTF,
         CONST.CONTRACTS.TEST_NXT
-        // CONST.CONTRACTS.TEST_RPX,
-        // CONST.CONTRACTS.TEST_RHTT4,
-        // CONST.CONTRACTS.TEST_LWTF,
-        // CONST.CONTRACTS.TEST_NXT
       ],
       "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW"
     );
 
-    expect(Object.keys(info).map(key => info[key])).toEqual(
-      expect.arrayContaining([
-        {
-          balance: "1032.011",
-          decimals: 8,
-          name: "Red Pulse Token 3.1.4",
-          symbol: "RPX",
-          totalSupply: 43467000
-        },
-        {
-          balance: "0.00015718",
-          decimals: 8,
-          name: "LOCALTOKEN",
-          symbol: "LWTF",
-          totalSupply: 2270000
-        },
-        {
-          balance: "1861",
-          decimals: 8,
-          name: "NEX Template",
-          symbol: "NXT",
-          totalSupply: 2508560
-        }
-      ])
-    );
+    expect(tokensInfo.length).toBe(3);
 
-    // expect(typeof info.name).toBe("string");
-    // expect(info.symbol).toMatch(/[A-Z]+/);
-    // expect(typeof info.decimals).toBe("number");
-    // expect(typeof info.totalSupply).toBe("number");
-    // expect(info.balance).toBeDefined();
-    // const balanceNum = info.balance.toNumber();
-    // expect(balanceNum).toBeGreaterThan(0);
+    Object.keys(tokensInfo).map(key => {
+      const info = tokensInfo[key];
+
+      expect(typeof info.name).toBe("string");
+      expect(info.symbol).toMatch(/[A-Z]+/);
+      expect(typeof info.decimals).toBe("number");
+      expect(typeof info.totalSupply).toBe("number");
+      expect(info.balance).toBeDefined();
+      const balanceNum = info.balance.toNumber();
+      expect(balanceNum).toBeGreaterThan(0);
+    });
   });
 });

--- a/packages/neon-nep5/__integration__/main.ts
+++ b/packages/neon-nep5/__integration__/main.ts
@@ -105,34 +105,22 @@ describe("getToken", () => {
 
 describe("getTokens", () => {
   test("without balance", async () => {
-    const info = await getTokens(TESTNET_URL, [
+    const tokensInfo = await getTokens(TESTNET_URL, [
       CONST.CONTRACTS.TEST_RPX,
       CONST.CONTRACTS.TEST_LWTF,
       CONST.CONTRACTS.TEST_NXT
     ]);
 
-    expect(Object.keys(info).map(key => info[key])).toEqual(
-      expect.arrayContaining([
-        {
-          decimals: 8,
-          name: "Red Pulse Token 3.1.4",
-          symbol: "RPX",
-          totalSupply: 43467000
-        },
-        {
-          decimals: 8,
-          name: "LOCALTOKEN",
-          symbol: "LWTF",
-          totalSupply: 2270000
-        },
-        {
-          decimals: 8,
-          name: "NEX Template",
-          symbol: "NXT",
-          totalSupply: 2508560
-        }
-      ])
-    );
+    Object.keys(tokensInfo).map(key => {
+      const info = tokensInfo[key];
+
+      expect(typeof info.name).toBe("string");
+      expect(info.symbol).toMatch(/[A-Z]+/);
+      expect(typeof info.decimals).toBe("number");
+      expect(typeof info.totalSupply).toBe("number");
+      expect(info.totalSupply).toBeGreaterThan(99999);
+      expect(info.balance).toBeUndefined();
+    });
   });
 
   test("with balance", async () => {
@@ -155,6 +143,7 @@ describe("getTokens", () => {
       expect(info.symbol).toMatch(/[A-Z]+/);
       expect(typeof info.decimals).toBe("number");
       expect(typeof info.totalSupply).toBe("number");
+      expect(info.totalSupply).toBeGreaterThan(99999);
       expect(info.balance).toBeDefined();
       const balanceNum = info.balance.toNumber();
       expect(balanceNum).toBeGreaterThan(0);

--- a/packages/neon-nep5/__integration__/main.ts
+++ b/packages/neon-nep5/__integration__/main.ts
@@ -1,5 +1,10 @@
 import { CONST, rpc, u } from "@cityofzion/neon-core";
-import { getToken, getTokenBalance, getTokenBalances, getTokens } from "../src/main";
+import {
+  getToken,
+  getTokenBalance,
+  getTokenBalances,
+  getTokens
+} from "../src/main";
 
 const TESTNET_URLS = [
   "https://test1.cityofzion.io:443",
@@ -98,42 +103,38 @@ describe("getToken", () => {
   });
 });
 
-
 describe("getTokens", () => {
   test("without balance", async () => {
     const info = await getTokens(TESTNET_URL, [
       CONST.CONTRACTS.TEST_RPX,
       // CONST.CONTRACTS.TEST_RHTT4,
       CONST.CONTRACTS.TEST_LWTF,
-      CONST.CONTRACTS.TEST_NXT,
+      CONST.CONTRACTS.TEST_NXT
       // CONST.CONTRACTS.TEST_RPX,
       // CONST.CONTRACTS.TEST_RHTT4,
       // CONST.CONTRACTS.TEST_LWTF,
       // CONST.CONTRACTS.TEST_NXT
     ]);
 
-    expect(Object.keys(info).map(key=>info[key])).toEqual(
+    expect(Object.keys(info).map(key => info[key])).toEqual(
       expect.arrayContaining([
         {
-          "balance": 0,
-          "decimals": 8,
-          "name": "Red Pulse Token 3.1.4",
-          "symbol": "RPX",
-          "totalSupply": 43467000,
+          decimals: 8,
+          name: "Red Pulse Token 3.1.4",
+          symbol: "RPX",
+          totalSupply: 43467000
         },
         {
-          "balance": 0,
-          "decimals": 8,
-          "name": "LOCALTOKEN",
-          "symbol": "LWTF",
-          "totalSupply": 2270000,
+          decimals: 8,
+          name: "LOCALTOKEN",
+          symbol: "LWTF",
+          totalSupply: 2270000
         },
         {
-          "balance": 0,
-          "decimals": 8,
-          "name": "NEX Template",
-          "symbol": "NXT",
-          "totalSupply": 2508560,
+          decimals: 8,
+          name: "NEX Template",
+          symbol: "NXT",
+          totalSupply: 2508560
         }
       ])
     );
@@ -141,11 +142,12 @@ describe("getTokens", () => {
 
   test("with balance", async () => {
     const info = await getTokens(
-      TESTNET_URL, [
+      TESTNET_URL,
+      [
         CONST.CONTRACTS.TEST_RPX,
         // CONST.CONTRACTS.TEST_RHTT4,
         CONST.CONTRACTS.TEST_LWTF,
-        CONST.CONTRACTS.TEST_NXT,
+        CONST.CONTRACTS.TEST_NXT
         // CONST.CONTRACTS.TEST_RPX,
         // CONST.CONTRACTS.TEST_RHTT4,
         // CONST.CONTRACTS.TEST_LWTF,
@@ -154,28 +156,28 @@ describe("getTokens", () => {
       "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW"
     );
 
-    expect(Object.keys(info).map(key=>info[key])).toEqual(
+    expect(Object.keys(info).map(key => info[key])).toEqual(
       expect.arrayContaining([
         {
-          "balance": 1032.011,
-          "decimals": 8,
-          "name": "Red Pulse Token 3.1.4",
-          "symbol": "RPX",
-          "totalSupply": 43467000,
+          balance: "1032.011",
+          decimals: 8,
+          name: "Red Pulse Token 3.1.4",
+          symbol: "RPX",
+          totalSupply: 43467000
         },
         {
-          "balance": 0.00015721,
-          "decimals": 8,
-          "name": "LOCALTOKEN",
-          "symbol": "LWTF",
-          "totalSupply": 2270000,
+          balance: "0.00015718",
+          decimals: 8,
+          name: "LOCALTOKEN",
+          symbol: "LWTF",
+          totalSupply: 2270000
         },
         {
-          "balance": 1861,
-          "decimals": 8,
-          "name": "NEX Template",
-          "symbol": "NXT",
-          "totalSupply": 2508560,
+          balance: "1861",
+          decimals: 8,
+          name: "NEX Template",
+          symbol: "NXT",
+          totalSupply: 2508560
         }
       ])
     );

--- a/packages/neon-nep5/src/main.ts
+++ b/packages/neon-nep5/src/main.ts
@@ -143,7 +143,7 @@ export async function getToken(
 }
 
 /**
- * Retrieves the complete information about all (or a list of) tokens.
+ * Retrieves the complete information about a list of tokens.
  * @param url RPC Node url to query.
  * @param scriptHashArray Array of NEP5 contract scriptHashes.
  * @param address Optional address to query the balance for. If provided, the returned object will include the balance property.
@@ -153,26 +153,26 @@ export async function getTokens(
   scriptHashArray: string[],
   address?: string
 ): Promise<TokenInfo[]> {
-  const sb = new sc.ScriptBuilder();
-  scriptHashArray.forEach(scriptHash => {
-    if (address) {
-      const addrScriptHash = u.reverseHex(
-        wallet.getScriptHashFromAddress(address)
-      );
-      sb.emitAppCall(scriptHash, "name")
-        .emitAppCall(scriptHash, "symbol")
-        .emitAppCall(scriptHash, "decimals")
-        .emitAppCall(scriptHash, "totalSupply")
-        .emitAppCall(scriptHash, "balanceOf", [addrScriptHash]);
-    } else {
-      sb.emitAppCall(scriptHash, "name")
-        .emitAppCall(scriptHash, "symbol")
-        .emitAppCall(scriptHash, "decimals")
-        .emitAppCall(scriptHash, "totalSupply");
-    }
-  });
-
   try {
+    const sb = new sc.ScriptBuilder();
+    scriptHashArray.forEach(scriptHash => {
+      if (address) {
+        const addrScriptHash = u.reverseHex(
+          wallet.getScriptHashFromAddress(address)
+        );
+        sb.emitAppCall(scriptHash, "name")
+          .emitAppCall(scriptHash, "symbol")
+          .emitAppCall(scriptHash, "decimals")
+          .emitAppCall(scriptHash, "totalSupply")
+          .emitAppCall(scriptHash, "balanceOf", [addrScriptHash]);
+      } else {
+        sb.emitAppCall(scriptHash, "name")
+          .emitAppCall(scriptHash, "symbol")
+          .emitAppCall(scriptHash, "decimals")
+          .emitAppCall(scriptHash, "totalSupply");
+      }
+    });
+
     const res = await rpc.Query.invokeScript(sb.str).execute(url);
 
     const result: TokenInfo[] = [];
@@ -205,14 +205,16 @@ export async function getTokens(
         totalSupply,
         balance
       };
-      
-      if(!obj.balance) delete obj.balance;
+
+      if (!obj.balance) {
+        delete obj.balance;
+      }
 
       result.push(obj);
     }
     return result;
   } catch (err) {
-    log.error(`getToken failed with : ${err.message}`);
+    log.error(`getTokens failed with : ${err.message}`);
     throw err;
   }
 }

--- a/packages/neon-nep5/src/plugin.ts
+++ b/packages/neon-nep5/src/plugin.ts
@@ -1,4 +1,4 @@
 import * as abi from "./abi";
-import { getToken, getTokenBalance, getTokens } from "./main";
+import { getToken, getTokenBalance, getTokenBalances, getTokens } from "./main";
 
-export { abi, getToken, getTokens, getTokenBalance };
+export { abi, getToken, getTokens, getTokenBalance, getTokenBalances };

--- a/packages/neon-nep5/src/plugin.ts
+++ b/packages/neon-nep5/src/plugin.ts
@@ -1,4 +1,4 @@
 import * as abi from "./abi";
-import { getToken, getTokens, getTokenBalance } from "./main";
+import { getToken, getTokenBalance, getTokens } from "./main";
 
 export { abi, getToken, getTokens, getTokenBalance };

--- a/packages/neon-nep9/src/parse.ts
+++ b/packages/neon-nep9/src/parse.ts
@@ -51,11 +51,14 @@ function validatePath(path: string) {
 
 function reduceParamsToDict(params: string): { [k: string]: string } {
   const keyvalues = params ? params.split("&") : [];
-  return keyvalues.reduce((obj, keyValuePair) => {
-    const [key, val] = keyValuePair.split("=", 2);
-    obj[key] = val;
-    return obj;
-  }, {} as { [k: string]: string });
+  return keyvalues.reduce(
+    (obj, keyValuePair) => {
+      const [key, val] = keyValuePair.split("=", 2);
+      obj[key] = val;
+      return obj;
+    },
+    {} as { [k: string]: string }
+  );
 }
 
 export default parse;


### PR DESCRIPTION
You're able to get multiple token balances in 1 call, but not the ability to get multiple tokens (with more detailed info) in 1 call.
This PR resolves this issue, with the addition of `getTokens`