### PR TITLE
fix(rpc): Update VM status output for neo v2.10.2

### DIFF
--- a/docs/guides/basic/createscript.md
+++ b/docs/guides/basic/createscript.md
@@ -42,7 +42,7 @@ const script = Neon.create.script(props)
 Neon.rpc.Query.invokeScript(script)
   .execute('http://seed3.neo.org:20332')
   .then(res => {
-    console.log(res) // You should get a result with state: "HALT, BREAK"
+    console.log(res) // You should get a result with state: "HALT"
   })
 ```
 
@@ -54,7 +54,7 @@ Your console result should look something like this::
     "id": 1234,
     "result": {
         "script": "143775292229eccdf904f16fff8e83e7cffdc0f0ce51c10962616c616e63654f666711c4d1f4fba619f2628870d36e3a9773e874705b",
-        "state": "HALT, BREAK",
+        "state": "HALT",
         "gas_consumed": "0.338",
         "stack": [
             {
@@ -104,7 +104,7 @@ Now our result would look like:
     "id": 1234,
     "result": {
         "script": "00c1046e616d656711c4d1f4fba619f2628870d36e3a9773e874705b00c108646563696d616c736711c4d1f4fba619f2628870d36e3a9773e874705b00c10673796d626f6c6711c4d1f4fba619f2628870d36e3a9773e874705b00c10b746f74616c537570706c796711c4d1f4fba619f2628870d36e3a9773e874705b",
-        "state": "HALT, BREAK",
+        "state": "HALT",
         "gas_consumed": "0.646",
         "stack": [
             {

--- a/packages/neon-core/__integration__/rpc/RPCClient.ts
+++ b/packages/neon-core/__integration__/rpc/RPCClient.ts
@@ -234,7 +234,7 @@ describe("RPC Methods", () => {
       expect(Object.keys(result)).toEqual(
         expect.arrayContaining(["script", "state", "gas_consumed", "stack"])
       );
-      expect(result.state).toEqual("HALT, BREAK");
+      expect(result.state).toContain("HALT");
       expect(result.stack[0].value).toEqual(
         "5265642050756c736520546f6b656e20332e312e34"
       );
@@ -255,7 +255,7 @@ describe("RPC Methods", () => {
       expect(Object.keys(result)).toEqual(
         expect.arrayContaining(["script", "state", "gas_consumed", "stack"])
       );
-      expect(result.state).toEqual("HALT, BREAK");
+      expect(result.state).toContain("HALT");
       expect(result.stack.length).toBe(1);
     });
 
@@ -265,7 +265,7 @@ describe("RPC Methods", () => {
       expect(Object.keys(result)).toEqual(
         expect.arrayContaining(["script", "state", "gas_consumed", "stack"])
       );
-      expect(result.state).toEqual("HALT, BREAK");
+      expect(result.state).toContain("HALT");
       expect(result.stack[0].value).toEqual(
         "5265642050756c736520546f6b656e20332e312e34"
       );
@@ -278,7 +278,7 @@ describe("RPC Methods", () => {
       expect(Object.keys(result)).toEqual(
         expect.arrayContaining(["script", "state", "gas_consumed", "stack"])
       );
-      expect(result.state).toEqual("HALT, BREAK");
+      expect(result.state).toContain("HALT");
       expect(result.stack[0].value).toEqual(
         "5265642050756c736520546f6b656e20332e312e34"
       );

--- a/packages/neon-core/src/rpc/parse.ts
+++ b/packages/neon-core/src/rpc/parse.ts
@@ -6,7 +6,7 @@ import { Fixed8, hexstring2str } from "../u";
  */
 export interface RPCVMResponse {
   script: string;
-  state: "HALT, BREAK" | "FAULT, BREAK";
+  state: "HALT, BREAK" | "FAULT, BREAK" | "HALT" | "FAULT";
   gas_consumed: string;
   stack: StackItemLike[];
 }


### PR DESCRIPTION
With the new update to v2.10.2, the new VM cuts out the word `BREAK`. This PR addresses the change by relaxing the tests assertions to just `HALT` or `FAULT` instead of looking for the exact phrase `HALT, BREAK` or `FAULT, BREAK`.