### PR TITLE
fix(api): Fix es6 getter error

### DIFF
--- a/packages/neon-api/src/index.ts
+++ b/packages/neon-api/src/index.ts
@@ -5,7 +5,7 @@ import { default as apiSettings } from "./settings";
 function bundle<T extends typeof _Neon>(
   neonCore: T
 ): T & { api: typeof plugin } {
-  neonCore.settings = Object.assign(neonCore.settings, apiSettings);
+  Object.assign(neonCore.settings, apiSettings);
   return { ...(neonCore as any), api: plugin };
 }
 


### PR DESCRIPTION
Fix the mistake where we were trying to override an import. ES6 imports are immutable.