### PR TITLE
chore(lint): Remove camelcase rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
       }
     ],
     "@typescript-eslint/no-non-null-assertion": ["warn"],
-    "@typescript-eslint/camelcase": 1,
+    "@typescript-eslint/camelcase": 0,
     "@typescript-eslint/no-unused-vars": [
       "error",
       { varsIgnorePattern: "^_", argsIgnorePattern: "^_" }

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": ["tslint:recommended", "tslint-config-prettier"],
-  "rules": {
-    "interface-name": false,
-    "object-literal-sort-keys":false
-  }
-}


### PR DESCRIPTION
- Remove camelcase rule since many interfaces coming from c# code are using camelcase.
- Remove redundant tslint file.