### PR TITLE
feat(rpc): Update RPC to 3.0.0-preview2-00

### DIFF
--- a/packages/neon-core/__integration__/rpc/RPCClient.ts
+++ b/packages/neon-core/__integration__/rpc/RPCClient.ts
@@ -24,6 +24,7 @@ function safelyCheckHeight(url: string): Promise<number> {
     .then(res => res.result)
     .catch(_e => -1);
 }
+
 beforeAll(async () => {
   const heights = (
     await Promise.all(TESTNET_URLS.map(url => safelyCheckHeight(url)))
@@ -35,121 +36,121 @@ beforeAll(async () => {
   client = new rpc.RPCClient(best.url);
 });
 
-describe.skip("RPC Methods", () => {
-  describe("getBlock", () => {
-    const the100thBlockHash =
-      "000000003d8ee950672593017c40d8469571e3b1ad97a78dbaf3b1f41d3601f7a7f4d65f6f91255ed97c70a24d0a0cd2e23fc73c127f7b3fbe93b5efb973a54acb3f4091aa48063a6d010000640000003991af1bc2546596d3e129df102e2ac011d2ab5901fd4501405b10d7050286170b716e2c167b7cdf6b04a9985f20d5d5848617e27f4cb7a0ab1b93c85f4561f3aa6bbd5d1da15ceb1f1670a840239bbfa1acb598507834d0c040a38b8ad2d1e314e0f517947b3d9a7a9fa3a76a76c7c4846de75bddcb034ccd071ad9af2c581c2521acbe5ddab4bf1c04285819c16cfe5fba9d64d141571e6055400c56c276e4bed164781beb75f20d42e3744e0ae30125581da2cea1215655fadeacafb56c66b3f9c36b22ac25cc222d20e4a435608d801b7a7feac232c6520a2c40ce923ee4aff98a21e8640b56cb7c989a1568cecb2813b1ec8e13bb9b16e8f4fd4a9f53520c58d17f2dfc95efca4ab3158696e6b9fc4e4a79e4e9286cb338b9214021ae5c51c119e8b65fb5d78640b1161d722634b1dcee89f6252c88d393e9115fbfc3a0d52d2acd233d8de407b1840ae2462e6c0001a9da0babc56c37e04fc3bdf5552103009b7540e10f2562e5fd8fac9eaec25166a58b26e412348ff5a86927bfac22a221030205e9cefaea5a1dfc580af20c8d5aa2468bb0148f1a5e4605fc622c80e604ba210214baf0ceea3a66f17e7e1e839ea25fd8bed6cd82e6bb6e68250189065f44ff0121023e9b32ea89b94d066e649b124fd50e396ee91369e8e2a6ae1b11c170d022256d2103408dcd416396f64783ac587ea1e1593c57d9fea880c8a6a1920e92a2594778062102a7834be9b32e2981d157cb5bbd3acb42cfd11ea5c3b10224d7a44e98c5910f1b2102ba2c70f5996f357a43198705859fae2cfea13e1172962800772b3d588a9d4abd5768c7c34cba0102416f54b693afc926";
-    const the100thBlockJson = {
-      confirmations: 0,
-      consensusData: { nonce: "26c9af93b6546f41", primary: 2 },
-      hash:
-        "0x47383336f5bf76e4eb621484a58c4d2de064b28bc197000a7218177c77d4d1c8",
-      index: 100,
-      merkleroot:
-        "0x91403fcb4aa573b9efb593be3f7b7f123cc73fe2d20c0a4da2707cd95e25916f",
-      nextblockhash:
-        "0x890627674a48c530f53ddb20ff4a4552c18f0d2ac45f9dec72fa44abd1fe07ba",
-      nextconsensus: "AM2GgjcwzHDGGJP3FuizmmvEEL9re9V43M",
-      previousblockhash:
-        "0x5fd6f4a7f701361df4b1f3ba8da797adb1e3719546d8407c0193256750e98e3d",
-      size: 685,
-      time: 1568636553386,
-      tx: [],
-      version: 0,
-      witnesses: [
+describe("RPC Methods", () => {
+  const REFERENCE_BLOCK_HEADER = {
+    hash: "0x95380d2d8601a0e0d97fbe95c43cbc07e1d9ba6473ea5ddc39b8c381f3e3ae85",
+    size: 171,
+    version: 0,
+    previousblockhash:
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    merkleroot:
+      "0x97eaae7de20c8a28b26a85d1bc8e87034209c7ce59d3afabe411761971f2f542",
+    time: 1468595301000,
+    index: 0,
+    nextconsensus: "NRwdxuyAw559S3qomjSptn77EAJeVRcguV",
+    witnesses: [
+      {
+        invocation: "",
+        verification: "EQ=="
+      }
+    ],
+    // do not match confirmations
+    nextblockhash:
+      "0xcecd22244e794b9f97f45ed9c7b0e82262568b0cc3b285f9bcc04adc69f3b577"
+  };
+  const REFERENCE_BLOCK = Object.assign(
+    {
+      consensus_data: {
+        primary: 0,
+        nonce: "000000007c2bac1d"
+      },
+      tx: [
         {
-          invocation:
-            "405b10d7050286170b716e2c167b7cdf6b04a9985f20d5d5848617e27f4cb7a0ab1b93c85f4561f3aa6bbd5d1da15ceb1f1670a840239bbfa1acb598507834d0c040a38b8ad2d1e314e0f517947b3d9a7a9fa3a76a76c7c4846de75bddcb034ccd071ad9af2c581c2521acbe5ddab4bf1c04285819c16cfe5fba9d64d141571e6055400c56c276e4bed164781beb75f20d42e3744e0ae30125581da2cea1215655fadeacafb56c66b3f9c36b22ac25cc222d20e4a435608d801b7a7feac232c6520a2c40ce923ee4aff98a21e8640b56cb7c989a1568cecb2813b1ec8e13bb9b16e8f4fd4a9f53520c58d17f2dfc95efca4ab3158696e6b9fc4e4a79e4e9286cb338b9214021ae5c51c119e8b65fb5d78640b1161d722634b1dcee89f6252c88d393e9115fbfc3a0d52d2acd233d8de407b1840ae2462e6c0001a9da0babc56c37e04fc3bd",
-          verification:
-            "552103009b7540e10f2562e5fd8fac9eaec25166a58b26e412348ff5a86927bfac22a221030205e9cefaea5a1dfc580af20c8d5aa2468bb0148f1a5e4605fc622c80e604ba210214baf0ceea3a66f17e7e1e839ea25fd8bed6cd82e6bb6e68250189065f44ff0121023e9b32ea89b94d066e649b124fd50e396ee91369e8e2a6ae1b11c170d022256d2103408dcd416396f64783ac587ea1e1593c57d9fea880c8a6a1920e92a2594778062102a7834be9b32e2981d157cb5bbd3acb42cfd11ea5c3b10224d7a44e98c5910f1b2102ba2c70f5996f357a43198705859fae2cfea13e1172962800772b3d588a9d4abd5768c7c34cba"
+          hash:
+            "0x1e16f97be7fe8e9e2136dfdea37207fc27d2bc42661dd1feb6f37381233c44ad",
+          size: 57,
+          version: 0,
+          nonce: 0,
+          sender: "NeN4xPMn4kHoj7G8Lciq9oorgLTvqt4qi1",
+          sys_fee: "0",
+          net_fee: "0",
+          valid_until_block: 0,
+          attributes: [],
+          cosigners: [],
+          script: "QRI+f+g=",
+          witnesses: [
+            {
+              invocation: "",
+              verification: "EQ=="
+            }
+          ]
         }
       ]
-    };
+    },
+    REFERENCE_BLOCK_HEADER
+  );
+
+  describe("getBlock", () => {
     test("height as index, verbose = 0", async () => {
-      const result = await client.getBlock(100);
-      expect(result).toBe(the100thBlockHash);
+      const result = await client.getBlock(0);
+      expect(result).toBe(
+        "00000000000000000000000000000000000000000000000000000000000000000000000042f5f271197611e4abafd359cec7094203878ebcd1856ab2288a0ce27daeea9788ea19ef550100000000000042218a992bdd8b981607766347e1ae195c3959cd0100011102001dac2b7c000000000000000000ca61e52e881d41374e640f819cd118cc153b21a7000000000000000000000000000000000000000000000541123e7fe801000111"
+      );
+    });
+
+    test("height as index, verbose = true", async () => {
+      const result = await client.getBlock(0, true);
+      expect(result).toMatchObject(REFERENCE_BLOCK);
     });
 
     test("hash as index, verbose = 1", async () => {
       const result = await client.getBlock(
-        "47383336f5bf76e4eb621484a58c4d2de064b28bc197000a7218177c77d4d1c8",
+        "95380d2d8601a0e0d97fbe95c43cbc07e1d9ba6473ea5ddc39b8c381f3e3ae85",
         1
       );
-      expect(result["consensus_data"]).toStrictEqual(
-        the100thBlockJson.consensusData
-      );
+      expect(result).toMatchObject(REFERENCE_BLOCK);
     });
   });
 
   test("getBlockHash", async () => {
     const result = await client.getBlockHash(1);
-    expect(typeof result === "string").toBeTruthy();
+    expect(typeof result).toBe("string");
   });
 
   test("getBestBlockHash", async () => {
     const result = await client.getBestBlockHash();
-    expect(result).toBeDefined();
+    expect(typeof result).toBe("string");
   });
 
   test("getBlockCount", async () => {
     const result = await client.getBlockCount();
-    expect(typeof result === "number").toBeTruthy();
+    expect(typeof result).toBe("number");
   });
 
   describe("getBlockHeader", () => {
-    const the100thBlockHeaderHash =
-      "000000003d8ee950672593017c40d8469571e3b1ad97a78dbaf3b1f41d3601f7a7f4d65f6f91255ed97c70a24d0a0cd2e23fc73c127f7b3fbe93b5efb973a54acb3f4091aa48063a6d010000640000003991af1bc2546596d3e129df102e2ac011d2ab5901fd4501405b10d7050286170b716e2c167b7cdf6b04a9985f20d5d5848617e27f4cb7a0ab1b93c85f4561f3aa6bbd5d1da15ceb1f1670a840239bbfa1acb598507834d0c040a38b8ad2d1e314e0f517947b3d9a7a9fa3a76a76c7c4846de75bddcb034ccd071ad9af2c581c2521acbe5ddab4bf1c04285819c16cfe5fba9d64d141571e6055400c56c276e4bed164781beb75f20d42e3744e0ae30125581da2cea1215655fadeacafb56c66b3f9c36b22ac25cc222d20e4a435608d801b7a7feac232c6520a2c40ce923ee4aff98a21e8640b56cb7c989a1568cecb2813b1ec8e13bb9b16e8f4fd4a9f53520c58d17f2dfc95efca4ab3158696e6b9fc4e4a79e4e9286cb338b9214021ae5c51c119e8b65fb5d78640b1161d722634b1dcee89f6252c88d393e9115fbfc3a0d52d2acd233d8de407b1840ae2462e6c0001a9da0babc56c37e04fc3bdf5552103009b7540e10f2562e5fd8fac9eaec25166a58b26e412348ff5a86927bfac22a221030205e9cefaea5a1dfc580af20c8d5aa2468bb0148f1a5e4605fc622c80e604ba210214baf0ceea3a66f17e7e1e839ea25fd8bed6cd82e6bb6e68250189065f44ff0121023e9b32ea89b94d066e649b124fd50e396ee91369e8e2a6ae1b11c170d022256d2103408dcd416396f64783ac587ea1e1593c57d9fea880c8a6a1920e92a2594778062102a7834be9b32e2981d157cb5bbd3acb42cfd11ea5c3b10224d7a44e98c5910f1b2102ba2c70f5996f357a43198705859fae2cfea13e1172962800772b3d588a9d4abd5768c7c34cba00";
-    const the100thBlockHeaderJson = {
-      confirmations: 0,
-      hash:
-        "0x47383336f5bf76e4eb621484a58c4d2de064b28bc197000a7218177c77d4d1c8",
-      index: 100,
-      merkleroot:
-        "0x91403fcb4aa573b9efb593be3f7b7f123cc73fe2d20c0a4da2707cd95e25916f",
-      nextblockhash:
-        "0x890627674a48c530f53ddb20ff4a4552c18f0d2ac45f9dec72fa44abd1fe07ba",
-      nextconsensus: "AM2GgjcwzHDGGJP3FuizmmvEEL9re9V43M",
-      previousblockhash:
-        "0x5fd6f4a7f701361df4b1f3ba8da797adb1e3719546d8407c0193256750e98e3d",
-      size: 685,
-      time: 1568636553386,
-      version: 0,
-      witnesses: [
-        {
-          invocation:
-            "405b10d7050286170b716e2c167b7cdf6b04a9985f20d5d5848617e27f4cb7a0ab1b93c85f4561f3aa6bbd5d1da15ceb1f1670a840239bbfa1acb598507834d0c040a38b8ad2d1e314e0f517947b3d9a7a9fa3a76a76c7c4846de75bddcb034ccd071ad9af2c581c2521acbe5ddab4bf1c04285819c16cfe5fba9d64d141571e6055400c56c276e4bed164781beb75f20d42e3744e0ae30125581da2cea1215655fadeacafb56c66b3f9c36b22ac25cc222d20e4a435608d801b7a7feac232c6520a2c40ce923ee4aff98a21e8640b56cb7c989a1568cecb2813b1ec8e13bb9b16e8f4fd4a9f53520c58d17f2dfc95efca4ab3158696e6b9fc4e4a79e4e9286cb338b9214021ae5c51c119e8b65fb5d78640b1161d722634b1dcee89f6252c88d393e9115fbfc3a0d52d2acd233d8de407b1840ae2462e6c0001a9da0babc56c37e04fc3bd",
-          verification:
-            "552103009b7540e10f2562e5fd8fac9eaec25166a58b26e412348ff5a86927bfac22a221030205e9cefaea5a1dfc580af20c8d5aa2468bb0148f1a5e4605fc622c80e604ba210214baf0ceea3a66f17e7e1e839ea25fd8bed6cd82e6bb6e68250189065f44ff0121023e9b32ea89b94d066e649b124fd50e396ee91369e8e2a6ae1b11c170d022256d2103408dcd416396f64783ac587ea1e1593c57d9fea880c8a6a1920e92a2594778062102a7834be9b32e2981d157cb5bbd3acb42cfd11ea5c3b10224d7a44e98c5910f1b2102ba2c70f5996f357a43198705859fae2cfea13e1172962800772b3d588a9d4abd5768c7c34cba"
-        }
-      ]
-    };
     test("height as index, verbose = 0", async () => {
-      const result = await client.getBlockHeader(100);
-      expect(result).toBe(the100thBlockHeaderHash);
+      const result = await client.getBlockHeader(0);
+      expect(result).toBe(
+        "00000000000000000000000000000000000000000000000000000000000000000000000042f5f271197611e4abafd359cec7094203878ebcd1856ab2288a0ce27daeea9788ea19ef550100000000000042218a992bdd8b981607766347e1ae195c3959cd0100011100"
+      );
     });
 
     test("hash as index, verbose = 1", async () => {
       const result = await client.getBlock(
-        "47383336f5bf76e4eb621484a58c4d2de064b28bc197000a7218177c77d4d1c8",
+        "0x95380d2d8601a0e0d97fbe95c43cbc07e1d9ba6473ea5ddc39b8c381f3e3ae85",
         1
       );
-      expect(result.merkleroot).toStrictEqual(
-        the100thBlockHeaderJson.merkleroot
-      );
+      expect(result).toMatchObject(REFERENCE_BLOCK_HEADER);
     });
-  });
-
-  test("getBlockSysFee", async () => {
-    const result = await client.getBlockSysFee(1);
-    expect(typeof result === "string").toBeTruthy();
   });
 
   test("getConnectionCount", async () => {
     const result = await client.getConnectionCount();
-    expect(typeof result === "number").toBeTruthy();
+    expect(typeof result).toBe("number");
   });
 
-  test("getContractState", async () => {
+  // TODO: Find a contract on neo3
+  test.skip("getContractState", async () => {
     const result = await client.getContractState(contractHash);
     expect(Object.keys(result)).toEqual([
       "groups",
@@ -176,7 +177,7 @@ describe.skip("RPC Methods", () => {
     });
 
     test("get comfirmed and unconfirmed", async () => {
-      const result = await client.getRawMemPool(1);
+      const result = await client.getRawMemPool(true);
       expect(Object.keys(result)).toEqual(
         expect.arrayContaining(["height", "verified", "unverified"])
       );
@@ -185,37 +186,49 @@ describe.skip("RPC Methods", () => {
 
   describe("getRawTransaction", () => {
     test("verbose", async () => {
+      const REFERENCE_TX = Object.assign(
+        {
+          blockhash:
+            "0x95380d2d8601a0e0d97fbe95c43cbc07e1d9ba6473ea5ddc39b8c381f3e3ae85",
+          // do not match confirmations
+          blocktime: 1468595301000,
+          vm_state: "HALT"
+        },
+        REFERENCE_BLOCK.tx[0]
+      );
       const result = await client.getRawTransaction(
-        "7d6f49c21623c25817b4ca5b14ecc79284d75e14b65b8415d01fa439c48ba064",
+        "1e16f97be7fe8e9e2136dfdea37207fc27d2bc42661dd1feb6f37381233c44ad",
         1
       );
-      expect(result.nonce).toEqual(242735824);
+
+      expect(result).toMatchObject(REFERENCE_TX);
     });
 
     test("non-verbose", async () => {
       const result = await client.getRawTransaction(
-        "7d6f49c21623c25817b4ca5b14ecc79284d75e14b65b8415d01fa439c48ba064"
+        "1e16f97be7fe8e9e2136dfdea37207fc27d2bc42661dd1feb6f37381233c44ad"
       );
       expect(result).toBe(
-        "00d0da770ec7e4fce7f40b9616bd1884a9b85d33e4f617c3de00e1f5050000000000e1f50500000000244a20000001c7e4fce7f40b9616bd1884a9b85d33e4f617c3de01505114c7e4fce7f40b9616bd1884a9b85d33e4f617c3de14c7e4fce7f40b9616bd1884a9b85d33e4f617c3de53c1087472616e736665721415caa04214310670d5e5a398e147e0dbed98cf4368627d5b5201414030f17ca4b22d50bb6b7f4398466d2f700eb24e5a9d762acc7a5091a0ab774f311af28b81d3488431dffe91bb5ab89cfdadcf9a75028a66e54cb8eb77c7db03cb2721031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c968747476aa"
+        "0000000000ca61e52e881d41374e640f819cd118cc153b21a7000000000000000000000000000000000000000000000541123e7fe801000111"
       );
     });
   });
 
+  // TODO: Find a contract on neo3
   test.skip("getStorage", async () => {
     const result = await client.getStorage(
       contractHash,
       "9847e26135152874355e324afd5cc99f002acb33"
     );
 
-    expect(typeof result === "string").toBeTruthy();
+    expect(typeof result).toBe("string");
   });
 
   test("getTransactionHeight", async () => {
     const result = await client.getTransactionHeight(
-      "7d6f49c21623c25817b4ca5b14ecc79284d75e14b65b8415d01fa439c48ba064"
+      "1e16f97be7fe8e9e2136dfdea37207fc27d2bc42661dd1feb6f37381233c44ad"
     );
-    expect(result).toBe(13733);
+    expect(result).toBe(0);
   });
 
   test("getValidators", async () => {
@@ -237,9 +250,16 @@ describe.skip("RPC Methods", () => {
   test("listPlugins", async () => {
     const result = await client.listPlugins();
     expect(result.length).toBeGreaterThan(0);
+    result.forEach(element => {
+      expect(element).toMatchObject({
+        name: expect.any(String),
+        version: expect.any(String),
+        interfaces: expect.any(Array)
+      });
+    });
   });
 
-  describe("Invocation methods", () => {
+  describe.skip("Invocation methods", () => {
     test("invokeFunction", async () => {
       const result = await client.invokeFunction(contractHash, "name");
 
@@ -261,7 +281,7 @@ describe.skip("RPC Methods", () => {
     });
   });
 
-  test("sendRawTransaction", async () => {
+  test.skip("sendRawTransaction", async () => {
     const account = new Account(privateKey);
     const addressInHash160 = ContractParam.hash160(account.address);
     const script = createScript({
@@ -285,18 +305,25 @@ describe.skip("RPC Methods", () => {
       script: script
     }).sign(account);
     const result = await client.sendRawTransaction(transaction.serialize(true));
-    expect(typeof result).toBe("string");
+    expect(typeof result).toBe(String);
   }, 10000);
 
-  test("submitBlock", () => {
+  test.skip("submitBlock", () => {
     const alreadyExistedBlock =
       "000000003d8ee950672593017c40d8469571e3b1ad97a78dbaf3b1f41d3601f7a7f4d65f6f91255ed97c70a24d0a0cd2e23fc73c127f7b3fbe93b5efb973a54acb3f4091aa48063a6d010000640000003991af1bc2546596d3e129df102e2ac011d2ab5901fd4501405b10d7050286170b716e2c167b7cdf6b04a9985f20d5d5848617e27f4cb7a0ab1b93c85f4561f3aa6bbd5d1da15ceb1f1670a840239bbfa1acb598507834d0c040a38b8ad2d1e314e0f517947b3d9a7a9fa3a76a76c7c4846de75bddcb034ccd071ad9af2c581c2521acbe5ddab4bf1c04285819c16cfe5fba9d64d141571e6055400c56c276e4bed164781beb75f20d42e3744e0ae30125581da2cea1215655fadeacafb56c66b3f9c36b22ac25cc222d20e4a435608d801b7a7feac232c6520a2c40ce923ee4aff98a21e8640b56cb7c989a1568cecb2813b1ec8e13bb9b16e8f4fd4a9f53520c58d17f2dfc95efca4ab3158696e6b9fc4e4a79e4e9286cb338b9214021ae5c51c119e8b65fb5d78640b1161d722634b1dcee89f6252c88d393e9115fbfc3a0d52d2acd233d8de407b1840ae2462e6c0001a9da0babc56c37e04fc3bdf5552103009b7540e10f2562e5fd8fac9eaec25166a58b26e412348ff5a86927bfac22a221030205e9cefaea5a1dfc580af20c8d5aa2468bb0148f1a5e4605fc622c80e604ba210214baf0ceea3a66f17e7e1e839ea25fd8bed6cd82e6bb6e68250189065f44ff0121023e9b32ea89b94d066e649b124fd50e396ee91369e8e2a6ae1b11c170d022256d2103408dcd416396f64783ac587ea1e1593c57d9fea880c8a6a1920e92a2594778062102a7834be9b32e2981d157cb5bbd3acb42cfd11ea5c3b10224d7a44e98c5910f1b2102ba2c70f5996f357a43198705859fae2cfea13e1172962800772b3d588a9d4abd5768c7c34cba0102416f54b693afc926";
 
     expect(client.submitBlock(alreadyExistedBlock)).rejects.toThrow();
   }, 10000);
 
-  test("validateAddress", async () => {
-    const result = await client.validateAddress(address);
-    expect(result).toBe(true);
+  describe("validateAddress", () => {
+    test("valid", async () => {
+      const result = await client.validateAddress(address);
+      expect(result).toBe(true);
+    });
+
+    test("invalid", async () => {
+      const result = await client.validateAddress("wrongaddress");
+      expect(result).toBe(false);
+    });
   });
 });

--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -84,12 +84,6 @@ describe("static", () => {
     });
   });
 
-  test("getBlockSysFee", () => {
-    const result = Query.getBlockSysFee(123);
-    expect(result.method).toEqual("getblocksysfee");
-    expect(result.params).toEqual([123]);
-  });
-
   test("getConnectionCount", () => {
     const result = Query.getConnectionCount();
     expect(result.method).toEqual("getconnectioncount");

--- a/packages/neon-core/__tests__/rpc/RPCClient.ts
+++ b/packages/neon-core/__tests__/rpc/RPCClient.ts
@@ -254,29 +254,6 @@ describe("RPC Methods", () => {
     });
   });
 
-  describe("getBlockSysFee", () => {
-    test("success", async () => {
-      const expected = 5;
-      Axios.post.mockImplementationOnce(async (url, data) => {
-        expect(url).toEqual("testUrl");
-        expect(data).toMatchObject({
-          method: "getblocksysfee",
-          params: [123]
-        });
-        return {
-          data: {
-            jsonrpc: "2.0",
-            id: data.id,
-            result: expected
-          }
-        };
-      });
-
-      const result = await client.getBlockSysFee(123);
-      expect(result).toEqual(expected);
-    });
-  });
-
   describe("getConnectionCount", () => {
     test("success", async () => {
       const expected = 100;
@@ -523,8 +500,7 @@ describe("RPC Methods", () => {
 
   describe("getVersion", () => {
     test("success", async () => {
-      const versionString = "/Neo:3.0.0-preview1/";
-      const expected = "3.0.0-preview1";
+      const expected = "3.0.0-preview2-00";
       Axios.post.mockImplementationOnce(async (url, data) => {
         expect(url).toEqual("testUrl");
         expect(data).toMatchObject({
@@ -536,10 +512,10 @@ describe("RPC Methods", () => {
             jsonrpc: "2.0",
             id: data.id,
             result: {
-              tcpPort: 1234,
-              wsPort: 2345,
-              nonce: 1,
-              useragent: versionString
+              tcp_port: 20333,
+              ws_port: 20334,
+              nonce: 288566725,
+              user_agent: "/Neo:3.0.0-preview2-00/"
             }
           }
         };

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -6,8 +6,9 @@ import {
   WitnessLike
 } from "../tx";
 import { ContractManifestLike, StackItemLike } from "../sc";
-import { BlockJson, Validator } from "../types";
+import { BlockJson, Validator, BlockHeaderJson } from "../types";
 
+export type BooleanLikeParam = 0 | 1 | boolean;
 export interface QueryLike<T extends unknown[]> {
   method: string;
   params: T;
@@ -80,10 +81,10 @@ export interface GetRawTransactionResult {
 }
 
 export interface GetVersionResult {
-  tcpPort: number;
-  wsPort: number;
+  tcp_port: number;
+  ws_port: number;
   nonce: number;
-  useragent: string;
+  user_agent: string;
 }
 
 export interface NodePeer {
@@ -129,19 +130,19 @@ export class Query<TParams extends unknown[], TResponse> {
    */
   public static getBlock(
     indexOrHash: number | string,
-    verbose: 1
-  ): Query<[number | string, 1], BlockJson>;
+    verbose: 1 | true
+  ): Query<[number | string, 1 | true], BlockJson>;
   public static getBlock(
     indexOrHash: number | string,
-    verbose?: 0
-  ): Query<[number | string, 0], string>;
+    verbose?: 0 | false
+  ): Query<[number | string, 0 | false], string>;
   public static getBlock(
     indexOrHash: number | string,
-    verbose?: 0 | 1
-  ): Query<[number | string, 0 | 1], string | BlockJson> {
+    verbose: BooleanLikeParam = 0
+  ): Query<[number | string, BooleanLikeParam], string | BlockJson> {
     return new Query({
       method: "getblock",
-      params: [indexOrHash, verbose ?? 0]
+      params: [indexOrHash, verbose]
     });
   }
 
@@ -173,22 +174,19 @@ export class Query<TParams extends unknown[], TResponse> {
    */
   public static getBlockHeader(
     indexOrHash: string | number,
-    verbose: 0 | 1 = 0
-  ): Query<[string | number, 0 | 1], string> {
+    verbose: 1 | true
+  ): Query<[string | number, 1 | true], BlockHeaderJson>;
+  public static getBlockHeader(
+    indexOrHash: string | number,
+    verbose?: 0 | false
+  ): Query<[string | number, 0 | false], string>;
+  public static getBlockHeader(
+    indexOrHash: string | number,
+    verbose: BooleanLikeParam = 0
+  ): Query<[string | number, BooleanLikeParam], string | BlockHeaderJson> {
     return new Query({
       method: "getblockheader",
       params: [indexOrHash, verbose]
-    });
-  }
-
-  /**
-   * This Query returns the amount of GAS burnt as fees within a specific block.
-   * @param index height of block.
-   */
-  public static getBlockSysFee(index: number): Query<[number], string> {
-    return new Query({
-      method: "getblocksysfee",
-      params: [index]
     });
   }
 
@@ -200,6 +198,7 @@ export class Query<TParams extends unknown[], TResponse> {
       method: "getconnectioncount"
     });
   }
+
   /**
    * This Query returns information about the smart contract registered at the specific hash.
    * @param scriptHash hash of contract
@@ -230,13 +229,15 @@ export class Query<TParams extends unknown[], TResponse> {
    *
    * shouldGetUnverified = 1, get current block height and confirmed and unconfirmed tx hash
    */
-  public static getRawMemPool(shouldGetUnverified?: 0): Query<[0], string[]>;
   public static getRawMemPool(
-    shouldGetUnverified: 1
+    shouldGetUnverified?: BooleanLikeParam
+  ): Query<[0 | false], string[]>;
+  public static getRawMemPool(
+    shouldGetUnverified: 1 | true
   ): Query<[1], GetRawMemPoolResult>;
   public static getRawMemPool(
-    shouldGetUnverified: 0 | 1 = 0
-  ): Query<[0 | 1], string[] | GetRawMemPoolResult> {
+    shouldGetUnverified: BooleanLikeParam = 0
+  ): Query<[BooleanLikeParam], string[] | GetRawMemPoolResult> {
     return new Query({
       method: "getrawmempool",
       params: [shouldGetUnverified]
@@ -250,16 +251,16 @@ export class Query<TParams extends unknown[], TResponse> {
    */
   public static getRawTransaction(
     txid: string,
-    verbose?: 0
-  ): Query<[string, 0], string>;
+    verbose?: 0 | false
+  ): Query<[string, 0 | false], string>;
   public static getRawTransaction(
     txid: string,
-    verbose: 1
-  ): Query<[string, 1], GetRawTransactionResult>;
+    verbose: 1 | true
+  ): Query<[string, 1 | true], GetRawTransactionResult>;
   public static getRawTransaction(
     txid: string,
-    verbose: 0 | 1 = 0
-  ): Query<[string, 0 | 1], string | GetRawTransactionResult> {
+    verbose: BooleanLikeParam = 0
+  ): Query<[string, BooleanLikeParam], string | GetRawTransactionResult> {
     return new Query({
       method: "getrawtransaction",
       params: [txid, verbose]


### PR DESCRIPTION
- optional verbose parameter now accepts booleans.
- remove getBlockSysFee.
- amend getVersion to read the keys correctly.
- update test data to use new neo3 chain.