### PR TITLE
feat(wallet): Transition method for wallet from neo2 to neo3

### DIFF
--- a/packages/neon-core/__tests__/wallet/nep2.ts
+++ b/packages/neon-core/__tests__/wallet/nep2.ts
@@ -25,6 +25,25 @@ const simpleKeys = {
   }
 };
 
+const neo2Keys = {
+  a: {
+    wif: "L1QqQJnpBwbsPGAuutuzPTac8piqvbR1HRjrY5qHup48TBCBFe4g",
+    passphrase: "city of zion",
+    encryptedWif: "6PYLHmDf7R4im6NUF34MwcbViPpjwfdkrPMdFjuCXnEFmmK2A7AAzVAvTa"
+  },
+  b: {
+    wif: "L2QTooFoDFyRFTxmtiVHt5CfsXfVnexdbENGDkkrrgTTryiLsPMG",
+    passphrase: "我的密码",
+    encryptedWif: "6PYWVp3xerNdVMtSELSNZDBMP1qXrM1o6NrCQHqpeWLMd3rgeUE1rQuwrm"
+  },
+  c: {
+    wif: "KyKvWLZsNwBJx5j9nurHYRwhYfdQUu9tTEDsLCUHDbYBL8cHxMiG",
+    passphrase: "MyL33tP@33w0rd",
+    encryptedWif: "6PYNoc1EFvW5rJD2Tg6k24xEVGZ56sY1YN5NG2sSF1qUKHy47uEwTkdcYs"
+  }
+};
+
+// This uses default scrypt params
 const testKey = {
   wif: "L1QqQJnpBwbsPGAuutuzPTac8piqvbR1HRjrY5qHup48TBCBFe4g",
   passphrase: "city of zion",
@@ -52,27 +71,33 @@ describe("NEP2", () => {
     ["Basic", simpleKeys.a],
     ["Chinese", simpleKeys.b],
     ["Symbols", simpleKeys.c]
-  ])("%s", (msg: string, data: any) => {
-    test("encrypt", async () => {
-      const result = await NEP2.encrypt(
-        data.wif,
-        data.passphrase,
-        simpleScrypt
-      );
-      expect(isNEP2(result)).toBeTruthy();
-      expect(result).toBe(data.encryptedWif);
-    });
+  ])(
+    "%s",
+    (
+      msg: string,
+      data: { wif: string; encryptedWif: string; passphrase: string }
+    ) => {
+      test("encrypt", async () => {
+        const result = await NEP2.encrypt(
+          data.wif,
+          data.passphrase,
+          simpleScrypt
+        );
+        expect(isNEP2(result)).toBeTruthy();
+        expect(result).toBe(data.encryptedWif);
+      });
 
-    test("decrypt", async () => {
-      const result = await NEP2.decrypt(
-        data.encryptedWif,
-        data.passphrase,
-        simpleScrypt
-      );
-      expect(isWIF(result)).toBeTruthy();
-      expect(result).toBe(data.wif);
-    });
-  });
+      test("decrypt", async () => {
+        const result = await NEP2.decrypt(
+          data.encryptedWif,
+          data.passphrase,
+          simpleScrypt
+        );
+        expect(isWIF(result)).toBeTruthy();
+        expect(result).toBe(data.wif);
+      });
+    }
+  );
 
   describe("Error", () => {
     test("Errors on wrong password", () => {
@@ -93,3 +118,25 @@ describe("NEP2", () => {
     });
   });
 });
+
+describe.each([
+  ["Basic", neo2Keys.a],
+  ["Chinese", neo2Keys.b],
+  ["Symbols", neo2Keys.c]
+])(
+  "%s",
+  (
+    msg: string,
+    data: { wif: string; encryptedWif: string; passphrase: string }
+  ) => {
+    test("decrypt neo2 key", async () => {
+      const result = await NEP2.decryptNeo2(
+        data.encryptedWif,
+        data.passphrase,
+        simpleScrypt
+      );
+      expect(isWIF(result)).toBeTruthy();
+      expect(result).toBe(data.wif);
+    });
+  }
+);

--- a/packages/neon-core/src/wallet/index.ts
+++ b/packages/neon-core/src/wallet/index.ts
@@ -5,3 +5,4 @@ export * from "./verify";
 export * from "./signing";
 export * from "./Wallet";
 export * from "./multisig";
+export * from "./upgrade";

--- a/packages/neon-core/src/wallet/upgrade.ts
+++ b/packages/neon-core/src/wallet/upgrade.ts
@@ -1,0 +1,35 @@
+import Account from "./Account";
+import { decryptNeo2 } from "./nep2";
+import { DEFAULT_SCRYPT } from "../consts";
+
+/**
+ * Upgrades a Neo2 account to a Neo3 account. If an encrypted account is provided, the returned account is also encrypted with the same passphrase.
+ */
+export async function upgrade(
+  account: Account,
+  passphrase = "",
+  scryptParams = DEFAULT_SCRYPT
+): Promise<Account> {
+  // Checks that account is upgradable
+  if (!account.tryGet("privateKey") && passphrase === "") {
+    throw new Error(`The account needs an unencrypted private key.`);
+  }
+  // Check if address is neo2 style (Starts with A)
+  if (!account.address.startsWith("A")) {
+    throw new Error(`This is not a neo2 Address.`);
+  }
+
+  if (passphrase) {
+    const wifKey = await decryptNeo2(
+      account.encrypted,
+      passphrase,
+      scryptParams
+    );
+    const neo3Account = new Account(wifKey);
+    return await neo3Account.encrypt(passphrase, scryptParams);
+  }
+
+  const wifKey = account.WIF;
+  const neo3Account = new Account(wifKey);
+  return neo3Account;
+}

--- a/packages/neon-nep5/src/main.ts
+++ b/packages/neon-nep5/src/main.ts
@@ -1,4 +1,4 @@
-import { logging, rpc, sc, u, wallet } from "@cityofzion/neon-core";
+import { logging, rpc, sc, u } from "@cityofzion/neon-core";
 import * as abi from "./abi";
 const log = logging.default("nep5");
 


### PR DESCRIPTION
Add methods to allow conversion of neo2 wallet data to neo3 wallet. This only works with simple private key based accounts.