### PR TITLE
fix(rpc): RpcClient to reject promise with Error

### DIFF
--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -227,14 +227,14 @@ describe("execute", () => {
     expect(result).toBe(expected);
   });
 
-  test("basic error", () => {
+  test("basic error", async () => {
     const url = "testUrl";
     const expected = jest.fn();
     axios.post.mockImplementationOnce(() =>
       Promise.resolve({ error: { message: expected } })
     );
     const result = Query.getVersion().execute(url);
-    expect(result).rejects.toThrow();
+    await expect(result).rejects.toThrow();
   });
 
   test("cannot re-query", async () => {
@@ -243,7 +243,7 @@ describe("execute", () => {
     const q = Query.getVersion();
     const r1 = await q.execute(url);
     const r2 = q.execute(url);
-    expect(r2).rejects.toThrow("This request has been sent");
+    await expect(r2).rejects.toThrow("This request has been sent");
   });
 
   test("calls parser when successful", async () => {

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -336,13 +336,13 @@ export class Query {
     config: AxiosRequestConfig = {}
   ): Promise<any> {
     if (this.completed) {
-      return Promise.reject("This request has been sent");
+      throw new Error("This request has been sent");
     }
     const response = await queryRPC(url, this.req, config);
     this.res = response;
     this.completed = true;
     if (response.error) {
-      return Promise.reject(`${url}: ${response.error.message}`);
+      throw new Error(`${url}: ${response.error.message}`);
     }
     if (this.parse) {
       log.info(`Query[${this.req.method}] successful`);


### PR DESCRIPTION
- Instead of rejecting with string, reject with Error.
- Update code to use throw with async syntax