### PR TITLE
[fix] networkFee calculation is not right in validateNetworkFee.

### DIFF
--- a/packages/neon-api/src/transaction/util.ts
+++ b/packages/neon-api/src/transaction/util.ts
@@ -1,36 +1,31 @@
 import { tx, wallet, u, sc, CONST } from "@cityofzion/neon-core";
 
-export function getNetworkFeeForSig(): number {
-  return (
+export function getNetworkFeeForSig(): u.Fixed8 {
+  return new u.Fixed8(
     sc.OpCodePrices[sc.OpCode.PUSHBYTES64] +
-    sc.OpCodePrices[sc.OpCode.PUSHBYTES33] +
-    sc.getInteropServicePrice(sc.InteropServiceCode.NEO_CRYPTO_CHECKSIG)
+      sc.OpCodePrices[sc.OpCode.PUSHBYTES33] +
+      sc.getInteropServicePrice(sc.InteropServiceCode.NEO_CRYPTO_CHECKSIG)
   );
 }
 
 export function getNetworkFeeForMultiSig(
   signingThreshold: number,
   pubkeysNum: number
-): number {
+): u.Fixed8 {
   const sb = new sc.ScriptBuilder();
-  return (
+  return new u.Fixed8(
     sc.OpCodePrices[sc.OpCode.PUSHBYTES64] * signingThreshold +
-    sc.OpCodePrices[
-      sb.emitPush(signingThreshold).str.slice(0, 2) as sc.OpCode
-    ] +
-    sc.OpCodePrices[sc.OpCode.PUSHBYTES33] * pubkeysNum +
-    sc.OpCodePrices[sb.emitPush(pubkeysNum).str.slice(0, 2) as sc.OpCode] +
-    sc.getInteropServicePrice(sc.InteropServiceCode.NEO_CRYPTO_CHECKMULTISIG, {
-      size: pubkeysNum
-    })
-  );
-}
-
-function getVerificationScriptsFromWitnesses(
-  transaction: tx.Transaction
-): Array<string> {
-  return transaction.scripts.map(witness =>
-    witness.verificationScript.toBigEndian()
+      sc.OpCodePrices[
+        sb.emitPush(signingThreshold).str.slice(0, 2) as sc.OpCode
+      ] +
+      sc.OpCodePrices[sc.OpCode.PUSHBYTES33] * pubkeysNum +
+      sc.OpCodePrices[sb.emitPush(pubkeysNum).str.slice(0, 2) as sc.OpCode] +
+      sc.getInteropServicePrice(
+        sc.InteropServiceCode.NEO_CRYPTO_CHECKMULTISIG,
+        {
+          size: pubkeysNum
+        }
+      )
   );
 }
 
@@ -41,25 +36,39 @@ function isMultiSig(verificationScript: string): boolean {
   );
 }
 
-export function getNetworkFee(transaction: tx.Transaction): u.Fixed8 {
+export function getNetworkFee(
+  transaction: tx.Transaction,
+  verificationScripts: Array<string>
+): u.Fixed8 {
   let networkFee = new u.Fixed8(0e-8);
-  const verificationScripts = getVerificationScriptsFromWitnesses(transaction);
+  let size = transaction.serialize().length / 2;
   verificationScripts.forEach(verificationScript => {
-    if (isMultiSig(verificationScript)) {
+    if (!isMultiSig(verificationScript)) {
       networkFee = networkFee.add(getNetworkFeeForSig());
+      size +=
+        66 +
+        (u.num2VarInt(verificationScript.length / 2) + verificationScript)
+          .length /
+          2;
     } else {
       const n = wallet.getPublicKeysFromVerificationScript(verificationScript)
         .length;
       const m = wallet.getSigningThresholdFromVerificationScript(
         verificationScript
       );
+      const sizeInv = 66 * m;
+      size +=
+        u.num2VarInt(sizeInv).length / 2 +
+        sizeInv +
+        (u.num2VarInt(verificationScript.length / 2) + verificationScript)
+          .length /
+          2;
       networkFee = networkFee.add(getNetworkFeeForMultiSig(m, n));
     }
     // TODO: consider about contract verfication script
   });
-  const size = transaction.serialize(true).length / 2;
   networkFee = networkFee.add(
-    new u.Fixed8(size).multipliedBy(CONST.POLICY_FEE_PERBYTE)
+    new u.Fixed8(CONST.POLICY_FEE_PERBYTE).times(size)
   );
   return networkFee;
 }


### PR DESCRIPTION
- Bug 
Networkfee calculation is based on the witnesses(signatures) of the transaction.
However the signatures are invalid before networkFee is set, so validation(calculation) of networkFee should be done before signing the transaction.
- Fix
validateNetworkFee API needs param `signers` - accounts that will sign this transaction.
