### PR TITLE
fix(rpc): Move timeout out of headers in RPCClient

### DIFF
--- a/packages/neon-core/src/rpc/RPCClient.ts
+++ b/packages/neon-core/src/rpc/RPCClient.ts
@@ -26,9 +26,9 @@ export async function sendQuery<TResponse>(
   const conf = Object.assign(
     {
       headers: {
-        "Content-Type": "application/json",
-        timeout: timeout.rpc
-      }
+        "Content-Type": "application/json"
+      },
+      timeout: timeout.rpc
     },
     config
   );


### PR DESCRIPTION
timeout was not supposed to be sent as headers but passed as configuration to axios.