### PR TITLE
Updating dependency to csbiginteger 3.0.0

### DIFF
--- a/packages/neon-core/package.json
+++ b/packages/neon-core/package.json
@@ -46,7 +46,7 @@
     "bs58": "^4.0.1",
     "bs58check": "^2.1.2",
     "crypto-js": "^3.1.9-1",
-    "csbiginteger": "^2.12.0",
+    "csbiginteger": "^3.0.0",
     "elliptic": "^6.4.0",
     "loglevel": "^1.6.1",
     "loglevel-plugin-prefix": "^0.8.4",


### PR DESCRIPTION
Snowy, now project was moved to NeoResearch page for future and more stable maintainance. I'm using "bn.js" library to handle internals now, so it's very stable. The idea is to manage it to be compatible with C# representation, but at least now the code is much shorter and easier to maintain. I believe this major can last a long time now, since it's very tested on many cases.