### PR TITLE
fix(typing): Fix typing for buildMultiSig

### DIFF
--- a/src/transactions/typings/components.d.ts
+++ b/src/transactions/typings/components.d.ts
@@ -1,4 +1,5 @@
 import { Fixed8, StringStream } from '../../utils';
+import { Account } from "../../wallet";
 
 export interface TransactionAttribute {
   data: string


### PR DESCRIPTION
Possible fix for #350. Im unable to reproduce properly but this is something I noticed that could fix it. I found that the old Account was actually referencing the Account interface from node.