### PR TITLE
refactor(webpack): Fix exports for webpack based packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "tslint packages/**/src/**/*.ts packages/**/__tests__/**/*.ts packages/**/__integration__/**/*.ts",
     "precommit": "yarn lint && yarn pretty",
     "prestart": "yarn build && yarn dist",
-    "prepublishOnly": "yarn clean && yarn build && yarn dist:prod",
+    "prepublishOnly": "lerna run prepublishOnly",
     "pretty": "prettier --write --loglevel=warn \"**/{src,__{tests,integration}__}/**/*.ts\"",
     "release": "yarn prepublishOnly && lerna publish",
     "start": "jest --watch",
@@ -28,7 +28,11 @@
     "ts-jest": "23.10.5",
     "tslint": "5.12.0",
     "tslint-config-prettier": "1.17.0",
-    "typescript": "3.2.2"
+    "typescript": "3.2.2",
+    "clean-webpack-plugin": "1.0.0",
+    "ts-loader": "5.3.2",
+    "webpack": "4.28.3",
+    "webpack-cli": "3.1.2"
   },
   "private": true,
   "workspaces": [

--- a/packages/neon-api/__integration__/funcs/main.ts
+++ b/packages/neon-api/__integration__/funcs/main.ts
@@ -1,5 +1,4 @@
 import * as neonCore from "@cityofzion/neon-core";
-import { RPCClient } from "@cityofzion/neon-core/lib/rpc";
 import apiPlugin from "../../src/index";
 
 const neonJs = apiPlugin(neonCore);
@@ -183,7 +182,7 @@ describe("setupVote", () => {
     "Vote for some candidates",
     async () => {
       const rpcUrl = await provider.getRPCEndpoint();
-      const client = new RPCClient(rpcUrl);
+      const client = new neonCore.rpc.RPCClient(rpcUrl);
       const validators = await client.getValidators();
       const chosenOnes = validators
         .filter(v => v.active)

--- a/packages/neon-api/__tests__/func/fill.ts
+++ b/packages/neon-api/__tests__/func/fill.ts
@@ -1,5 +1,5 @@
+import { wallet } from "@cityofzion/neon-core";
 import { mocked } from "ts-jest/utils";
-import { wallet } from "../../../neon-js/src";
 import { SendAssetConfig } from "../../lib/funcs/types";
 import * as fill from "../../src/funcs/fill";
 import { signWithPrivateKey as _signWithPrivateKey } from "../../src/funcs/sign";

--- a/packages/neon-api/package.json
+++ b/packages/neon-api/package.json
@@ -17,13 +17,14 @@
   ],
   "author": "Yak Jun Xiang <snowypowers@gmail.com> (https://github.com/snowypowers)",
   "license": "MIT",
-  "main": "lib/index.js",
-  "module": "src/index.js",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc -b",
+    "dist:prod":"tsc -m commonjs --outDir dist",
     "clean": "rimraf ./lib ./dist",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "yarn clean && yarn build && yarn dist:prod",
     "lint": "tslint src/**/*.ts __tests__/**/*.ts __integration__/**/*.ts",
     "pretty": "prettier --write --loglevel=warn \"./{src,__{tests,integration}__}/**/*.ts\"",
     "start": "jest --watch",
@@ -39,6 +40,7 @@
     "@cityofzion/neon-core": "^4.0.0"
   },
   "files": [
+    "dist/",
     "lib/"
   ]
 }

--- a/packages/neon-core/package.json
+++ b/packages/neon-core/package.json
@@ -22,7 +22,7 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "clean": "rimraf ./lib ./dist",
     "dist": "cross-env NODE_ENV=development webpack --mode development",
     "dist:prod": "cross-env NODE_ENV=production webpack --mode production",
@@ -36,11 +36,11 @@
   },
   "dependencies": {
     "@types/bn.js": "4.11.3",
-    "@types/bs58": "3.0.30",
+    "@types/bs58": "4.0.0",
     "@types/crypto-js": "3.1.43",
-    "@types/elliptic": "6.4.0",
+    "@types/elliptic": "6.4.1",
     "@types/loglevel": "1.5.3",
-    "@types/node": "10.12.17",
+    "@types/node": "10.12.18",
     "axios": "0.18.0",
     "bignumber.js": "7.2.1",
     "bn.js": "4.11.8",

--- a/packages/neon-core/test.html
+++ b/packages/neon-core/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Neon Browser Test</title>
+</head>
+
+<body>
+  <section class="section">
+    <div class="container">
+      <h1 class="title">
+        Open Console
+      </h1>
+    </div>
+  </section>
+  <script src="./dist/browser.js"></script>
+</body>
+
+</html>

--- a/packages/neon-core/webpack.config.js
+++ b/packages/neon-core/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = function() {
     output: {
       path: __dirname,
       filename: "./dist/index.js",
-      libraryTarget: "umd"
+      libraryTarget: "commonjs2"
     }
   });
   nodeOutput.optimization = Object.assign({}, nodeOutput.optimization, {
@@ -19,7 +19,7 @@ module.exports = function() {
       path: __dirname,
       filename: "./dist/browser.js",
       libraryTarget: "umd",
-      library: "Neon" // This is the var name in browser
+      library: "NeonCore" // This is the var name in browser
     }
   });
 

