### PR TITLE
Neo3 contracts abi

### DIFF
--- a/packages/neon-core/__tests__/sc/native_contracts_abi/gas.ts
+++ b/packages/neon-core/__tests__/sc/native_contracts_abi/gas.ts
@@ -1,0 +1,62 @@
+import { GAS } from "../../../src/sc";
+
+describe("GAS Native Contract", () => {
+  const gas = new GAS();
+  test("balanceOf", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const result = gas.balanceOf(addr);
+    expect(result).toBe(
+      "14e849739c4d7711fed5a4e27fa3d5ae950038d04951c10962616c616e63654f66142582d1b275e86c8f0e93a9b2facd5fdb760976a168627d5b52"
+    );
+  });
+
+  test("decimals", () => {
+    const result = gas.decimals();
+    expect(result).toBe(
+      "00c108646563696d616c73142582d1b275e86c8f0e93a9b2facd5fdb760976a168627d5b52"
+    );
+  });
+
+  test("getSysFeeAmount", () => {
+    const result = gas.getSysFeeAmount(10000);
+    expect(result).toBe(
+      "02102751c10f676574537973466565416d6f756e74142582d1b275e86c8f0e93a9b2facd5fdb760976a168627d5b52"
+    );
+  });
+
+  test("name", () => {
+    const result = gas.name();
+    expect(result).toBe(
+      "00c1046e616d65142582d1b275e86c8f0e93a9b2facd5fdb760976a168627d5b52"
+    );
+  });
+
+  test("supportedStandards", () => {
+    const result = gas.supportedStandards();
+    expect(result).toBe(
+      "00c112737570706f727465645374616e6461726473142582d1b275e86c8f0e93a9b2facd5fdb760976a168627d5b52"
+    );
+  });
+
+  test("symbol", () => {
+    const result = gas.symbol();
+    expect(result).toBe(
+      "00c10673796d626f6c142582d1b275e86c8f0e93a9b2facd5fdb760976a168627d5b52"
+    );
+  });
+
+  test("totalSupply", () => {
+    const result = gas.totalSupply();
+    expect(result).toBe(
+      "00c10b746f74616c537570706c79142582d1b275e86c8f0e93a9b2facd5fdb760976a168627d5b52"
+    );
+  });
+
+  test("transfer", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const result = gas.transfer(addr, addr, 10000);
+    expect(result).toBe(
+      "060010a5d4e80014e849739c4d7711fed5a4e27fa3d5ae950038d04914e849739c4d7711fed5a4e27fa3d5ae950038d04953c1087472616e73666572142582d1b275e86c8f0e93a9b2facd5fdb760976a168627d5b52"
+    );
+  });
+});

