### PR TITLE
fix(neon-core): Fix ContractParam.Integer transformation

### DIFF
--- a/packages/neon-core/__tests__/sc/ScriptBuilder.ts
+++ b/packages/neon-core/__tests__/sc/ScriptBuilder.ts
@@ -1,3 +1,4 @@
+import ContractParam from "../../src/sc/ContractParam";
 import OpCode from "../../src/sc/OpCode";
 import ScriptBuilder from "../../src/sc/ScriptBuilder";
 
@@ -153,7 +154,12 @@ describe("emitPush", () => {
     ["500", 500, "02f401"],
     ["65536", 65536, "03000001"],
     ["true", true, "51"],
-    ["false", false, "00"]
+    ["false", false, "00"],
+    ["ContractParam(integer) 1", ContractParam.integer(1), (0x50 + 1).toString(16)],
+    ["ContractParam(integer) 256", ContractParam.integer(256), "020001"],
+    ["ContractParam(integer) 14256661", ContractParam.integer(14256661), "04158ad900"],
+    ["ContractParam(integer) -1", ContractParam.integer(-1), "4f"],
+    ["ContractParam(integer) -12345", ContractParam.integer(-12345), "02c7cf"]
   ])("%s", (msg: string, data: any, expected: string) => {
     const sb = new ScriptBuilder();
     sb.emitPush(data);

--- a/packages/neon-core/package.json
+++ b/packages/neon-core/package.json
@@ -45,6 +45,7 @@
     "bs58": "^4.0.1",
     "bs58check": "^2.1.2",
     "crypto-js": "^3.1.9-1",
+    "csbiginteger": "^2.12.0",
     "elliptic": "^6.4.0",
     "loglevel": "^1.6.1",
     "loglevel-plugin-prefix": "^0.8.4",

--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -1,3 +1,4 @@
+import { csBigInteger } from "csbiginteger";
 import {
   ensureHex,
   int2hex,
@@ -198,8 +199,8 @@ export class ScriptBuilder extends StringStream {
     if (num > 0 && num <= 16) {
       return this.emit(OpCode.PUSH1 - 1 + num);
     }
-    const hexstring = int2hex(num);
-    return this.emitPush(reverseHex(hexstring));
+    const bn = new csBigInteger(num);
+    return this.emitPush(bn.toHexString());
   }
 
   /**

--- a/packages/neon-core/typings/csbiginteger.d.ts
+++ b/packages/neon-core/typings/csbiginteger.d.ts
@@ -1,0 +1,8 @@
+declare module "csbiginteger" {
+  export class csBigInteger {
+    constructor(n: number, base?: number);
+    toString: (base?: number) => string;
+    parse: (s: string, base?: number) => csBigInteger;
+    toHexString: () => string;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2060,6 +2060,13 @@ crypto-js@^3.1.9-1:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
   integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
 
+csbiginteger@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/csbiginteger/-/csbiginteger-2.12.0.tgz#4ef0118e98a26a339686a0b40bd75ae242a5e5d3"
+  integrity sha512-5RPMY3Y1HZOSPx7pvEu21i9I68AuwYZKNdWqFBVCmdoa6eeUWx21c10fUEp5PmquTsIfqxGBHHa1rjv3Ni4R+A==
+  dependencies:
+    webpack "^4.20.2"
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
@@ -6961,7 +6968,7 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.16.3, webpack@^4.19.0:
+webpack@^4.16.3, webpack@^4.19.0, webpack@^4.20.2:
   version "4.25.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.25.1.tgz#4f459fbaea0f93440dc86c89f771bb3a837cfb6d"
   integrity sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==


### PR DESCRIPTION
C# BigInteger uses two's complement which wasn't reflected by the `parseInt` of javascript. This solution brings in Igor's `csbiginteger` package which is a javascript implementation of the c# BigInteger class. With this, we should be able to convert correctly. It's a good place to start testing the package out too.

Fix #345 