### PR TITLE
Update readme instructions to ensure local tests pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ yarn build
 ```sh
 yarn lint
 yarn build
+yarn dist
 yarn test:unit
 yarn test:integration
 ```


### PR DESCRIPTION
The added instruction is necessary to get tests to pass locally.

Please see https://github.com/CityOfZion/neon-js/pull/403 for details of why.