### PR TITLE
docs(core): Initialize browser example docs with updated cdn

### DIFF
--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -1,0 +1,294 @@
+
+## JSFiddle Examples
+
+- [JSFiddle Examples](#jsfiddle-examples)
+	- [/Neo:v2.9.0/ API Reference](#neov290-api-reference)
+		- [Asset Identifiers](#asset-identifiers)
+		- [Get Account State](#get-account-state)
+			- [getaccountstate](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getaccountstate/demo)
+		- [Get Asset State](#get-asset-state)
+			- [getassetstate](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getassetstate/demo)
+		- [Get Balance (not implemented)](#get-balance-not-implemented)
+			- [getbalance](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getbalance/demo)
+		- [Get Best Block Hash](#get-best-block-hash)
+			- [getbestblockhash](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getbestblockhash/demo)
+		- [Get Block](#get-block)
+			- [getblock](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getblock/demo)
+		- [Get Block Count](#get-block-count)
+			- [getblockcount](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getblockcount/demo)
+		- [Get Block Header](#get-block-header)
+			- [getblockheader](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getblockheader/demo)
+		- [Get Block Sys Fee](#get-block-sys-fee)
+			- [getblocksysfee](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getblocksysfee/demo)
+		- [Get Connection Count](#get-connection-count)
+			- [getconnectioncount](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getconnectioncount/demo)
+		- [Get Contract State](#get-contract-state)
+			- [getcontractstate](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getcontractstate/demo)
+		- [Get Peers](#get-peers)
+			- [getpeers](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getpeers/demo)
+		- [Get Raw Memory Pool](#get-raw-memory-pool)
+			- [getrawmempool](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getrawmempool/demo)
+		- [Get Raw Transaction](#get-raw-transaction)
+			- [getrawtransaction](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getrawtransaction/demo)
+		- [Get Storage](#get-storage) 		
+			- [getstorage](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getstorage/demo)
+		- [Get Transaction Output](#get-transaction-output) 	
+			- [gettxout](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/gettxout/demo)
+		- [Get Validators](#get-validators)
+			- [getvalidators](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getvalidators/demo)
+		- [Get Version](#get-version)
+			- [getversion](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getassetstate/demo)
+		- [Invoke](#invoke)
+			- [doinvoke](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/doinvoke/demo)
+		- [Invoke Function](#invoke-function)
+			- [invokefunction](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/invokefunction/demo)
+		- [Invoke Script](#invoke-script)
+			- [invokescript](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/invokescript/demo)
+		- [Validate Address](#validate-address)
+			- [validateaddress](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/validateaddress/demo)
+	- [Other Examples](#other-examples)
+	- [Utilities](#utilities)
+
+### /Neo:v2.9.0/ API Reference
+This section provides links to JSFiddle examples of the neon-js implementation of the /Neo:v2.9.0/ API.
+
+See https://docs.neo.org/en-us/node/cli/2.9.0/api.html for more information.
+
+NOTES:
+  - In most cases, the '0x' prefix for hashes is optional.
+  - If an API endpoint isn't implemented by neon-js, a generic query is built and executed using neon-js RPC query.execute().
+
+### Asset Identifiers
+
+Neo: 0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b
+
+Gas: 0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7
+
+#### Get Account State
+
+getaccountstate(address)
+
+Get the account state for a wallet address.
+
+JSFiddle: [getaccountstate](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getaccountstate/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getaccountstate.html
+
+#### Get Asset State
+
+getassetstate(asset_id_hash)
+
+Queries the asset information, based on the specified asset number.
+
+JSFiddle: [getassetstate](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getassetstate/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getassetstate.html
+
+#### Get Balance (not implemented)
+
+getbalance(asset_id_hash)
+
+Returns the balance of the corresponding asset in the wallet according to the specified asset number.
+
+NOTE: getBalance is not currently implemented as an RPC call in neon-js as the Neo API requires a wallet to be open to access it. Balances for arbitrary addresses can be queried with getaccountstate. This reference is here to educate and provide reminder to future implementation using an API like Neoscan.
+
+JSFiddle: [getbalance](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getbalance/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getbalance.html
+
+#### Get Best Block Hash
+
+getbestblockhash()
+
+Get the hash of the highest (most recent) block.
+
+JSFiddle: [getBestBlockHash](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getbestblockhash/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getbestblockhash.html
+
+#### Get Block
+
+getblock(hash)
+
+getblock(index)
+
+Get block data by its hash or index.
+
+JSFiddle: [getBlock](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getblock/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getblock.html
+
+#### Get Block Count
+
+getblockcount()
+
+Get the number of blocks on a chain.
+
+JSFiddle: [getBlockCount](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getblockcount/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getblockcount.html
+
+#### Get Block Header
+
+getblockheader(hash)
+
+Returns the corresponding block header information according to the specified script hash.
+This method builds a custom request and executes it using the neon-js RPC query facility.
+
+JSFiddle: [getblockheader](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getblockheader/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getblockheader.html
+
+#### Get Block Sys Fee
+
+getblocksysfee(blockIndex)
+
+Returns the system fees of the block, based on the specified index.
+
+JSFiddle: [getblocksysfee](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getblocksysfee/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getblocksysfee.html
+
+#### Get Connection Count
+
+getconnectioncount()
+
+Gets the current number of connections for the node.
+
+JSFiddle: [getconnectioncount](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getconnectioncount/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getconnectioncount.html
+
+#### Get Contract State
+
+getcontractstate(hash)
+
+Queries contract information, according to the contract script hash.
+
+JSFiddle: [getcontractstate](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getcontractstate/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getcontractstate.html
+
+#### Get Peers
+
+getpeers()
+
+Gets a list of nodes that are currently connected/disconnected by this node.
+
+JSFiddle: [getpeers](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getpeers/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getpeers.html
+
+
+#### Get Raw Memory Pool
+
+getrawmempool()
+
+Gets a list of unconfirmed transactions in memory.
+
+JSFiddle: [getrawmempool](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getrawmempool/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getrawmempool.html
+
+#### Get Raw Transaction
+
+getrawtransaction(hash)
+
+Returns the corresponding transaction information based on the specified hash value.
+
+JSFiddle: [getrawtransaction](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getrawtransaction/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getrawmempool.html
+
+#### Get Storage
+
+getstorage(hash, key)
+
+Returns the stored value, according to the contract script hash and the stored key.
+
+JSFiddle: [getstorage](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getstorage/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getcontractstate.html
+
+#### Get Transaction Output
+
+gettxout(txid, index)
+
+Returns the corresponding unspent transaction output information (returned change), based on the specified hash and index. If the transaction output is already spent, the result value will be null.
+
+JSFiddle: [gettxout](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/gettxout/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/gettxout.html
+
+#### Get Validators
+
+getvalidators()
+
+Returns the current NEO consensus nodes information and voting status.
+
+JSFiddle: [getvalidators](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getvalidators/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getvalidators.html
+
+#### Get Version
+
+getversion()
+
+Gets version information of this node.
+
+JSFiddle: [getversion](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/getversion/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/getversion.html
+
+#### Invoke
+
+invoke(scriptHash, params)
+
+Invokes a smart contract at specified script hash with the given parameters.
+
+neon-js wraps invoke with a helper called doInvoke.
+
+JSFiddle: [invoke](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/doinvoke/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/invoke.html
+
+#### Invoke Function
+
+invokefunction(scriptHash, operation, params)
+
+Invokes a smart contract at specified script hash, passing in an operation and its params.
+
+JSFiddle: [invokefunction](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/invokefunction/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/invokefunction.html
+
+#### Invoke Script
+
+invokescript(script)
+
+Runs a script through the virtual machine and returns the results.
+
+JSFiddle: [invokescript](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/invokescript/demo)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/invokescript.html
+
+#### Validate Address
+
+validateaddress(address)
+
+Verify that the address is a correct NEO address.
+
+JSFiddle: [validateAddress](https://jsfiddle.net/gh/get/jquery/3.0/phetter/neon-js/tree/master/examples/browser/validateaddress/demo/)
+
+API Ref: https://docs.neo.org/en-us/node/cli/2.9.0/api/validateaddress.html
+
+
+
+### Other Examples
+
+[Restrict API to HTTPS Operation](https://jsfiddle.net/n1o5xjy4/)
+
+[Transfer Tokens](https://jsfiddle.net/t16y0ek3/)
+
+
+### Utilities

--- a/examples/browser/doinvoke/demo/demo.css
+++ b/examples/browser/doinvoke/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/doinvoke/demo/demo.details
+++ b/examples/browser/doinvoke/demo/demo.details
@@ -1,0 +1,2 @@
+name: doInvoke (browser version)
+description: Demonstrates the doInvoke function of the neon-js API

--- a/examples/browser/doinvoke/demo/demo.html
+++ b/examples/browser/doinvoke/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+Press button above to invoke the smart contract
+</div>
+<p>
+</p>

--- a/examples/browser/doinvoke/demo/demo.js
+++ b/examples/browser/doinvoke/demo/demo.js
@@ -1,0 +1,42 @@
+const sendingKey =
+  "9ab7e154840daca3a2efadaf0df93cd3a5b51768c632f5433f86909d9b994a69";
+const additionalInvocationGas = 0;
+const additionalIntents = [];
+
+function InvokeOperation()
+{
+
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+Neon.settings.httpsOnly = true;
+
+const account = new Neon.wallet.Account(sendingKey);
+
+const props = {
+  scriptHash: '9488220e8654d798f9b9cb9e74bd611ecc83fd0f',
+  operation: 'getBalance',
+  args: [Neon.u.reverseHex('def0c0fdcfe7838eff6ff104f9cdec2922297525'),
+         Neon.u.reverseHex('def0c0fdcfe7838eff6ff104f9cdec2922297524')]
+}
+
+const script = Neon.sc.createScript(props);
+const gas = additionalInvocationGas;
+const intent = additionalIntents;
+const config = {
+  api: provider,
+  account: account,
+  intents: intent,
+  script: script,
+  gas: gas
+};
+Neon.api.doInvoke(config)
+  .then(config => {
+    document.getElementById("result").innerHTML = "Relayed TX: " + config.response.txid;
+    console.log("\n\n--- Response ---");
+    console.log(config.response);
+  })
+  .catch(config => {
+    console.log(config);
+    document.getElementById("result").innerHTML = config;
+  });
+}

--- a/examples/browser/getaccountstate/demo/demo.css
+++ b/examples/browser/getaccountstate/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getaccountstate/demo/demo.details
+++ b/examples/browser/getaccountstate/demo/demo.details
@@ -1,0 +1,4 @@
+name: getaccountstate
+description: Get the account state for a wallet address
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getaccountstate/demo/demo.html
+++ b/examples/browser/getaccountstate/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getaccountstate/demo/demo.js
+++ b/examples/browser/getaccountstate/demo/demo.js
@@ -1,0 +1,44 @@
+// Wallet address to query
+const accountAddress = "APJnYRic9fYo1bLAdrqDbwrsnqoUD92dWo"
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getAccountState(accountAddress).then(response => {
+      outputHtml('Wallet Address: ' + accountAddress);
+      outputHtml('Account State:');
+      iterate(response, '');
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getassetstate/demo/demo.css
+++ b/examples/browser/getassetstate/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getassetstate/demo/demo.details
+++ b/examples/browser/getassetstate/demo/demo.details
@@ -1,0 +1,4 @@
+name: getassetstate
+description: Queries the asset information, based on the specified asset number.
+resources:
+- https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getassetstate/demo/demo.html
+++ b/examples/browser/getassetstate/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getassetstate/demo/demo.js
+++ b/examples/browser/getassetstate/demo/demo.js
@@ -1,0 +1,47 @@
+// Hashes of the Neo and Gas assets
+const neoHash = "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b"
+const gasHash = "0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7"
+const hash = neoHash
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getAssetState(hash).then(response => {
+      outputHtml('Hash: ' + hash);
+      outputHtml('Asset:');
+      iterate(response, '');
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s;
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getbalance/demo/demo.css
+++ b/examples/browser/getbalance/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getbalance/demo/demo.details
+++ b/examples/browser/getbalance/demo/demo.details
@@ -1,0 +1,4 @@
+name: getbalance
+description: Returns the balance of the corresponding asset in the wallet according to the specified asset number.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getbalance/demo/demo.html
+++ b/examples/browser/getbalance/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getbalance/demo/demo.js
+++ b/examples/browser/getbalance/demo/demo.js
@@ -1,0 +1,48 @@
+// Hashes of the Neo and Gas assets
+const neoHash = "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b"
+const gasHash = "0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7"
+const hash = neoHash
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getBalance(hash).then(response => {
+      outputHtml('Hash: ' + hash);
+      outputHtml('Asset:');
+      iterate(response, '');
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getbestblockhash/demo/demo.css
+++ b/examples/browser/getbestblockhash/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getbestblockhash/demo/demo.details
+++ b/examples/browser/getbestblockhash/demo/demo.details
@@ -1,0 +1,4 @@
+name: getbestblockhash
+description: Get the hash of the highest (most recent) block.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getbestblockhash/demo/demo.html
+++ b/examples/browser/getbestblockhash/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getbestblockhash/demo/demo.js
+++ b/examples/browser/getbestblockhash/demo/demo.js
@@ -1,0 +1,41 @@
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getBestBlockHash().then(response => {
+    	outputHtml('Result: ' + response);
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getblock/demo/demo.css
+++ b/examples/browser/getblock/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getblock/demo/demo.details
+++ b/examples/browser/getblock/demo/demo.details
@@ -1,0 +1,4 @@
+name: getblock
+description: Get block data by its hash or index.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getblock/demo/demo.html
+++ b/examples/browser/getblock/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getblock/demo/demo.js
+++ b/examples/browser/getblock/demo/demo.js
@@ -1,0 +1,49 @@
+// Hash of the block to get
+const hash = "0x3d298e045e9b8d191e94239848a1ccee5b835afe01b9f7cfe07a1fa7af3d908c"
+
+// Index of the block to get
+const index = 0 // <- very first block ever on neo blockchain!
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    // change 'hash' below to 'index' to use the index version of getblock
+    client.getBlock(hash).then(response => {
+    	outputHtml('Block Data: ');
+      iterate(response, '');
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getblockcount/demo/demo.css
+++ b/examples/browser/getblockcount/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getblockcount/demo/demo.details
+++ b/examples/browser/getblockcount/demo/demo.details
@@ -1,0 +1,4 @@
+name: getblockcount
+description: Get the number of blocks on a chain.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getblockcount/demo/demo.html
+++ b/examples/browser/getblockcount/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getblockcount/demo/demo.js
+++ b/examples/browser/getblockcount/demo/demo.js
@@ -1,0 +1,41 @@
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getBlockCount().then(response => {
+      outputHtml('Result: ' + response);
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getblockheader/demo/demo.css
+++ b/examples/browser/getblockheader/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getblockheader/demo/demo.details
+++ b/examples/browser/getblockheader/demo/demo.details
@@ -1,0 +1,4 @@
+  name: getblockheader
+  description: Returns the corresponding block header information according to the specified script hash. This method builds a custom request and executes it using the neon-js RPC query facility.
+  resources:
+    - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getblockheader/demo/demo.html
+++ b/examples/browser/getblockheader/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getblockheader/demo/demo.js
+++ b/examples/browser/getblockheader/demo/demo.js
@@ -1,0 +1,62 @@
+// Hash of the block to get
+const hash = "0x3d298e045e9b8d191e94239848a1ccee5b835afe01b9f7cfe07a1fa7af3d908c"
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+		rpcQuery(response => {
+			outputHtml('Block Data: ');
+			outputHtml("Block Header: ");
+			iterate(response, '');
+		}, nodeUrl, "getblockheader", hash);
+  });
+}
+
+// This is a reusable function that packages an unsupported RPC API call into a generic neon-js query object.
+function rpcQuery(callback, url, method, parms) {
+  let args
+
+  if (parms) {
+    let s = parms
+    args = s.split(',')
+    outputHtml('args: ' + args);
+  }
+
+  const query = Neon.default.create.query({method: method, params: args});
+
+  query.execute(url).then(response => {
+    callback(response);
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getblocksysfee/demo/demo.css
+++ b/examples/browser/getblocksysfee/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getblocksysfee/demo/demo.details
+++ b/examples/browser/getblocksysfee/demo/demo.details
@@ -1,0 +1,4 @@
+name: getblocksysfee
+description: Returns the system fees of the block, based on the specified index.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getblocksysfee/demo/demo.html
+++ b/examples/browser/getblocksysfee/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getblocksysfee/demo/demo.js
+++ b/examples/browser/getblocksysfee/demo/demo.js
@@ -1,0 +1,45 @@
+// Index of the block to get
+const index = 0 // <- very first block ever on neo blockchain!
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    // change 'hash' below to 'index' to use the index version of getblock
+    client.getBlockSysFee(index).then(response => {
+    	outputHtml('Block Data: ' + response);
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getblocksysfee/demo/demo.js
+++ b/examples/browser/getblocksysfee/demo/demo.js
@@ -14,7 +14,6 @@ function InvokeOperation()
   // Get an RPC Endpoint (Neo Node)
   provider.getRPCEndpoint().then(nodeUrl => {
     const client = Neon.default.create.rpcClient(nodeUrl);
-    // change 'hash' below to 'index' to use the index version of getblock
     client.getBlockSysFee(index).then(response => {
     	outputHtml('Block Data: ' + response);
     });

--- a/examples/browser/getconnectioncount/demo/demo.css
+++ b/examples/browser/getconnectioncount/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getconnectioncount/demo/demo.details
+++ b/examples/browser/getconnectioncount/demo/demo.details
@@ -1,0 +1,4 @@
+name: getconnectioncount
+description: Gets the current number of connections for the node.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getconnectioncount/demo/demo.html
+++ b/examples/browser/getconnectioncount/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getconnectioncount/demo/demo.js
+++ b/examples/browser/getconnectioncount/demo/demo.js
@@ -1,0 +1,42 @@
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getConnectionCount().then(response => {
+      outputHtml('Result: ' + response);
+      iterate(response, '');
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getcontractstate/demo/demo.css
+++ b/examples/browser/getcontractstate/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getcontractstate/demo/demo.details
+++ b/examples/browser/getcontractstate/demo/demo.details
@@ -1,0 +1,4 @@
+name: getcontractstate
+description: Queries contract information, according to the contract script hash.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getcontractstate/demo/demo.html
+++ b/examples/browser/getcontractstate/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getcontractstate/demo/demo.js
+++ b/examples/browser/getcontractstate/demo/demo.js
@@ -1,0 +1,45 @@
+// Hash of the contract to get
+const hash = "b3a14d99a3fb6646c78bf2f4e2f25a7964d2956a"
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getContractState(hash).then(response => {
+    	outputHtml('Result: ');
+      iterate(response, '');
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getpeers/demo/demo.css
+++ b/examples/browser/getpeers/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getpeers/demo/demo.details
+++ b/examples/browser/getpeers/demo/demo.details
@@ -1,0 +1,4 @@
+name: getpeers
+description: Gets a list of nodes that are currently connected/disconnected by this node.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getpeers/demo/demo.html
+++ b/examples/browser/getpeers/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getpeers/demo/demo.js
+++ b/examples/browser/getpeers/demo/demo.js
@@ -1,0 +1,42 @@
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getPeers().then(response => {
+      outputHtml('Result: ');
+      iterate(response, '');
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getrawmempool/demo/demo.css
+++ b/examples/browser/getrawmempool/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getrawmempool/demo/demo.details
+++ b/examples/browser/getrawmempool/demo/demo.details
@@ -1,0 +1,4 @@
+name: getrawmempool
+description: Gets a list of unconfirmed transactions in memory.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getrawmempool/demo/demo.html
+++ b/examples/browser/getrawmempool/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getrawmempool/demo/demo.js
+++ b/examples/browser/getrawmempool/demo/demo.js
@@ -1,0 +1,42 @@
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getRawMemPool().then(response => {
+      outputHtml('Result: ');
+      iterate(response, '');
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getrawtransaction/demo/demo.css
+++ b/examples/browser/getrawtransaction/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getrawtransaction/demo/demo.details
+++ b/examples/browser/getrawtransaction/demo/demo.details
@@ -1,0 +1,4 @@
+name: getrawtransaction
+description: Get the account state for a wallet address
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getrawtransaction/demo/demo.html
+++ b/examples/browser/getrawtransaction/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getrawtransaction/demo/demo.js
+++ b/examples/browser/getrawtransaction/demo/demo.js
@@ -1,0 +1,46 @@
+// Hash of the transaction we want
+const hash = "0x2e5793b7c9766aba7c9f9812243827dbd722a6a47b7e002204f1407f844332a8"
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getRawTransaction(hash).then(response => {
+      outputHtml('TxID: ' + hash);
+      outputHtml('Transaction:');
+      iterate(response, '');
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getstorage/demo/demo.css
+++ b/examples/browser/getstorage/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getstorage/demo/demo.details
+++ b/examples/browser/getstorage/demo/demo.details
@@ -1,0 +1,4 @@
+name: getstorage
+description: Returns the stored value, according to the contract script hash and the stored key.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getstorage/demo/demo.html
+++ b/examples/browser/getstorage/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getstorage/demo/demo.js
+++ b/examples/browser/getstorage/demo/demo.js
@@ -1,0 +1,47 @@
+// Hash of the contract to get
+const hash = "b3a14d99a3fb6646c78bf2f4e2f25a7964d2956a"
+
+// Key of the storage to get for this contract
+const key = "74657374"
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getStorage(hash, key).then(response => {
+    	outputHtml('Result: ' + Neon.u.hexstring2str(response));
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/gettxout/demo/demo.css
+++ b/examples/browser/gettxout/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/gettxout/demo/demo.details
+++ b/examples/browser/gettxout/demo/demo.details
@@ -1,0 +1,4 @@
+name: gettxout
+description: Returns the corresponding unspent transaction output information (returned change), based on the specified hash and index. If the transaction output is already spent, the result value will be null.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/gettxout/demo/demo.html
+++ b/examples/browser/gettxout/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/gettxout/demo/demo.js
+++ b/examples/browser/gettxout/demo/demo.js
@@ -1,0 +1,47 @@
+// Transaction id to get
+const hash = "f4250dab094c38d8265acc15c366dc508d2e14bf5699e12d9df26577ed74d657";
+
+// Index of the unspent transaction output to get for the given tx
+const index = 0;
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getTxOut(hash, index).then(response => {
+    	outputHtml('Result: ' + response);
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getvalidators/demo/demo.css
+++ b/examples/browser/getvalidators/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getvalidators/demo/demo.details
+++ b/examples/browser/getvalidators/demo/demo.details
@@ -1,0 +1,4 @@
+name: getvalidators
+description: Returns the current NEO consensus nodes information and voting status.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getvalidators/demo/demo.html
+++ b/examples/browser/getvalidators/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getvalidators/demo/demo.js
+++ b/examples/browser/getvalidators/demo/demo.js
@@ -1,0 +1,42 @@
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getValidators().then(response => {
+      outputHtml('Result: ');
+      iterate(response, '')
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/getversion/demo/demo.css
+++ b/examples/browser/getversion/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/getversion/demo/demo.details
+++ b/examples/browser/getversion/demo/demo.details
@@ -1,0 +1,4 @@
+name: getversion
+description: Gets version information of this node.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/getversion/demo/demo.html
+++ b/examples/browser/getversion/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/getversion/demo/demo.js
+++ b/examples/browser/getversion/demo/demo.js
@@ -1,0 +1,41 @@
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.getVersion().then(response => {
+      outputHtml('Result: ' + response);
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/index/demo/demo.css
+++ b/examples/browser/index/demo/demo.css
@@ -1,0 +1,32 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    background: rgb(66, 184, 221); /* this is a light blue */
+}
+#buttons {
+  float: left;
+
+}
+
+#result {
+  float: left;
+  white-space: pre-wrap;      /* CSS3 */
+  white-space: -moz-pre-wrap; /* Firefox */
+  white-space: -pre-wrap;     /* Opera <7 */
+  white-space: -o-pre-wrap;   /* Opera 7 */
+  word-wrap: break-word;      /* IE */
+}
+.child_div_1 {
+  float: left;
+  margin-right: 5px;
+}

--- a/examples/browser/index/demo/demo.details
+++ b/examples/browser/index/demo/demo.details
@@ -1,0 +1,4 @@
+name: /Neon:v2.9.0/ API Browser Example Index
+description: Press each button to run that example
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/index/demo/demo.html
+++ b/examples/browser/index/demo/demo.html
@@ -1,0 +1,23 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<p>
+</p>
+<div id="buttons">
+  <button id="go" onclick="getAccountState();">
+  getAccountState
+  </button>
+  <p>
+  </p>
+  <button id="go1" onclick="getAssetState();">
+  getAssetState
+  </button>
+  <p>
+  </p>
+  <button id="go" onclick="getBestBlockHash();">
+  getBestBlockHash
+  </button>
+  <p>
+  </p>
+</div>
+<div id="result">
+Press a button to run an example.
+</div>

--- a/examples/browser/index/demo/demo.js
+++ b/examples/browser/index/demo/demo.js
@@ -1,0 +1,97 @@
+
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+	clearHtml();
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+function clearHtml() {
+	document.getElementById("result").innerHTML = "";
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+
+// API Wrappers - Yeah, boyyeee
+
+function getAccountState()
+{
+	clearHtml();
+
+  // Wallet address to query
+  const accountAddress = "APJnYRic9fYo1bLAdrqDbwrsnqoUD92dWo"
+  // Get an instance of Neoscan so we can find a working node
+  const provider = new Neon.api.neoscan.instance("TestNet");
+
+  // Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+	Neon.settings.httpsOnly = true;
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl)
+    client.getAccountState(accountAddress).then(response => {
+      outputHtml('Wallet Address: ' + accountAddress);
+      outputHtml('Account State:');
+      iterate(response, '')
+    });
+  });
+}
+
+
+function getAssetState()
+{
+	clearHtml();
+
+  // Hashes of the Neo and Gas assets
+  const neoHash = "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b"
+  const gasHash = "0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7"
+  const hash = neoHash
+
+  // Get an instance of Neoscan so we can find a working node
+  const provider = new Neon.api.neoscan.instance("TestNet");
+
+  // Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+	Neon.settings.httpsOnly = true;
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl)
+    client.getAssetState(hash).then(response => {
+      outputHtml('Hash: ' + hash);
+      outputHtml('Asset:');
+      iterate(response, '');
+    });
+  });
+}
+
+function getBestBlockHash()
+{
+	clearHtml();
+
+  // Get an instance of Neoscan so we can find a working node
+  const provider = new Neon.api.neoscan.instance("TestNet");
+
+  // Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+	Neon.settings.httpsOnly = true;
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl)
+    client.getBestBlockHash().then(response => {
+      outputHtml('Result: ' + response);
+    });
+  });
+}

--- a/examples/browser/invokefunction/demo/demo.css
+++ b/examples/browser/invokefunction/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/invokefunction/demo/demo.details
+++ b/examples/browser/invokefunction/demo/demo.details
@@ -1,0 +1,4 @@
+name: invokefunction
+description: Invokes a smart contract at specified script hash, passing in an operation and its params.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/invokefunction/demo/demo.html
+++ b/examples/browser/invokefunction/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/invokefunction/demo/demo.js
+++ b/examples/browser/invokefunction/demo/demo.js
@@ -1,0 +1,53 @@
+
+const contractHash = "5b7074e873973a6ed3708862f219a6fbf4d1c411";
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+		invokeFunction(response => {
+			outputHtml('Results: ');
+			iterate(response, '');
+		}, nodeUrl);
+  });
+}
+
+// We're wrapping the neon-js call to make our code a little clearer.
+function invokeFunction(callback, url) {
+  Neon.rpc.Query.invokeFunction(contractHash, "name")
+    .execute(url)
+    .then(res => {
+      callback(res); // You should get a result with state: "HALT, BREAK"
+    })
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/invokescript/demo/demo.css
+++ b/examples/browser/invokescript/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/invokescript/demo/demo.details
+++ b/examples/browser/invokescript/demo/demo.details
@@ -1,0 +1,4 @@
+name: invokescript
+description: Runs a script through the virtual machine and returns the results.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/invokescript/demo/demo.html
+++ b/examples/browser/invokescript/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/invokescript/demo/demo.js
+++ b/examples/browser/invokescript/demo/demo.js
@@ -1,0 +1,61 @@
+const props = {
+  // Scripthash for the contract
+  scriptHash: '5b7074e873973a6ed3708862f219a6fbf4d1c411',
+  // name of operation to perform.
+  operation: 'balanceOf',
+  // any optional arguments to pass in. If null, use empty array.
+  args: [Neon.u.reverseHex('cef0c0fdcfe7838eff6ff104f9cdec2922297537')]
+}
+
+const script = Neon.sc.createScript(props);
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+		invokeScipt(response => {
+			outputHtml('Results: ');
+			iterate(response, '');
+		}, nodeUrl);
+  });
+}
+
+// We're wrapping the neon-js call to make our code a little clearer.
+function invokeScipt(callback, url) {
+  Neon.rpc.Query.invokeScript(script)
+    .execute(url)
+    .then(res => {
+      callback(res); // You should get a result with state: "HALT, BREAK"
+    })
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}

--- a/examples/browser/validateaddress/demo/demo.css
+++ b/examples/browser/validateaddress/demo/demo.css
@@ -1,0 +1,17 @@
+body {
+ color: #24292e;
+ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+ font-size: 16px;
+ line-height: 1.5;
+ -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%;
+ word-wrap: break-word;
+}
+
+button {
+    font-size: 16px;
+    color: white;
+    border-radius: 4px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: rgb(66, 184, 221); /* this is a light blue */
+}

--- a/examples/browser/validateaddress/demo/demo.details
+++ b/examples/browser/validateaddress/demo/demo.details
@@ -1,0 +1,4 @@
+name: validateaddress
+description: Verify that the address is a correct NEO address.
+resources:
+  - https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js

--- a/examples/browser/validateaddress/demo/demo.html
+++ b/examples/browser/validateaddress/demo/demo.html
@@ -1,0 +1,11 @@
+<script src="https://cdn.jsdelivr.net/npm/@cityofzion/neon-js@4.5.2/dist/browser.min.js"></script>
+<button id="go" onclick="InvokeOperation();">
+  Invoke Operation
+</button>
+<p>
+</p>
+<div id="result">
+  Press button above to run the example.
+</div>
+<p>
+</p>

--- a/examples/browser/validateaddress/demo/demo.js
+++ b/examples/browser/validateaddress/demo/demo.js
@@ -1,0 +1,44 @@
+// Wallet address to query
+const accountAddress = "APJnYRic9fYo1bLAdrqDbwrsnqoUD92dWo";
+
+// Get an instance of Neoscan so we can find a working node
+const provider = new Neon.api.neoscan.instance("TestNet");
+
+// Ensure neon-js only talks to RPC endpoint (Neo node) using HTTPS
+Neon.settings.httpsOnly = true;
+
+function InvokeOperation()
+{
+  clearHtml();
+
+  // Get an RPC Endpoint (Neo Node)
+  provider.getRPCEndpoint().then(nodeUrl => {
+    const client = Neon.default.create.rpcClient(nodeUrl);
+    client.validateAddress(accountAddress).then(response => {
+      outputHtml('Result: ' + response);
+    });
+  });
+}
+
+// Utility function to iterate over objects and display them to an output div
+function iterate(obj, stack) {
+  for (var property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] == "object") {
+        iterate(obj[property], stack + '.' + property);
+      } else {
+        console.log(property + "  " + obj[property]);
+        outputHtml(stack + '.' + property + ': ' + obj[property]);
+      }
+    }
+  }
+}
+
+// Utility function to print output to an HTML div tag
+function outputHtml(s) {
+  document.getElementById("result").innerHTML += s + "<br>";
+}
+
+function clearHtml() {
+  document.getElementById("result").innerHTML = "";
+}


### PR DESCRIPTION
This PR adds an index and an array of embedded references and jsfiddle examples built against the official neon-js@4.5.2 cdn package on jsdelivr.net. It is an effort to improve the quality of documentation as a way to show clear, useful, interactive examples with hopes of accelerating understanding and adoption.

This documentation is a work in progress. This commit is the initial effort to establish formatting and other conventions. The documentation should be reviewed and improved upon over time. Bindings against versions of neon-js <-> Neo API mappings will evolve.

The current fiddles have been tested and confirmed to work. Please comment with any errors, suggestions, or issues.

The documentation must be in master branch in the given format for the fiddles to be tested. As such, all testing was committed against my fork of neon-js coz official and then submitted here.

Thanks!