### PR TITLE
Implement buildIteratorScript

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           at: .
       - run:
           name: Install neo-boa
-          command: yarn boa
+          command: yarn pip && yarn boa
       - run: mkdir reports
       - run:
           name: Integration Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - run:
+          name: Install neo-boa
+          command: yarn boa
       - run: mkdir reports
       - run:
           name: Integration Tests

--- a/docs/examples/nep-11.md
+++ b/docs/examples/nep-11.md
@@ -1,0 +1,27 @@
+---
+id: nep11
+title: NEP-11
+---
+
+## Tokens Of
+
+The `tokensOf` method returns an iterator object. In order to access the values you need to invoke a script that reads the values. `buildIteratorScript` can automatically generate the script for `tokensOf` using an `Account` and script hash.
+
+### Using buildIteratorScript
+
+```javascript
+const { wallet, nep11 } = require("@cityofzion/neon-js");
+
+const account = new wallet.Account("ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW");
+const contractHash = "c938e29961a8d05fcf2a9847e95aebae9003c8be";
+const page = 0;
+const maxResults = 1000;
+
+nep11.buildIteratorScript(account, contractHash, page, maxResults)
+  .then((script) => {
+    console.log(`Got script: ${script}`);
+  })
+  .catch((error) => {
+    console.log(`Error getting build iterator script: ${error}`);
+  });
+```

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "jest",
     "test:integration": "jest /packages/.*/__integration__/.*",
     "test:unit": "jest /packages/.*/__tests__/.*",
+    "pip": "apt update && apt install python3-pip && apt install python3.7",
     "boa": "pip3 install neo-boa"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start": "jest --watch",
     "test": "jest",
     "test:integration": "jest /packages/.*/__integration__/.*",
-    "test:unit": "jest /packages/.*/__tests__/.*"
+    "test:unit": "jest /packages/.*/__tests__/.*",
+    "boa": "pip3 install neo-boa"
   },
   "devDependencies": {
     "@types/jest": "24.0.15",

--- a/packages/neon-nep11/__integration__/main.ts
+++ b/packages/neon-nep11/__integration__/main.ts
@@ -1,4 +1,4 @@
-import { wallet } from "@cityofzion/neon-core";
+import { logging, wallet } from "@cityofzion/neon-core";
 import {
   buildIteratorScript
 } from "../src/main";
@@ -11,6 +11,6 @@ describe("buildIteratorScript", () => {
       0,
       1000
     );
-    expect(avm).toBe('');
+    expect(avm).toBe('5dc56b14cef0c0fdcfe7838eff6ff104f9cdec29222975376a00527ac408746f6b656e734f666a00c351c176c97ce10102bec80390aeeb5ae947982acf5fd0a86199e238c96a51527ac4006a52527ac400c176c96a53527ac402e8036a54527ac4006a54c3956a55527ac461616a51c368134e656f2e456e756d657261746f722e4e6578746441006a52c36a54c39f6437006a52c36a55c3a2641f006a53c36a51c368124e656f2e4974657261746f722e56616c756561c8616a52c351936a52527ac462a9ff6161616a53c36c7566');
   });
 });

--- a/packages/neon-nep11/__integration__/main.ts
+++ b/packages/neon-nep11/__integration__/main.ts
@@ -1,0 +1,16 @@
+import { wallet } from "@cityofzion/neon-core";
+import {
+  buildIteratorScript
+} from "../src/main";
+
+describe("buildIteratorScript", () => {
+  test("buildIteratorScript with contract", async () => {
+    const avm = await buildIteratorScript(
+      new wallet.Account("ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW"),
+      "c938e29961a8d05fcf2a9847e95aebae9003c8be",
+      0,
+      1000
+    );
+    expect(avm).toBe('');
+  });
+});

