### PR TITLE
fix(sc): Fix emitAppCall with only scriptHash

### DIFF
--- a/packages/neon-core/__tests__/sc/ScriptBuilder.ts
+++ b/packages/neon-core/__tests__/sc/ScriptBuilder.ts
@@ -116,6 +116,13 @@ describe("emitAppCall", () => {
         useTailCall: false
       },
       "143775292229eccdf904f16fff8e83e7cffdc0f0ce51c10962616c616e63654f666711c4d1f4fba619f2628870d36e3a9773e874705b"
+    ],
+    [
+      "emitAppCall with only scriptHash",
+      {
+        scriptHash: "5b7074e873973a6ed3708862f219a6fbf4d1c411"
+      },
+      "6711c4d1f4fba619f2628870d36e3a9773e874705b"
     ]
   ])("%s", (msg: string, data: any, expected: string) => {
     const sb = new ScriptBuilder();

--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -118,8 +118,10 @@ export class ScriptBuilder extends StringStream {
     args?: any[] | string | number | boolean,
     useTailCall = false
   ): this {
-    this.emitPush(args);
-    if (operation) {
+    if (args !== undefined) {
+      this.emitPush(args);
+    }
+    if (operation !== null) {
       let hexOp = "";
       for (let i = 0; i < operation.length; i++) {
         hexOp += num2hexstring(operation.charCodeAt(i));

--- a/packages/neon-nep5/__tests__/abi.ts
+++ b/packages/neon-nep5/__tests__/abi.ts
@@ -20,14 +20,14 @@ const toAddr = randomAddress();
 test("name", () => {
   const resultFunction = abi.name(scriptHash);
   const resultScript = resultFunction().str;
-  expect(resultScript).toBe(`00046e616d6567${u.reverseHex(scriptHash)}`);
+  expect(resultScript).toBe(`00c1046e616d6567${u.reverseHex(scriptHash)}`);
 });
 
 test("decimals", () => {
   const resultFunction = abi.decimals(scriptHash);
   const resultScript = resultFunction().str;
   expect(resultScript).toBe(
-    `0008646563696d616c7367${u.reverseHex(scriptHash)}`
+    `00c108646563696d616c7367${u.reverseHex(scriptHash)}`
   );
 });
 
@@ -35,7 +35,7 @@ test("totalSupply", () => {
   const resultFunction = abi.totalSupply(scriptHash);
   const resultScript = resultFunction().str;
   expect(resultScript).toBe(
-    `000b746f74616c537570706c7967${u.reverseHex(scriptHash)}`
+    `00c10b746f74616c537570706c7967${u.reverseHex(scriptHash)}`
   );
 });
 

--- a/packages/neon-nep5/src/abi.ts
+++ b/packages/neon-nep5/src/abi.ts
@@ -14,7 +14,7 @@ export function name(
   scriptHash: string
 ): (sb?: sc.ScriptBuilder) => sc.ScriptBuilder {
   return (sb = new sc.ScriptBuilder()) => {
-    return sb.emitAppCall(scriptHash, "name");
+    return sb.emitAppCall(scriptHash, "name", []);
   };
 }
 
@@ -28,7 +28,7 @@ export function symbol(
   scriptHash: string
 ): (sb?: sc.ScriptBuilder) => sc.ScriptBuilder {
   return (sb = new sc.ScriptBuilder()) => {
-    return sb.emitAppCall(scriptHash, "symbol");
+    return sb.emitAppCall(scriptHash, "symbol", []);
   };
 }
 
@@ -42,7 +42,7 @@ export function decimals(
   scriptHash: string
 ): (sb?: sc.ScriptBuilder) => sc.ScriptBuilder {
   return (sb = new sc.ScriptBuilder()) => {
-    return sb.emitAppCall(scriptHash, "decimals");
+    return sb.emitAppCall(scriptHash, "decimals", []);
   };
 }
 
@@ -56,7 +56,7 @@ export function totalSupply(
   scriptHash: string
 ): (sb?: sc.ScriptBuilder) => sc.ScriptBuilder {
   return (sb = new sc.ScriptBuilder()) => {
-    return sb.emitAppCall(scriptHash, "totalSupply");
+    return sb.emitAppCall(scriptHash, "totalSupply", []);
   };
 }
 

--- a/packages/neon-nep5/src/main.ts
+++ b/packages/neon-nep5/src/main.ts
@@ -63,12 +63,11 @@ export async function getTokenBalances(
   scriptHashArray: string[],
   address: string
 ): Promise<{ [symbol: string]: u.Fixed8 }> {
-  const addrScriptHash = u.reverseHex(wallet.getScriptHashFromAddress(address));
   const sb = new sc.ScriptBuilder();
   scriptHashArray.forEach(scriptHash => {
-    sb.emitAppCall(scriptHash, "symbol")
-      .emitAppCall(scriptHash, "decimals")
-      .emitAppCall(scriptHash, "balanceOf", [addrScriptHash]);
+    abi.symbol(scriptHash)(sb);
+    abi.decimals(scriptHash)(sb);
+    abi.balanceOf(scriptHash, address)(sb);
   });
 
   const res = await rpc.Query.invokeScript(sb.str).execute(url);
@@ -156,20 +155,12 @@ export async function getTokens(
   try {
     const sb = new sc.ScriptBuilder();
     scriptHashArray.forEach(scriptHash => {
+      abi.name(scriptHash)(sb);
+      abi.symbol(scriptHash)(sb);
+      abi.decimals(scriptHash)(sb);
+      abi.totalSupply(scriptHash)(sb);
       if (address) {
-        const addrScriptHash = u.reverseHex(
-          wallet.getScriptHashFromAddress(address)
-        );
-        sb.emitAppCall(scriptHash, "name")
-          .emitAppCall(scriptHash, "symbol")
-          .emitAppCall(scriptHash, "decimals")
-          .emitAppCall(scriptHash, "totalSupply")
-          .emitAppCall(scriptHash, "balanceOf", [addrScriptHash]);
-      } else {
-        sb.emitAppCall(scriptHash, "name")
-          .emitAppCall(scriptHash, "symbol")
-          .emitAppCall(scriptHash, "decimals")
-          .emitAppCall(scriptHash, "totalSupply");
+        abi.balanceOf(scriptHash, address)(sb);
       }
     });
 


### PR DESCRIPTION
fixes #502

Originally, the call to emitAppCall without any arguments will produce a script that will push a `00` at the start of the script. This can be seen as an error if the contract did not consume the parameter, leaving it in the stack.

By adding a check for undefined, we can prevent the `00` from appearing when no arguments are provided. This breaks existing behaviour for all scripts that rely on no arguments filling in an empty parameter. For example, standard NEP5 contracts will consume 2 variables off the stack. This fix will cause the old code to emit only a single variable and result in a fault when running the script.

This can be fixed by explicitly providing an empty array for args (which is what should happen anyway) which will prompt the ScriptBuilder to inject the appropriate variable onto the stack.

Fundamentally, this is a design fault in exposing the emitAppCall in such a fashion. The current defaults makes it difficult to adapt the method to be flexible enough for contracts that do not follow the convention of `Main(string, any[])`.