### PR TITLE
Chore: Make Neoscan getRPCEndpoint Respect httpsOnly Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ yarn build
 ```sh
 yarn lint
 yarn build
+yarn dist
 yarn test:unit
 yarn test:integration
 ```

--- a/packages/neon-api/__integration__/provider/neoscan-testnet.ts
+++ b/packages/neon-api/__integration__/provider/neoscan-testnet.ts
@@ -1,0 +1,87 @@
+import * as neonCore from "@cityofzion/neon-core";
+
+import apiPlugin from "../../src/index";
+
+const neonJs = apiPlugin(neonCore);
+
+import * as util from "util"
+
+const { rpc, wallet, u } = neonJs;
+
+const net = "TestNet";
+const addr = "APJnYRic9fYo1bLAdrqDbwrsnqoUD92dWo";
+neonJs.settings.networks[net] = new rpc.Network({
+  Name: "TestNet",
+  ExtraConfiguration: {
+    neoscan: "https://neoscan-testnet.io/api/test_net"
+  }
+});
+
+const provider = new neonJs.api.neoscan.instance("TestNet");
+const invalidAddr = "address";
+
+describe(`Valid Address: ${provider.name}`, () => {
+  test("getBalance", async () => {
+    const result = await provider.getBalance(addr);
+    expect(result).toBeInstanceOf(wallet.Balance);
+  });
+
+  test("getClaims", async () => {
+    const result = await provider.getClaims(addr);
+    expect(result).toBeInstanceOf(wallet.Claims);
+  });
+
+  test("getMaxClaimAmount", async () => {
+    const result = await provider.getMaxClaimAmount(addr);
+    expect(result).toBeInstanceOf(u.Fixed8);
+  });
+
+  test("getRPCEndpoint", async () => {
+    const result = await provider.getRPCEndpoint();
+    expect(typeof result === "string").toBeTruthy();
+  });
+
+  test("httpsOnly getRPCEndpoint", async () => {
+    const httpsOnly = neonJs.settings.httpsOnly = true;
+    const result = await provider.getRPCEndpoint();
+    expect(httpsOnly).toBe(true);
+    expect(typeof result === "string").toBeTruthy();
+    expect(result).toEqual(expect.stringContaining("https://"));
+  });
+
+  test("getTransactionHistory", async () => {
+    const result = await provider.getTransactionHistory(addr);
+    expect(result).toBeInstanceOf(Array);
+  });
+
+  test("getHeight", async () => {
+    const result = await provider.getHeight();
+    expect(typeof result === "number").toBeTruthy();
+  });
+});
+
+describe(`Invalid Address: ${provider.name}`, () => {
+  test("getBalance", async () => {
+    const result = await provider.getBalance(invalidAddr);
+    expect(result).toBeInstanceOf(wallet.Balance);
+    expect(result.assetSymbols).toEqual([]);
+    expect(result.tokenSymbols).toEqual([]);
+  });
+
+  test("getClaims", async () => {
+    const result = await provider.getClaims(invalidAddr);
+    expect(result).toBeInstanceOf(wallet.Claims);
+    expect(result.claims).toEqual([]);
+  });
+
+  test("getMaxClaimAmount", async () => {
+    const result = await provider.getMaxClaimAmount(invalidAddr);
+    expect(result).toBeInstanceOf(u.Fixed8);
+    expect(result).toEqual(new u.Fixed8(0));
+  });
+
+  test("getTransactionHistory", async () => {
+    const result = await provider.getTransactionHistory(invalidAddr);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/neon-api/__integration__/provider/neoscan-testnet.ts
+++ b/packages/neon-api/__integration__/provider/neoscan-testnet.ts
@@ -40,9 +40,8 @@ describe(`Valid Address: ${provider.name}`, () => {
   });
 
   test("httpsOnly getRPCEndpoint", async () => {
-    const httpsOnly = neonJs.settings.httpsOnly = true;
+    provider.set({httpsOnly: true})
     const result = await provider.getRPCEndpoint();
-    expect(httpsOnly).toBe(true);
     expect(typeof result === "string").toBeTruthy();
     expect(result).toEqual(expect.stringContaining("https://"));
   });

--- a/packages/neon-api/__integration__/provider/neoscan-testnet.ts
+++ b/packages/neon-api/__integration__/provider/neoscan-testnet.ts
@@ -40,7 +40,9 @@ describe(`Valid Address: ${provider.name}`, () => {
   });
 
   test("httpsOnly getRPCEndpoint", async () => {
-    provider.set({httpsOnly: true})
+    expect(neonCore.settings.httpsOnly).toBe(false);
+    neonCore.settings.httpsOnly = true
+    expect(neonCore.settings.httpsOnly).toBe(true);
     const result = await provider.getRPCEndpoint();
     expect(typeof result === "string").toBeTruthy();
     expect(result).toEqual(expect.stringContaining("https://"));

--- a/packages/neon-api/__integration__/provider/neoscan-testnet.ts
+++ b/packages/neon-api/__integration__/provider/neoscan-testnet.ts
@@ -40,9 +40,9 @@ describe(`Valid Address: ${provider.name}`, () => {
   });
 
   test("httpsOnly getRPCEndpoint", async () => {
-    expect(neonCore.settings.httpsOnly).toBe(false);
-    neonCore.settings.httpsOnly = true
-    expect(neonCore.settings.httpsOnly).toBe(true);
+    expect(neonJs.settings.httpsOnly).toBe(false);
+    neonJs.settings.httpsOnly = true
+    expect(neonJs.settings.httpsOnly).toBe(true);
     const result = await provider.getRPCEndpoint();
     expect(typeof result === "string").toBeTruthy();
     expect(result).toEqual(expect.stringContaining("https://"));

--- a/packages/neon-api/__integration__/provider/neoscan-testnet.ts
+++ b/packages/neon-api/__integration__/provider/neoscan-testnet.ts
@@ -4,8 +4,6 @@ import apiPlugin from "../../src/index";
 
 const neonJs = apiPlugin(neonCore);
 
-import * as util from "util"
-
 const { rpc, wallet, u } = neonJs;
 
 const net = "TestNet";

--- a/packages/neon-api/__integration__/provider/neoscan.ts
+++ b/packages/neon-api/__integration__/provider/neoscan.ts
@@ -37,6 +37,14 @@ describe(`Valid Address: ${provider.name}`, () => {
     expect(typeof result === "string").toBeTruthy();
   });
 
+  test("httpsOnly getRPCEndpoint", async () => {
+    const httpsOnly = neonJs.settings.httpsOnly = true;
+    const result = await provider.getRPCEndpoint();
+    expect(httpsOnly).toBe(true);
+    expect(typeof result === "string").toBeTruthy();
+    expect(result).toEqual(expect.stringContaining("https://"));
+  });
+
   test("getTransactionHistory", async () => {
     const result = await provider.getTransactionHistory(addr);
     expect(result).toBeInstanceOf(Array);
@@ -74,4 +82,3 @@ describe(`Valid Address: ${provider.name}`, () => {
       expect(result).toEqual([]);
     });
   });
-

--- a/packages/neon-api/__integration__/provider/neoscan.ts
+++ b/packages/neon-api/__integration__/provider/neoscan.ts
@@ -38,7 +38,9 @@ describe(`Valid Address: ${provider.name}`, () => {
   });
 
   test("httpsOnly getRPCEndpoint", async () => {
-    provider.set({httpsOnly: true})
+    expect(neonCore.settings.httpsOnly).toBe(false);
+    neonCore.settings.httpsOnly = true
+    expect(neonCore.settings.httpsOnly).toBe(true);
     const result = await provider.getRPCEndpoint();
     expect(typeof result === "string").toBeTruthy();
     expect(result).toEqual(expect.stringContaining("https://"));

--- a/packages/neon-api/__integration__/provider/neoscan.ts
+++ b/packages/neon-api/__integration__/provider/neoscan.ts
@@ -38,9 +38,9 @@ describe(`Valid Address: ${provider.name}`, () => {
   });
 
   test("httpsOnly getRPCEndpoint", async () => {
-    expect(neonCore.settings.httpsOnly).toBe(false);
-    neonCore.settings.httpsOnly = true
-    expect(neonCore.settings.httpsOnly).toBe(true);
+    expect(neonJs.settings.httpsOnly).toBe(false);
+    neonJs.settings.httpsOnly = true
+    expect(neonJs.settings.httpsOnly).toBe(true);
     const result = await provider.getRPCEndpoint();
     expect(typeof result === "string").toBeTruthy();
     expect(result).toEqual(expect.stringContaining("https://"));

--- a/packages/neon-api/__integration__/provider/neoscan.ts
+++ b/packages/neon-api/__integration__/provider/neoscan.ts
@@ -38,9 +38,8 @@ describe(`Valid Address: ${provider.name}`, () => {
   });
 
   test("httpsOnly getRPCEndpoint", async () => {
-    const httpsOnly = neonJs.settings.httpsOnly = true;
+    provider.set({httpsOnly: true})
     const result = await provider.getRPCEndpoint();
-    expect(httpsOnly).toBe(true);
     expect(typeof result === "string").toBeTruthy();
     expect(result).toEqual(expect.stringContaining("https://"));
   });

--- a/packages/neon-api/__tests__/provider/neoscan/core.ts
+++ b/packages/neon-api/__tests__/provider/neoscan/core.ts
@@ -62,8 +62,8 @@ describe("getRPCEndpoint", () => {
     common.getBestUrl.mockImplementationOnce(() =>
       Promise.resolve("https://url2")
     );
-    set({ httpsOnly: true });
-
+    settings.httpsOnly = true;
+    
     const result = await neoscan.getRPCEndpoint(testUrl);
 
     expect(getCall).toHaveBeenCalledTimes(1);

--- a/packages/neon-api/__tests__/provider/neoscan/core.ts
+++ b/packages/neon-api/__tests__/provider/neoscan/core.ts
@@ -2,7 +2,7 @@ import { rpc, settings, u, wallet } from "@cityofzion/neon-core";
 import axios from "axios";
 import * as common from "../../../src/provider/common";
 import * as neoscan from "../../../src/provider/neoscan/core";
-import { set } from "../../../src/settings";
+import { default as internal } from "../../../src/settings";
 jest.mock("axios");
 jest.mock("../../../src/provider/common");
 
@@ -62,8 +62,8 @@ describe("getRPCEndpoint", () => {
     common.getBestUrl.mockImplementationOnce(() =>
       Promise.resolve("https://url2")
     );
-    settings.httpsOnly = true;
-    
+    internal.httpsOnly = true;
+
     const result = await neoscan.getRPCEndpoint(testUrl);
 
     expect(getCall).toHaveBeenCalledTimes(1);

--- a/packages/neon-api/src/index.ts
+++ b/packages/neon-api/src/index.ts
@@ -2,10 +2,22 @@ import * as _Neon from "@cityofzion/neon-core";
 import * as plugin from "./plugin";
 import { default as apiSettings } from "./settings";
 
+function assignSettings(baseSettings: typeof _Neon.settings, newSettings: {[k:string] : any}): void {
+  for(var key in newSettings) {
+    Object.defineProperty(baseSettings, key, {
+      get() {
+        return newSettings[key]
+      },
+      set(val) {
+        newSettings[key] = val
+      }
+    })
+  }
+}
 function bundle<T extends typeof _Neon>(
   neonCore: T
 ): T & { api: typeof plugin } {
-  Object.assign(neonCore.settings, apiSettings);
+  assignSettings(neonCore.settings, apiSettings);
   return { ...(neonCore as any), api: plugin };
 }
 

--- a/packages/neon-api/src/index.ts
+++ b/packages/neon-api/src/index.ts
@@ -2,16 +2,21 @@ import * as _Neon from "@cityofzion/neon-core";
 import * as plugin from "./plugin";
 import { default as apiSettings } from "./settings";
 
-function assignSettings(baseSettings: typeof _Neon.settings, newSettings: {[k:string] : any}): void {
-  for(var key in newSettings) {
-    Object.defineProperty(baseSettings, key, {
-      get() {
-        return newSettings[key]
-      },
-      set(val) {
-        newSettings[key] = val
-      }
-    })
+function assignSettings(
+  baseSettings: typeof _Neon.settings,
+  newSettings: { [k: string]: any }
+): void {
+  for (var key in newSettings) {
+    if (!(key in baseSettings)) {
+      Object.defineProperty(baseSettings, key, {
+        get() {
+          return newSettings[key];
+        },
+        set(val) {
+          newSettings[key] = val;
+        }
+      });
+    }
   }
 }
 function bundle<T extends typeof _Neon>(

--- a/packages/neon-api/src/provider/neoscan/class.ts
+++ b/packages/neon-api/src/provider/neoscan/class.ts
@@ -1,6 +1,5 @@
 import { logging, rpc, settings, u, wallet } from "@cityofzion/neon-core";
 import { PastTransaction, Provider, RpcNode } from "../common";
-import * as internal from "../../settings";
 import {
   getBalance,
   getClaims,
@@ -16,10 +15,6 @@ export class Neoscan implements Provider {
 
   public get name() {
     return `Neoscan[${this.url}]`;
-  }
-
-  public set(settings: object) {
-    internal.set(settings)
   }
 
   private rpc: rpc.RPCClient | null = null;

--- a/packages/neon-api/src/provider/neoscan/class.ts
+++ b/packages/neon-api/src/provider/neoscan/class.ts
@@ -1,5 +1,5 @@
 import { logging, rpc, settings, u, wallet } from "@cityofzion/neon-core";
-import { PastTransaction, Provider, RpcNode } from "../common";
+import { PastTransaction, Provider } from "../common";
 import {
   getBalance,
   getClaims,

--- a/packages/neon-api/src/provider/neoscan/class.ts
+++ b/packages/neon-api/src/provider/neoscan/class.ts
@@ -1,5 +1,6 @@
 import { logging, rpc, settings, u, wallet } from "@cityofzion/neon-core";
 import { PastTransaction, Provider, RpcNode } from "../common";
+import * as internal from "../../settings";
 import {
   getBalance,
   getClaims,
@@ -15,6 +16,10 @@ export class Neoscan implements Provider {
 
   public get name() {
     return `Neoscan[${this.url}]`;
+  }
+
+  public set(settings: object) {
+    internal.set(settings)
   }
 
   private rpc: rpc.RPCClient | null = null;

--- a/packages/neon-api/src/provider/neoscan/core.ts
+++ b/packages/neon-api/src/provider/neoscan/core.ts
@@ -1,6 +1,6 @@
 import { CONST, logging, u, wallet } from "@cityofzion/neon-core";
+import * as _Neon from "@cityofzion/neon-core";
 import axios from "axios";
-import { settings as internalSettings } from "../../settings";
 import {
   filterHttpsOnly,
   findGoodNodesFromHeight,
@@ -28,7 +28,7 @@ const log = logging.default("api");
 export async function getRPCEndpoint(url: string): Promise<string> {
   const response = await axios.get(url + "/v1/get_all_nodes");
   let nodes = response.data as RpcNode[];
-  if (internalSettings.httpsOnly) {
+  if (_Neon.settings.httpsOnly) {
     nodes = filterHttpsOnly(nodes);
   }
   const goodNodes = findGoodNodesFromHeight(nodes);

--- a/packages/neon-api/src/provider/neoscan/core.ts
+++ b/packages/neon-api/src/provider/neoscan/core.ts
@@ -1,5 +1,4 @@
-import { CONST, logging, u, wallet, settings } from "@cityofzion/neon-core";
-import * as _Neon from "@cityofzion/neon-core";
+import { CONST, logging, u, wallet } from "@cityofzion/neon-core";
 import * as internal from "../../settings"
 import axios from "axios";
 import {
@@ -29,8 +28,7 @@ const log = logging.default("api");
 export async function getRPCEndpoint(url: string): Promise<string> {
   const response = await axios.get(url + "/v1/get_all_nodes");
   let nodes = response.data as RpcNode[];
-
-  if (settings.httpsOnly) {
+  if (internal.settings.httpsOnly) {
     nodes = filterHttpsOnly(nodes);
   }
   const goodNodes = findGoodNodesFromHeight(nodes);

--- a/packages/neon-api/src/provider/neoscan/core.ts
+++ b/packages/neon-api/src/provider/neoscan/core.ts
@@ -1,5 +1,6 @@
 import { CONST, logging, u, wallet } from "@cityofzion/neon-core";
 import * as _Neon from "@cityofzion/neon-core";
+import * as internal from "../../settings"
 import axios from "axios";
 import {
   filterHttpsOnly,
@@ -20,6 +21,7 @@ import {
 } from "./responses";
 const log = logging.default("api");
 
+
 /**
  * Returns an appropriate RPC endpoint retrieved from a NeoScan endpoint.
  * @param url - URL of a neoscan service.
@@ -28,7 +30,7 @@ const log = logging.default("api");
 export async function getRPCEndpoint(url: string): Promise<string> {
   const response = await axios.get(url + "/v1/get_all_nodes");
   let nodes = response.data as RpcNode[];
-  if (_Neon.settings.httpsOnly) {
+  if (internal.settings.httpsOnly) {
     nodes = filterHttpsOnly(nodes);
   }
   const goodNodes = findGoodNodesFromHeight(nodes);

--- a/packages/neon-api/src/provider/neoscan/core.ts
+++ b/packages/neon-api/src/provider/neoscan/core.ts
@@ -1,4 +1,4 @@
-import { CONST, logging, u, wallet } from "@cityofzion/neon-core";
+import { CONST, logging, u, wallet, settings } from "@cityofzion/neon-core";
 import * as _Neon from "@cityofzion/neon-core";
 import * as internal from "../../settings"
 import axios from "axios";
@@ -21,7 +21,6 @@ import {
 } from "./responses";
 const log = logging.default("api");
 
-
 /**
  * Returns an appropriate RPC endpoint retrieved from a NeoScan endpoint.
  * @param url - URL of a neoscan service.
@@ -30,7 +29,8 @@ const log = logging.default("api");
 export async function getRPCEndpoint(url: string): Promise<string> {
   const response = await axios.get(url + "/v1/get_all_nodes");
   let nodes = response.data as RpcNode[];
-  if (internal.settings.httpsOnly) {
+
+  if (settings.httpsOnly) {
     nodes = filterHttpsOnly(nodes);
   }
   const goodNodes = findGoodNodesFromHeight(nodes);

--- a/packages/neon-core/src/settings.ts
+++ b/packages/neon-core/src/settings.ts
@@ -9,3 +9,5 @@ export let timeout = {
   ping: 2000,
   rpc: 30000
 };
+
+export let httpsOnly = false;

--- a/packages/neon-core/src/settings.ts
+++ b/packages/neon-core/src/settings.ts
@@ -10,4 +10,3 @@ export let timeout = {
   rpc: 30000
 };
 
-export let httpsOnly = false;

--- a/packages/neon-js/src/index.ts
+++ b/packages/neon-js/src/index.ts
@@ -5,7 +5,7 @@ import nepPlugin from "@cityofzion/neon-nep5";
 const neonWithApi = apiPlugin(neonCore);
 const neonJs = nepPlugin(neonWithApi);
 
-export const { api, nep5, settings, sc, rpc, wallet, CONST, u, tx } = neonJs;
+export const { api, nep5, settings, sc, rpc, wallet, CONST, u, tx, logging } = neonJs;
 import defaultNetworks from "./networks";
 const bootstrap: {
   [net: string]: Partial<neonCore.rpc.NetworkJSON>;


### PR DESCRIPTION
This is an integration test and a code change to address the following issue:

https://github.com/CityOfZion/neon-js/issues/401