--- a/packages/neon-nep11/build-script.py
+++ b/packages/neon-nep11/build-script.py
@@ -1,0 +1,50 @@
+try:
+    from boa.compiler import Compiler
+    import tempfile
+    import sys
+
+    hsh = sys.argv[1]
+    address = sys.argv[2]
+    index = int(sys.argv[3])
+    limit = int(sys.argv[4])
+
+    beginning = """
+from boa.interop.Neo.App import RegisterAppCall
+from boa.interop.Neo.Iterator import Iterator
+
+enumerate = RegisterAppCall("""
+
+    middle = """, 'operation', 'args')
+
+def Main():
+    address = """
+
+    end = """
+    token_iter = enumerate('tokensOf', [address])
+    count = 0
+    result = []
+    limit = """
+
+    num = """
+    start = """ + str(index) + """ * limit
+
+    """
+
+    nxt = """while token_iter.next() and (count < limit):
+        if count >= start:
+            result.append(token_iter.Value)
+        count += 1
+    return result"""
+    script = beginning + "'" + hsh + "'" + middle + str(bytearray.fromhex(address)) + end + str(limit) + num + nxt
+
+    tp = tempfile.NamedTemporaryFile()
+    tp.write(str.encode(script))
+    tp.flush()
+    compiler = Compiler.load(tp.name)
+    avm = compiler.write()
+    avm = avm.hex()
+    print(avm)
+    sys.stdout.flush()
+except Exception as exception:
+    print(exception)
+    sys.stdout.flush()

--- a/packages/neon-nep11/jest.config.js
+++ b/packages/neon-nep11/jest.config.js
@@ -1,0 +1,4 @@
+const config = require("../../jest.config");
+config.globals["ts-jest"]["tsConfig"] = "../../tsconfig-test.json";
+config.testRegex = "./(__(tests|integration)__/.*)\\.ts$";
+module.exports = config;

--- a/packages/neon-nep11/package.json
+++ b/packages/neon-nep11/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@cityofzion/neon-nep11",
+  "description": "Neon-NEP11 Module",
+  "version": "4.7.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CityOfZion/neon-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "neo",
+    "antshares",
+    "javascript",
+    "libraries"
+  ],
+  "author": "Wyatt Mufson <wyatt@ryu.games> (https://github.com/wyattmufson)",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "dist:prod": "tsc -m commonjs --outDir dist",
+    "clean": "rimraf ./lib ./dist tsconfig.tsbuildinfo",
+    "prepublishOnly": "yarn clean && yarn build && yarn dist:prod",
+    "lint": "eslint src/**/*.ts __tests__/**/*.ts __integration__/**/*.ts",
+    "pretty": "prettier --write --loglevel=warn \"./{src,__{tests,integration}__}/**/*.ts\"",
+    "start": "jest --watch",
+    "test": "jest",
+    "test:integration": "jest /packages/.*/__integration__/.*",
+    "test:unit": "jest /packages/.*/__tests__/.*"
+  },
+  "dependencies": {
+    "@cityofzion/neon-core": "^4.7.0"
+  },
+  "peerDependencies": {
+    "@cityofzion/neon-core": "^4.0.0"
+  },
+  "files": [
+    "dist/",
+    "lib/"
+  ],
+  "gitHead": "d21633d03deca1f4bc6c3a4f4e1d32a61aec2fe3"
+}

--- a/packages/neon-nep11/src/index.ts
+++ b/packages/neon-nep11/src/index.ts
@@ -1,0 +1,11 @@
+import * as _Neon from "@cityofzion/neon-core";
+import * as nep11 from "./plugin";
+
+function bundle<T extends typeof _Neon>(
+  neonCore: T
+): T & { nep5: typeof nep11 } {
+  return { ...(neonCore as any), nep11 };
+}
+
+export default bundle;
+export * from "./plugin";

--- a/packages/neon-nep11/src/index.ts
+++ b/packages/neon-nep11/src/index.ts
@@ -3,7 +3,7 @@ import * as nep11 from "./plugin";
 
 function bundle<T extends typeof _Neon>(
   neonCore: T
-): T & { nep5: typeof nep11 } {
+): T & { nep11: typeof nep11 } {
   return { ...(neonCore as any), nep11 };
 }
 

--- a/packages/neon-nep11/src/main.ts
+++ b/packages/neon-nep11/src/main.ts
@@ -1,4 +1,4 @@
-import { logging, wallet } from "@cityofzion/neon-core";
+import { logging, wallet, u } from "@cityofzion/neon-core";
 const path = require('path');
 const { spawn } = require('child_process');
 
