### PR TITLE
Update sign method to allow for longer inputs

### DIFF
--- a/src/wallet/core.js
+++ b/src/wallet/core.js
@@ -131,8 +131,8 @@ export const generateSignature = (hex, privateKey) => {
   let elliptic = new EC('p256')
   const sig = elliptic.sign(msgHashHex, privateKey, null)
   const signature = Buffer.concat([
-    sig.r.toArrayLike(Buffer, 'be', 32),
-    sig.s.toArrayLike(Buffer, 'be', 32)
+    sig.r.toArrayLike(Buffer, 'be', 64),
+    sig.s.toArrayLike(Buffer, 'be', 64)
   ])
 
   return signature.toString('hex')


### PR DESCRIPTION
Signing inputs appear to error out when longer than 223 characters. For signing arbitrary messages it is causing errors, and we need to accept larger inputs.

@snowypowers Could you please review and merge upon confirming update.

Addresses this issue:
https://github.com/CityOfZion/neon-js/issues/434