--- a/packages/neon-core/__tests__/sc/native_contracts_abi/neo.ts
+++ b/packages/neon-core/__tests__/sc/native_contracts_abi/neo.ts
@@ -1,0 +1,104 @@
+import { NEO } from "../../../src/sc";
+
+describe("NEO Native Contract", () => {
+  const neo = new NEO();
+
+  test("balanceOf", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const result = neo.balanceOf(addr);
+    expect(result).toBe(
+      "14e849739c4d7711fed5a4e27fa3d5ae950038d04951c10962616c616e63654f661415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("decimals", () => {
+    const result = neo.decimals();
+    expect(result).toBe(
+      "00c108646563696d616c731415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("getNextBlockValidators", () => {
+    const result = neo.getNextBlockValidators();
+    expect(result).toBe(
+      "00c1166765744e657874426c6f636b56616c696461746f72731415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("getRegisteredValidators", () => {
+    const result = neo.getRegisteredValidators();
+    expect(result).toBe(
+      "00c1176765745265676973746572656456616c696461746f72731415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("getValidators", () => {
+    const result = neo.getValidators();
+    expect(result).toBe(
+      "00c10d67657456616c696461746f72731415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("name", () => {
+    const result = neo.name();
+    expect(result).toBe(
+      "00c1046e616d651415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("registerValidator", () => {
+    const pubkey =
+      "02ec3712c5e5b349445cc4ad038ecc34cdceff3b010be522b8690228e3a4525f6c";
+    const result = neo.registerValidator(pubkey);
+    expect(result).toBe(
+      "4230326563333731326335653562333439343435636334616430333865636333346364636566663362303130626535323262383639303232386533613435323566366351c111726567697374657256616c696461746f721415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("supportedStandards", () => {
+    const result = neo.supportedStandards();
+    expect(result).toBe(
+      "00c112737570706f727465645374616e64617264731415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("symbol", () => {
+    const result = neo.symbol();
+    expect(result).toBe(
+      "00c10673796d626f6c1415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("totalSupply", () => {
+    const result = neo.totalSupply();
+    expect(result).toBe(
+      "00c10b746f74616c537570706c791415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("transfer", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const result = neo.transfer(addr, addr, 10000);
+    expect(result).toBe(
+      "060010a5d4e80014e849739c4d7711fed5a4e27fa3d5ae950038d04914e849739c4d7711fed5a4e27fa3d5ae950038d04953c1087472616e736665721415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("unclaimedGas", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const result = neo.unclaimedGas(addr, 1000);
+    expect(result).toBe(
+      "02e80314e849739c4d7711fed5a4e27fa3d5ae950038d04952c10c756e636c61696d65644761731415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+
+  test("vote", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const pubkey =
+      "02ec3712c5e5b349445cc4ad038ecc34cdceff3b010be522b8690228e3a4525f6c";
+    const result = neo.vote(addr, [pubkey]);
+    expect(result).toBe(
+      "4230326563333731326335653562333439343435636334616430333865636333346364636566663362303130626535323262383639303232386533613435323566366351c114e849739c4d7711fed5a4e27fa3d5ae950038d04952c104766f74651415caa04214310670d5e5a398e147e0dbed98cf4368627d5b52"
+    );
+  });
+});

--- a/packages/neon-core/__tests__/sc/native_contracts_abi/nep5.ts
+++ b/packages/neon-core/__tests__/sc/native_contracts_abi/nep5.ts
@@ -1,0 +1,49 @@
+import { NEP5 } from "../../../src/sc";
+
+describe("NEP5 ABI", () => {
+  const contract_scriptHash = "ecc6b20d3ccac1ee9ef109af5a7cdb85706b1df9";
+  const nep5 = new NEP5("TestNep5", contract_scriptHash);
+  test("balanceOf", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const result = nep5.balanceOf(addr);
+    expect(result).toBe(
+      "14e849739c4d7711fed5a4e27fa3d5ae950038d04951c10962616c616e63654f6614f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec68627d5b52"
+    );
+  });
+
+  test("decimals", () => {
+    const result = nep5.decimals();
+    expect(result).toBe(
+      "00c108646563696d616c7314f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec68627d5b52"
+    );
+  });
+
+  test("name", () => {
+    const result = nep5.name();
+    expect(result).toBe(
+      "00c1046e616d6514f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec68627d5b52"
+    );
+  });
+
+  test("symbol", () => {
+    const result = nep5.symbol();
+    expect(result).toBe(
+      "00c10673796d626f6c14f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec68627d5b52"
+    );
+  });
+
+  test("totalSupply", () => {
+    const result = nep5.totalSupply();
+    expect(result).toBe(
+      "00c10b746f74616c537570706c7914f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec68627d5b52"
+    );
+  });
+
+  test("transfer", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const result = nep5.transfer(addr, addr, 10);
+    expect(result).toBe(
+      "0400ca9a3b14e849739c4d7711fed5a4e27fa3d5ae950038d04914e849739c4d7711fed5a4e27fa3d5ae950038d04953c1087472616e7366657214f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec68627d5b52"
+    );
+  });
+});

--- a/packages/neon-core/__tests__/sc/native_contracts_abi/policy.ts
+++ b/packages/neon-core/__tests__/sc/native_contracts_abi/policy.ts
@@ -1,0 +1,63 @@
+import { Policy } from "../../../src/sc";
+
+describe("Policy Contract ABI", () => {
+  const policy = new Policy();
+
+  test("blockAccount", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const result = policy.blockAccount(addr);
+    expect(result).toBe(
+      "14e849739c4d7711fed5a4e27fa3d5ae950038d04951c10c626c6f636b4163636f756e7414778bba6b68d2df455ddd60218e46bd60b299569c68627d5b52"
+    );
+  });
+
+  test("getBlockedAccounts", () => {
+    const result = policy.getBlockedAccounts();
+    expect(result).toBe(
+      "00c112676574426c6f636b65644163636f756e747314778bba6b68d2df455ddd60218e46bd60b299569c68627d5b52"
+    );
+  });
+
+  test("getFeePerByte", () => {
+    const result = policy.getFeePerByte();
+    expect(result).toBe(
+      "00c10d6765744665655065724279746514778bba6b68d2df455ddd60218e46bd60b299569c68627d5b52"
+    );
+  });
+
+  test("getMaxTransactionsPerBlock", () => {
+    const result = policy.getMaxTransactionsPerBlock();
+    expect(result).toBe(
+      "00c11a6765744d61785472616e73616374696f6e73506572426c6f636b14778bba6b68d2df455ddd60218e46bd60b299569c68627d5b52"
+    );
+  });
+
+  test("setFeePerByte", () => {
+    const result = policy.setFeePerByte(1000);
+    expect(result).toBe(
+      "02e80351c10d7365744665655065724279746514778bba6b68d2df455ddd60218e46bd60b299569c68627d5b52"
+    );
+  });
+
+  test("setMaxTransactionsPerBlock", () => {
+    const result = policy.setMaxTransactionsPerBlock(10023);
+    expect(result).toBe(
+      "02272751c11a7365744d61785472616e73616374696f6e73506572426c6f636b14778bba6b68d2df455ddd60218e46bd60b299569c68627d5b52"
+    );
+  });
+
+  test("unblockAccount", () => {
+    const addr = "Acx6QWXVxsGPUvNqjS9zWY3SZCryq5R8bp";
+    const result = policy.unblockAccount(addr);
+    expect(result).toBe(
+      "14e849739c4d7711fed5a4e27fa3d5ae950038d04951c10e756e626c6f636b4163636f756e7414778bba6b68d2df455ddd60218e46bd60b299569c68627d5b52"
+    );
+  });
+
+  test("supportedStandards", () => {
+    const result = policy.supportedStandards();
+    expect(result).toBe(
+      "00c112737570706f727465645374616e646172647314778bba6b68d2df455ddd60218e46bd60b299569c68627d5b52"
+    );
+  });
+});

--- a/packages/neon-core/src/sc/index.ts
+++ b/packages/neon-core/src/sc/index.ts
@@ -9,3 +9,4 @@ export * from "./InteropServicePrices";
 export * from "./StackItem";
 export * from "./NativeContractMethodPrices";
 export * from "./manifest";
+export * from "./native_contracts_abi";

--- a/packages/neon-core/src/sc/native_contracts_abi/NativeContract.ts
+++ b/packages/neon-core/src/sc/native_contracts_abi/NativeContract.ts
@@ -1,0 +1,11 @@
+export abstract class NativeContract {
+  public constructor(name = "Native") {
+    console.log(`Initiating ${name} contract`);
+  }
+
+  abstract buildScript(method: string, args?: any[]): string;
+
+  public supportedStandards(): string {
+    return this.buildScript("supportedStandards");
+  }
+}

--- a/packages/neon-core/src/sc/native_contracts_abi/gas.ts
+++ b/packages/neon-core/src/sc/native_contracts_abi/gas.ts
@@ -1,0 +1,22 @@
+import ContractParam from "../ContractParam";
+import { NEP5 } from "./nep5";
+import { ASSET_ID } from "../../consts";
+
+export class GAS extends NEP5 {
+  public constructor() {
+    super("GAS");
+  }
+
+  public buildScript(method: string, args?: any[]): string {
+    if (!this._sb) {
+      throw new Error("sb not initiated.");
+    }
+    this._sb.reset();
+    this._sb.str = "";
+    return this._sb.emitAppCall(ASSET_ID.GAS, method, args).str;
+  }
+
+  public getSysFeeAmount(index: number): string {
+    return this.buildScript("getSysFeeAmount", [ContractParam.integer(index)]);
+  }
+}

--- a/packages/neon-core/src/sc/native_contracts_abi/index.ts
+++ b/packages/neon-core/src/sc/native_contracts_abi/index.ts
@@ -1,0 +1,4 @@
+export * from "./gas";
+export * from "./neo";
+export * from "./nep5";
+export * from "./policy";

--- a/packages/neon-core/src/sc/native_contracts_abi/neo.ts
+++ b/packages/neon-core/src/sc/native_contracts_abi/neo.ts
@@ -1,0 +1,52 @@
+import ContractParam from "../ContractParam";
+import { NEP5 } from "./nep5";
+import { ASSET_ID } from "../../consts";
+
+export class NEO extends NEP5 {
+  public constructor() {
+    super("NEO");
+  }
+
+  public buildScript(method: string, args?: any[]): string {
+    if (!this._sb) {
+      throw new Error("sb not initiated.");
+    }
+    this._sb.reset();
+    this._sb.str = "";
+    return this._sb.emitAppCall(ASSET_ID.NEO, method, args).str;
+  }
+
+  public unclaimedGas(addr: string, end: number): string {
+    return this.buildScript("unclaimedGas", [
+      ContractParam.hash160(addr),
+      ContractParam.integer(end.toString())
+    ]);
+  }
+
+  public registerValidator(pubkey: string): string {
+    return this.buildScript("registerValidator", [
+      ContractParam.publicKey(pubkey)
+    ]);
+  }
+
+  public getRegisteredValidators(): string {
+    return this.buildScript("getRegisteredValidators");
+  }
+
+  public getValidators(): string {
+    return this.buildScript("getValidators");
+  }
+
+  public getNextBlockValidators(): string {
+    return this.buildScript("getNextBlockValidators");
+  }
+
+  public vote(addr: string, pubkeys: string[]): string {
+    return this.buildScript("vote", [
+      ContractParam.hash160(addr),
+      ContractParam.array(
+        ...pubkeys.map(pubkey => ContractParam.publicKey(pubkey))
+      )
+    ]);
+  }
+}

--- a/packages/neon-core/src/sc/native_contracts_abi/nep5.ts
+++ b/packages/neon-core/src/sc/native_contracts_abi/nep5.ts
@@ -1,0 +1,64 @@
+import { ScriptBuilder } from "../ScriptBuilder";
+import { Fixed8 } from "../../u";
+import ContractParam from "../ContractParam";
+import { NativeContract } from "./NativeContract";
+
+/**
+ * In neo core project, NEP5Token is a native contract that is extended by NEO and GAS
+ */
+export class NEP5 extends NativeContract {
+  public scriptHash: string;
+  protected _sb: ScriptBuilder;
+  public constructor(name: string = "NEP5", scriptHash: string = "") {
+    super(name);
+    this.scriptHash = scriptHash;
+    this._sb = new ScriptBuilder();
+  }
+
+  public buildScript(method: string, args?: any[]): string {
+    if (!this._sb) {
+      throw new Error("sb not initiated.");
+    }
+    if (!this.scriptHash) {
+      throw new Error("scriptHash not assigned.");
+    }
+    this._sb.reset();
+    this._sb.str = "";
+    return this._sb.emitAppCall(this.scriptHash, method, args).str;
+  }
+
+  public name(): string {
+    return this.buildScript("name");
+  }
+
+  public symbol(): string {
+    return this.buildScript("symbol");
+  }
+
+  public decimals(): string {
+    return this.buildScript("decimals");
+  }
+
+  public totalSupply(): string {
+    return this.buildScript("totalSupply");
+  }
+
+  public balanceOf(addr: string): string {
+    return this.buildScript("balanceOf", [ContractParam.hash160(addr)]);
+  }
+
+  public transfer(
+    fromAddr: string,
+    toAddr: string,
+    amt: Fixed8 | number
+  ): string {
+    const fromHash = ContractParam.hash160(fromAddr);
+    const toHash = ContractParam.hash160(toAddr);
+    const adjustedAmt = new Fixed8(amt).toRawNumber();
+    return this.buildScript("transfer", [
+      fromHash,
+      toHash,
+      ContractParam.integer(adjustedAmt.toString())
+    ]);
+  }
+}

--- a/packages/neon-core/src/sc/native_contracts_abi/policy.ts
+++ b/packages/neon-core/src/sc/native_contracts_abi/policy.ts
@@ -1,0 +1,55 @@
+import ScriptBuilder from "../ScriptBuilder";
+import ContractParam from "../ContractParam";
+import { NativeContract } from "./NativeContract";
+import { ASSET_ID } from "../../consts";
+
+/**
+ * Policy Token Contract is about consensus configuration.
+ */
+export class Policy extends NativeContract {
+  private _sb: ScriptBuilder;
+
+  public constructor() {
+    super("Policy");
+    this._sb = new ScriptBuilder();
+  }
+
+  public buildScript(method: string, args?: any[]): string {
+    if (!this._sb) {
+      throw new Error("sb not initiated");
+    }
+    this._sb.reset();
+    this._sb.str = "";
+    return this._sb.emitAppCall(ASSET_ID.POLICY, method, args).str;
+  }
+
+  public getMaxTransactionsPerBlock(): string {
+    return this.buildScript("getMaxTransactionsPerBlock");
+  }
+
+  public getFeePerByte(): string {
+    return this.buildScript("getFeePerByte");
+  }
+
+  public getBlockedAccounts(): string {
+    return this.buildScript("getBlockedAccounts");
+  }
+
+  public setMaxTransactionsPerBlock(value: number): string {
+    return this.buildScript("setMaxTransactionsPerBlock", [
+      ContractParam.integer(value)
+    ]);
+  }
+
+  public setFeePerByte(value: number): string {
+    return this.buildScript("setFeePerByte", [ContractParam.integer(value)]);
+  }
+
+  public blockAccount(addr: string): string {
+    return this.buildScript("blockAccount", [ContractParam.hash160(addr)]);
+  }
+
+  public unblockAccount(addr: string): string {
+    return this.buildScript("unblockAccount", [ContractParam.hash160(addr)]);
+  }
+}


### PR DESCRIPTION
Refer to https://github.com/CityOfZion/neon-js/issues/441.
This feature is not elementary to neo3, but just a user-friendly module for user to generate script conveniently.
User can construct contract invocation script in a way like:
```ts
const neo = new NEO();
const script = neo.balanceOf(address);
```
And this feature provide ABIs for 4 (type) contracts:
- nep5
- neo
- gas
- policy

We could consider set up global instances for native contracts(NEO, GAS, POLICY)