@@ -19,9 +19,10 @@ export async function buildIteratorScript(
 ): Promise<string> {
   return new Promise((resolve) => {
     const { scriptHash } = account;
+    const reversed = u.reverseHex(scriptHash);
 
     const file = path.join(__dirname, '../build-script.py');
-    const pythonProcess = spawn('python3', [file, contractHash, scriptHash, page, maxResults]);
+    const pythonProcess = spawn('python3', [file, contractHash, reversed, page, maxResults]);
     pythonProcess.stdout.on('data', (data: any) => {
       let script = data.toString('utf8');
       script = script.replace(/^\s+|\s+$/g, '');

--- a/packages/neon-nep11/src/main.ts
+++ b/packages/neon-nep11/src/main.ts
@@ -1,0 +1,33 @@
+import { wallet } from "@cityofzion/neon-core";
+
+const log = logging.default("nep11");
+
+/**
+ * Creates a Iterator script for the tokensOf method of a NEP-11 contract
+ * @param account The account to query.
+ * @param contractHash The hash of the contract.
+ * @param page The page to check.
+ * @parap maxResults The maximum amount of items to retrieve at a time.
+ */
+export async function buildIteratorScript(
+  account: wallet.Account,
+  contractHash: string,
+  page: int,
+  maxResults: int
+): Promise<string> {
+  return new Promise((resolve) => {
+    const { scriptHash } = account;
+
+    const file = path.join(__dirname, 'load.py');
+    const pythonProcess = spawn('python3', [file, contractHash, scriptHash, page, maxResults]);
+    pythonProcess.stdout.on('data', (data) => {
+      let script = data.toString('utf8');
+      script = script.replace(/^\s+|\s+$/g, '');
+      resolve(script);
+    });
+
+    setTimeout(() => {
+      resolve('');
+    }, 7000);
+  }
+}

--- a/packages/neon-nep11/src/main.ts
+++ b/packages/neon-nep11/src/main.ts
@@ -1,4 +1,6 @@
-import { wallet } from "@cityofzion/neon-core";
+import { logging, wallet } from "@cityofzion/neon-core";
+const path = require('path');
+const { spawn } = require('child_process');
 
 const log = logging.default("nep11");
 
@@ -12,15 +14,15 @@ const log = logging.default("nep11");
 export async function buildIteratorScript(
   account: wallet.Account,
   contractHash: string,
-  page: int,
-  maxResults: int
+  page: number,
+  maxResults: number
 ): Promise<string> {
   return new Promise((resolve) => {
     const { scriptHash } = account;
 
-    const file = path.join(__dirname, 'load.py');
+    const file = path.join(__dirname, '../build-script.py');
     const pythonProcess = spawn('python3', [file, contractHash, scriptHash, page, maxResults]);
-    pythonProcess.stdout.on('data', (data) => {
+    pythonProcess.stdout.on('data', (data: any) => {
       let script = data.toString('utf8');
       script = script.replace(/^\s+|\s+$/g, '');
       resolve(script);
@@ -29,5 +31,5 @@ export async function buildIteratorScript(
     setTimeout(() => {
       resolve('');
     }, 7000);
-  }
+  });
 }

--- a/packages/neon-nep11/src/plugin.ts
+++ b/packages/neon-nep11/src/plugin.ts
@@ -1,0 +1,3 @@
+import { buildIteratorScript } from "./main";
+
+export { buildIteratorScript };

--- a/packages/neon-nep11/tsconfig.json
+++ b/packages/neon-nep11/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "references": [{ "path": "../neon-core" }],
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "./packages/neon-api" },
     { "path": "./packages/neon-nep5" },
     { "path": "./packages/neon-nep9" },
+    { "path": "./packages/neon-nep11" },
     { "path": "./packages/neon-js" },
     { "path": "./packages/neon-domain" }
   ]


### PR DESCRIPTION
I added a nep11 package with a `buildIteratorScript` method.

It takes four arguments, `account: wallet.Account`,  `contractHash: string`, `page: number`, and `maxResults: number`.

It creates a post script for the nep11 `tokensOf` method by using the neo-boa compiler to compile a dynamically created script to an avm string. When https://github.com/CityOfZion/neo-boa/pull/119 is merged in, it can be updated to not require the use of tempfile and to just use the neo-boa builtin method.

This will resolve #437