### PR TITLE
feat(tx): Use HexString class in tx

### DIFF
--- a/packages/neon-api/__tests__/transaction/builder.ts
+++ b/packages/neon-api/__tests__/transaction/builder.ts
@@ -106,7 +106,7 @@ describe("setter", () => {
         }
       )
       .build();
-    expect(transaction.script).toBe(
+    expect(transaction.script.toBigEndian()).toBe(
       "525152c1047465737414f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec68627d5b5214bd8bf7f95e33415fc242c48d143694a729172d9f51c10962616c616e63654f66149f2d1729a79436148dc442c25f41335ef9f78bbd68627d5b52"
     );
   });

--- a/packages/neon-api/__tests__/transaction/signer.ts
+++ b/packages/neon-api/__tests__/transaction/signer.ts
@@ -27,7 +27,7 @@ const MULTISIG_ACCOUNT = wallet.Account.createMultiSig(
   ACCOUNTS.map(account => account.publicKey)
 );
 
-const createTransactionSigner = (): TransactionSigner => {
+function createTransactionSigner(): TransactionSigner {
   return new TransactionSigner(
     new TransactionBuilder({
       nonce: 1,
@@ -44,7 +44,7 @@ const createTransactionSigner = (): TransactionSigner => {
       ]
     }).build()
   );
-};
+}
 
 describe("signWithAccount", () => {
   test("single private key", () => {

--- a/packages/neon-api/src/transaction/signer.ts
+++ b/packages/neon-api/src/transaction/signer.ts
@@ -61,7 +61,9 @@ export class TransactionSigner {
   }
 
   private _checkWitness(witness: tx.Witness): void {
-    this._assertShouldSign(u.reverseHex(u.hash160(witness.verificationScript)));
+    this._assertShouldSign(
+      u.reverseHex(u.hash160(witness.verificationScript.toBigEndian()))
+    );
   }
 
   private _checkMultisigAcc(multisigAcc: wallet.Account): void {
@@ -78,7 +80,7 @@ export class TransactionSigner {
     return [
       this.transaction.sender,
       ...this.transaction.cosigners.map(cosigner => cosigner.account)
-    ].map(hash => u.reverseHex(hash));
+    ].map(hash => u.reverseHex(hash.toBigEndian()));
   }
 
   private _assertShouldSign(scriptHash: string): void {

--- a/packages/neon-api/src/transaction/util.ts
+++ b/packages/neon-api/src/transaction/util.ts
@@ -29,7 +29,9 @@ export function getNetworkFeeForMultiSig(
 function getVerificationScriptsFromWitnesses(
   transaction: tx.Transaction
 ): Array<string> {
-  return transaction.scripts.map(witness => witness.verificationScript);
+  return transaction.scripts.map(witness =>
+    witness.verificationScript.toBigEndian()
+  );
 }
 
 function isMultiSig(verificationScript: string): boolean {
@@ -69,7 +71,9 @@ export function getScriptHashesFromTxWitnesses(
   transaction.scripts.forEach(script =>
     scriptHashes.push(
       ...wallet
-        .getPublicKeysFromVerificationScript(script.verificationScript)
+        .getPublicKeysFromVerificationScript(
+          script.verificationScript.toBigEndian()
+        )
         .map(publicKey => wallet.getScriptHashFromPublicKey(publicKey))
     )
   );

--- a/packages/neon-api/src/transaction/validator.ts
+++ b/packages/neon-api/src/transaction/validator.ts
@@ -121,7 +121,7 @@ export class TransactionValidator {
    */
   public async validateScript(): Promise<ValidationResult> {
     const { state } = await this.rpcClient.invokeScript(
-      this.transaction.script
+      this.transaction.script.toBigEndian()
     );
     if (state === "FAULT") {
       return {
@@ -136,7 +136,7 @@ export class TransactionValidator {
     }
 
     const intents = new sc.ScriptParser(
-      this.transaction.script
+      this.transaction.script.toBigEndian()
     ).toScriptParams();
     const intentsRes: Array<string> = [];
     await Promise.all(
@@ -220,7 +220,7 @@ export class TransactionValidator {
     const {
       state,
       gas_consumed: gasConsumed
-    } = await this.rpcClient.invokeScript(script);
+    } = await this.rpcClient.invokeScript(script.toBigEndian());
 
     if (state === "FAULT") {
       return {

--- a/packages/neon-core/__tests__/tx/components/Cosigner.ts
+++ b/packages/neon-core/__tests__/tx/components/Cosigner.ts
@@ -49,7 +49,7 @@ describe("add methods", () => {
       "a1760976db5fcdfab2a9930e8f6ce875b2d18225"
     );
     expect(!!(cosigner.scopes & WitnessScope.CustomContracts)).toBeTruthy();
-    expect(cosigner.allowedContracts).toStrictEqual([
+    expect(cosigner.allowedContracts.map(i => i.toBigEndian())).toStrictEqual([
       "43cf98eddbe047e198a3e5d57006311442a0ca15",
       "a1760976db5fcdfab2a9930e8f6ce875b2d18225"
     ]);
@@ -63,7 +63,7 @@ describe("add methods", () => {
       "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef"
     );
     expect(!!(cosigner.scopes & WitnessScope.CustomGroups)).toBeTruthy();
-    expect(cosigner.allowedGroups).toStrictEqual([
+    expect(cosigner.allowedGroups.map(i => i.toBigEndian())).toStrictEqual([
       "031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c9",
       "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef"
     ]);

--- a/packages/neon-core/__tests__/tx/components/TransactionAttribute.ts
+++ b/packages/neon-core/__tests__/tx/components/TransactionAttribute.ts
@@ -26,7 +26,7 @@ describe("constructor", () => {
     const result = new TransactionAttribute(testObject);
     expect(result instanceof TransactionAttribute).toBeTruthy();
     expect(result.usage).toEqual(testObject.usage);
-    expect(result.data).toEqual(testObject.data);
+    expect(result.data.toBigEndian()).toEqual(testObject.data);
   });
 
   test("TransactionAttributeLike (str usage)", () => {
@@ -38,7 +38,7 @@ describe("constructor", () => {
     const result = new TransactionAttribute(testObject);
     expect(result instanceof TransactionAttribute).toBeTruthy();
     expect(result.usage).toEqual(129);
-    expect(result.data).toEqual(testObject.data);
+    expect(result.data.toBigEndian()).toEqual(testObject.data);
   });
 
   test("TransactionAttributeLike (data not in hex)", () => {
@@ -65,7 +65,7 @@ describe("constructor", () => {
     const result = TransactionAttribute.Url("http://url");
     expect(result instanceof TransactionAttribute).toBeTruthy();
     expect(result.usage).toEqual(129);
-    expect(result.data).toEqual("687474703a2f2f75726c");
+    expect(result.data.toBigEndian()).toEqual("687474703a2f2f75726c");
   });
 });
 
@@ -102,9 +102,9 @@ describe("equals", () => {
   ])(
     "%s",
     (
-      msg: string,
+      _msg: string,
       a: TransactionAttribute,
-      b: Partial<TransactionAttributeLike>,
+      b: TransactionAttributeLike,
       cond: boolean
     ) => {
       expect(a.equals(b)).toBe(cond);

--- a/packages/neon-core/__tests__/tx/components/Witness.ts
+++ b/packages/neon-core/__tests__/tx/components/Witness.ts
@@ -17,8 +17,12 @@ describe("constructor", () => {
 
     const result = new Witness(testObject);
     expect(result instanceof Witness).toBeTruthy();
-    expect(result.invocationScript).toEqual(testObject.invocationScript);
-    expect(result.verificationScript).toEqual(testObject.verificationScript);
+    expect(result.invocationScript.toBigEndian()).toEqual(
+      testObject.invocationScript
+    );
+    expect(result.verificationScript.toBigEndian()).toEqual(
+      testObject.verificationScript
+    );
   });
 
   test("Witness", () => {
@@ -30,7 +34,8 @@ describe("constructor", () => {
     const result = new Witness(testObject);
     expect(result instanceof Witness).toBeTruthy();
     expect(result).not.toBe(testObject);
-    expect(result).toEqual(testObject);
+    expect(result.invocationScript).toEqual(testObject.invocationScript);
+    expect(result.verificationScript).toEqual(testObject.verificationScript);
   });
 });
 
@@ -68,8 +73,8 @@ describe("equals", () => {
     verificationScript: "cd"
   };
   const obj2: WitnessLike = {
-    invocationScript: "fg",
-    verificationScript: "hi"
+    invocationScript: "ef",
+    verificationScript: "12"
   };
   const witness1 = new Witness(obj1);
   const witness2 = new Witness(obj2);
@@ -103,7 +108,7 @@ const dataSet = [
 describe("serialize", () => {
   test.each(dataSet)(
     "%s",
-    (msg: string, data: WitnessLike, expected: string) => {
+    (_msg: string, data: WitnessLike, expected: string) => {
       const result = new Witness(data);
       expect(result.serialize()).toBe(expected);
     }
@@ -113,7 +118,7 @@ describe("serialize", () => {
 describe("deserialize", () => {
   test.each(dataSet)(
     "%s",
-    (msg: string, expected: WitnessLike, data: string) => {
+    (_msg: string, expected: WitnessLike, data: string) => {
       const result = Witness.deserialize(data);
       expect(result.export()).toEqual(expected);
     }
@@ -206,8 +211,12 @@ describe("buildMultiSig", () => {
     ) => {
       const result = Witness.buildMultiSig(tx, sigs, vScript);
 
-      expect(result.verificationScript).toEqual(verificationScript);
-      expect(result.invocationScript).toEqual(expectedInvocationScript);
+      expect(result.verificationScript.toBigEndian()).toEqual(
+        verificationScript
+      );
+      expect(result.invocationScript.toBigEndian()).toEqual(
+        expectedInvocationScript
+      );
     }
   );
 

--- a/packages/neon-core/__tests__/tx/transaction/Transaction.ts
+++ b/packages/neon-core/__tests__/tx/transaction/Transaction.ts
@@ -12,7 +12,7 @@ describe("constructor", () => {
     expect(result.validUntilBlock).toBeDefined();
     expect(result.systemFee.toNumber()).toBe(0);
     expect(result.networkFee.toNumber()).toBe(0);
-    expect(result.script).toEqual("");
+    expect(result.script.toBigEndian()).toEqual("");
   });
 
   test("TransactionLike", () => {
@@ -32,7 +32,7 @@ describe("constructor", () => {
     expect(result.validUntilBlock).toBe(testObject.validUntilBlock);
     expect(result.systemFee.toNumber()).toBe(testObject.systemFee);
     expect(result.networkFee.toNumber()).toBe(testObject.networkFee);
-    expect(result.script).toEqual(testObject.script);
+    expect(result.script.toBigEndian()).toEqual(testObject.script);
   });
 
   test("Transaction", () => {
@@ -46,7 +46,7 @@ describe("constructor", () => {
     const result = new Transaction(testObject);
     expect(result instanceof Transaction).toBeTruthy();
     expect(result).not.toBe(testObject);
-    expect(result.script).toBe(testObject.script);
+    expect(result.script).toStrictEqual(testObject.script);
     expect(result.scripts[0]).not.toBe(testObject.scripts[0]);
   });
 });
@@ -172,7 +172,7 @@ describe("Add Methods", () => {
       account: "9b58c48f384a4cf14d98c97fc09a9ba9c42d0e26",
       scopes: WitnessScope.Global
     });
-    expect(tx1.cosigners[0].account).toBe(
+    expect(tx1.cosigners[0].account.toBigEndian()).toBe(
       "9b58c48f384a4cf14d98c97fc09a9ba9c42d0e26"
     );
     expect(tx1.cosigners[0].scopes).toBe(WitnessScope.Global);
@@ -191,7 +191,7 @@ describe("Add Methods", () => {
       data: "72e9a2"
     });
     expect(tx1.attributes[0].usage).toBe(129);
-    expect(tx1.attributes[0].data).toBe("72e9a2");
+    expect(tx1.attributes[0].data.toBigEndian()).toBe("72e9a2");
   });
 
   test("addWitness", () => {
@@ -201,8 +201,8 @@ describe("Add Methods", () => {
       verificationScript:
         "210317595a739cfe90ea90b6392814bcdebcd4c920cb149d0ac2d88676f1b0894fba68747476aa"
     });
-    expect(tx1.scripts[0].invocationScript).toBe("ab");
-    expect(tx1.scripts[0].verificationScript).toBe(
+    expect(tx1.scripts[0].invocationScript.toBigEndian()).toBe("ab");
+    expect(tx1.scripts[0].verificationScript.toBigEndian()).toBe(
       "210317595a739cfe90ea90b6392814bcdebcd4c920cb149d0ac2d88676f1b0894fba68747476aa"
     );
   });
@@ -214,10 +214,10 @@ describe("Add Methods", () => {
     );
     tx1.scripts = [];
     tx1.sign(account);
-    expect(tx1.scripts[0].verificationScript).toBe(
+    expect(tx1.scripts[0].verificationScript.toBigEndian()).toBe(
       "210317595a739cfe90ea90b6392814bcdebcd4c920cb149d0ac2d88676f1b0894fba68747476aa"
     );
-    expect(tx1.scripts[0].invocationScript).toBe(
+    expect(tx1.scripts[0].invocationScript.toBigEndian()).toBe(
       "40ab51e521a287dfeb83a51b1444ca31fbdc88d2181c156e65d30b3423d24bed693feb5ac8511c24efd766c664a3b09ec9cf2e24588226aab16175d84dc0fcbeea"
     );
   });

--- a/packages/neon-core/src/tx/components/TransactionAttribute.ts
+++ b/packages/neon-core/src/tx/components/TransactionAttribute.ts
@@ -1,10 +1,4 @@
-import {
-  num2hexstring,
-  num2VarInt,
-  StringStream,
-  ensureHex,
-  str2hexstring
-} from "../../u";
+import { num2hexstring, num2VarInt, StringStream, HexString } from "../../u";
 import { TxAttrUsage } from "./txAttrUsage";
 import { NeonObject } from "../../model";
 
@@ -56,16 +50,17 @@ export class TransactionAttribute
   /**
    * @description data in hex format
    */
-  public data: string;
+  public data: HexString;
 
-  public constructor(obj: TransactionAttributeLike) {
-    if (!obj || !obj.usage || !obj.data) {
+  public constructor(
+    obj: Partial<TransactionAttributeLike | TransactionAttribute> = {}
+  ) {
+    if (!obj.usage || !obj.data) {
       throw new Error("TransactionAttribute requires usage and data fields");
     }
     const { usage, data } = obj;
     this.usage = toTxAttrUsage(usage);
-    ensureHex(data);
-    this.data = data;
+    this.data = HexString.fromHex(data);
   }
 
   /**
@@ -74,7 +69,7 @@ export class TransactionAttribute
   public static Url(url: string): TransactionAttribute {
     return new TransactionAttribute({
       usage: TxAttrUsage.Url,
-      data: str2hexstring(url)
+      data: HexString.fromAscii(url)
     });
   }
 
@@ -95,13 +90,16 @@ export class TransactionAttribute
   public export(): TransactionAttributeLike {
     return {
       usage: this.usage,
-      data: this.data
+      data: this.data.toBigEndian()
     };
   }
 
-  public equals(other: TransactionAttributeLike): boolean {
+  public equals(
+    other: Partial<TransactionAttributeLike | TransactionAttribute>
+  ): boolean {
     return (
-      this.usage === toTxAttrUsage(other.usage) && this.data === other.data
+      this.usage === toTxAttrUsage(other.usage ?? 0) &&
+      this.data.equals(other.data ?? "")
     );
   }
 }

--- a/packages/neon-core/src/u/HexString.ts
+++ b/packages/neon-core/src/u/HexString.ts
@@ -13,7 +13,11 @@ export class HexString {
    */
   private _value: string;
 
-  protected _checkValue(value: string): void {
+  public get length(): number {
+    return this._value.length;
+  }
+
+  public assert(value: string): void {
     ensureHex(value);
   }
 
@@ -26,8 +30,12 @@ export class HexString {
     if (value.startsWith("0x")) {
       value = value.slice(2);
     }
-    this._checkValue(value);
+    this.assert(value);
     this._value = littleEndian ? reverseHex(value) : value;
+  }
+
+  public toString(): string {
+    return this._value;
   }
 
   /**
@@ -48,7 +56,10 @@ export class HexString {
    * Judge if 2 HexString are equal
    * @param other
    */
-  public equals(other: HexString): boolean {
+  public equals(other: HexString | string): boolean {
+    if (typeof other === "string") {
+      return this.toBigEndian() === HexString.fromHex(other).toBigEndian();
+    }
     return this.toBigEndian() === other.toBigEndian();
   }
 
@@ -93,7 +104,15 @@ export class HexString {
    * @param str hex string
    * @param littleEndian whether `str` is little endian
    */
-  public static fromHex(str: string, littleEndian = false): HexString {
+  public static fromHex(str: string, littleEndian: boolean): HexString;
+  public static fromHex(str: string | HexString): HexString;
+  public static fromHex(
+    str: string | HexString,
+    littleEndian = false
+  ): HexString {
+    if (typeof str === "object" && str instanceof HexString) {
+      return new HexString(str.toBigEndian());
+    }
     return new HexString(str, littleEndian);
   }
 


### PR DESCRIPTION
This replaces the hexstring fields in the tx folder to use HexString class in u. This should allow more checking and easier development on our side. It also gives us easy 0x stripping, hex checks and removes endian knowledge.

One downside is that it is slightly more messy to write tests. Just like the Fixed8 construct, the string is hidden and we have to keep calling equal or toBigEndian to test the inner values.