### PR TITLE
chore(npm): Upgrade elliptic to v6.5.2

### DIFF
--- a/packages/neon-core/package.json
+++ b/packages/neon-core/package.json
@@ -46,7 +46,7 @@
     "bs58": "4.0.1",
     "bs58check": "2.1.2",
     "crypto-js": "3.1.9-1",
-    "elliptic": "6.4.1",
+    "elliptic": "6.5.2",
     "loglevel": "1.6.4",
     "loglevel-plugin-prefix": "0.8.4",
     "scrypt-js": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3055,7 +3055,20 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-elliptic@6.4.1, elliptic@^6.0.0:
+elliptic@6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
+elliptic@^6.0.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
   integrity sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==


### PR DESCRIPTION
This PR upgrades the `elliptic` package to it's latest version.