--- a/packages/neon-domain/package.json
+++ b/packages/neon-domain/package.json
@@ -25,13 +25,14 @@
     }
   ],
   "license": "MIT",
-  "main": "lib/index.js",
-  "module": "src/index.js",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc -b",
+    "dist:prod":"tsc -m commonjs --outDir dist",
     "clean": "rimraf ./lib ./dist",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "yarn clean && yarn build && yarn dist:prod",
     "lint": "tslint src/**/*.ts __tests__/**/*.ts __integration__/**/*.ts",
     "pretty": "prettier --write --loglevel=warn \"./{src,__{tests,integration}__}/**/*.ts\"",
     "start": "jest --watch",
@@ -43,6 +44,7 @@
     "@cityofzion/neon-core": "^4.0.0"
   },
   "files": [
+    "dist/",
     "lib/"
   ]
 }

--- a/packages/neon-js/package.json
+++ b/packages/neon-js/package.json
@@ -21,7 +21,7 @@
   "browser": "dist/browser.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "clean": "rimraf ./lib ./dist",
     "dist": "cross-env NODE_ENV=development webpack --mode development",
     "dist:prod": "cross-env NODE_ENV=production webpack --mode production",

--- a/packages/neon-js/webpack.config.js
+++ b/packages/neon-js/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = function() {
     output: {
       path: __dirname,
       filename: "./dist/index.js",
-      libraryTarget: "umd"
+      libraryTarget: "commonjs2"
     }
   });
   nodeOutput.optimization = Object.assign({}, nodeOutput.optimization, {

--- a/packages/neon-nep5/package.json
+++ b/packages/neon-nep5/package.json
@@ -17,13 +17,14 @@
   ],
   "author": "Yak Jun Xiang <snowypowers@gmail.com> (https://github.com/snowypowers)",
   "license": "MIT",
-  "main": "lib/index.js",
-  "module": "src/index.js",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc -b",
+    "dist:prod":"tsc -m commonjs --outDir dist",
     "clean": "rimraf ./lib ./dist",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "yarn clean && yarn build && yarn dist:prod",
     "lint": "tslint src/**/*.ts __tests__/**/*.ts __integration__/**/*.ts",
     "pretty": "prettier --write --loglevel=warn \"./{src,__{tests,integration}__}/**/*.ts\"",
     "start": "jest --watch",
@@ -38,6 +39,7 @@
     "@cityofzion/neon-core": "^4.0.0"
   },
   "files": [
+    "dist/",
     "lib/"
   ]
 }

--- a/packages/neon-nep9/package.json
+++ b/packages/neon-nep9/package.json
@@ -17,13 +17,14 @@
   ],
   "author": "Yak Jun Xiang <snowypowers@gmail.com> (https://github.com/snowypowers)",
   "license": "MIT",
-  "main": "lib/index.js",
-  "module": "src/index.js",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc -b",
+    "dist:prod":"tsc -m commonjs --outDir dist",
     "clean": "rimraf ./lib ./dist",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "yarn clean && yarn build && yarn dist:prod",
     "lint": "tslint src/**/*.ts __tests__/**/*.ts __integration__/**/*.ts",
     "pretty": "prettier --write --loglevel=warn \"./{src,__{tests,integration}__}/**/*.ts\"",
     "start": "jest --watch",
@@ -37,6 +38,7 @@
     "@cityofzion/neon-core": "^4.0.0"
   },
   "files": [
+    "dist/",
     "lib/"
   ]
 }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "module": "commonjs",
