### PR TITLE
Fix variable name

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,15 +46,15 @@ const query = new rpc.Query();
 As neon-js package uses ES6 module conventions, `require` will need to specify which module do they want exactly:
 
 ```js
-var neon-js = require('@cityofzion/neon-js')
+var neonJs = require('@cityofzion/neon-js')
 
 // Semantic Style by using default import
-var Neon = neon-js.default
+var Neon = neonJs.default
 const query = Neon.create.query()
 
 // Named imports are available too
-var wallet = neon-js.wallet
-var tx = neon-js.tx
+var wallet = neonJs.wallet
+var tx = neonJs.tx
 
 const account = new wallet.Account(privateKey)
 ```


### PR DESCRIPTION
'neon-js' is illegal as a variable name in JavaScript because dashes ('-') are not allowed in variable names. This results in an error when executing the script.
This PR fixes the variable name by replacing the dash with an underscore.