### PR TITLE
chore(git): ignore tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ build
 # Package stuff
 packages/**/lib
 packages/**/dist
+
+# Typescript
+*.tsbuildinfo


### PR DESCRIPTION
New file generated by tsc upgrade. Used for faster builds and therefore can be ignored.