+    "module": "ES6",
+    "moduleResolution": "node",
     "composite": true,
     "declaration": true,
     "declarationMap": true,

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "module": "commonjs",
+    "module": "ES6",
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -21,7 +21,8 @@ module.exports = function(rootDir) {
           options: {
             compilerOptions: {
               declarationDir: path.resolve(rootDir, "dist"),
-              sourceMap: env === "development"
+              sourceMap: env === "development",
+              module: "commonjs"
             }
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -603,10 +603,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/bs58@3.0.30":
-  version "3.0.30"
-  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-3.0.30.tgz#916ba10992465e56f81afc735e7935fd749893e1"
-  integrity sha1-kWuhCZJGXlb4GvxzXnk1/XSYk+E=
+"@types/bs58@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-4.0.0.tgz#baec75cb007b419ede3ec6b3410d2c8f14c92fc5"
+  integrity sha512-gYX+MHD4G/R+YGYwdhG5gbJj4LsEQGr3Vg6gVDAbe7xC5Bn8dNNG2Lpo6uDX/rT5dE7VBj0rGEFuV8L0AEx4Rg==
   dependencies:
     "@types/base-x" "*"
 
@@ -615,10 +615,10 @@
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-3.1.43.tgz#b859347d6289ba13e347c335a4c9efa63337a748"
   integrity sha512-EHe/YKctU3IYNBsDmSOPX/7jLHPRlx8WaiDKSY9JCTnJ8XJeM4c0ZJvx+9Gxmr2s2ihI92R+3U/gNL1sq5oRuQ==
 
-"@types/elliptic@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.0.tgz#eed3bd9dc83184f0f08987c05eb82e58ea7fb5de"
-  integrity sha512-wf/Iecb9HDfbfnZfrk49FdRFlEb+2ZRFDVjmiRZFutQVeUMnEpDelvNCNeck85FD5GkxsBc8kJR41/wgZWfF6g==
+"@types/elliptic@6.4.1":
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.1.tgz#7f922c6caa7f6f1022a33e3c39276c71e20348b1"
+  integrity sha512-RooUsMo8g+m4SfU8m4AOf88EvcIikO7PVIlE2ujmK4R0KO0bRSGuYPR5dLvVy+e9a24dFXnPYYX6zwIFYTdPDg==
   dependencies:
     "@types/bn.js" "*"
 
@@ -632,10 +632,15 @@
   resolved "https://registry.yarnpkg.com/@types/loglevel/-/loglevel-1.5.3.tgz#adfce55383edc5998a2170ad581b3e23d6adb5b8"
   integrity sha512-TzzIZihV+y9kxSg5xJMkyIkaoGkXi50isZTtGHObNHRqAAwjGNjSCNPI7AUAv0tZUKTq9f2cdkCUd/2JVZUTrA==
 
-"@types/node@*", "@types/node@10.12.17":
+"@types/node@*":
   version "10.12.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.17.tgz#7040565b2c93d59325a68fa69073e754a7eda93a"
   integrity sha512-umSCRkjWH70uNzFiOof5yxCqrMXIBJ9UJJUzbEsmtWt8apURQh06pylGMqnhdjHGJSeoBrhzk+mibu6NgL1oBA==
+
+"@types/node@10.12.18":
+  version "10.12.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
+  integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
@@ -6838,6 +6843,17 @@ ts-loader@5.3.1:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
+ts-loader@5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.3.2.tgz#31d10be522bedfac8ee4c20c735e05a9bd772faf"
+  integrity sha512-TPeXFkdPjOrVEawY4xUgRnzlHEmKQF1DclJghPGq67jKnroVvs6mEGHWYtbUczgeWTvTaqUjSSaMmp1k5do4vw==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^3.1.4"
+    semver "^5.0.1"
+
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -7131,6 +7147,36 @@ webpack@4.27.1:
   version "4.27.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.27.1.tgz#5f2e2db446d2266376fa15d7d2277a1a9c2e12bb"
   integrity sha512-WArHiLvHrlfyRM8i7f+2SFbr/XbQ0bXqTkPF8JpHOzub5482Y3wx7rEO8stuLGOKOgZJcqcisLhD7LrM/+fVMw==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-module-context" "1.7.11"
+    "@webassemblyjs/wasm-edit" "1.7.11"
+    "@webassemblyjs/wasm-parser" "1.7.11"
+    acorn "^5.6.2"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^0.4.4"
+    tapable "^1.1.0"
+    terser-webpack-plugin "^1.1.0"
+    watchpack "^1.5.0"
+    webpack-sources "^1.3.0"
+
+webpack@4.28.3:
+  version "4.28.3"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.28.3.tgz#8acef6e77fad8a01bfd0c2b25aa3636d46511874"
+  integrity sha512-vLZN9k5I7Nr/XB1IDG9GbZB4yQd1sPuvufMFgJkx0b31fi2LD97KQIjwjxE7xytdruAYfu5S0FLBLjdxmwGJCg==
   dependencies:
     "@webassemblyjs/ast" "1.7.11"
     "@webassemblyjs/helper-module-context" "1.7.11"


### PR DESCRIPTION
- Move webpack to top level dev dep
- Correct `module` exports for all packages
- tsc now defaults to es6/esm on build