### PR TITLE
feat(rpc): Update invoke RPCs to accept witness hashes

### DIFF
--- a/packages/neon-core/__integration__/rpc/RPCClient.ts
+++ b/packages/neon-core/__integration__/rpc/RPCClient.ts
@@ -244,6 +244,26 @@ describe("RPC Methods", () => {
       expect(result.state).toContain("HALT");
     });
 
+    test("invokeFunction with checkedWitness", async () => {
+      const fromAccount = wallet.accounts[0];
+      const toAccount = wallet.accounts[1];
+      const result = await client.invokeFunction(
+        contractHash,
+        "transfer",
+        [
+          ContractParam.hash160(fromAccount.address),
+          ContractParam.hash160(toAccount.address),
+          ContractParam.integer(1),
+        ],
+        [wallet.accounts[0].scriptHash]
+      );
+
+      expect(Object.keys(result)).toEqual(
+        expect.arrayContaining(["script", "state", "gas_consumed", "stack"])
+      );
+      expect(result.state).toContain("HALT");
+    });
+
     test("invokeScript", async () => {
       const result = await client.invokeScript(
         new ScriptBuilder()
@@ -263,6 +283,29 @@ describe("RPC Methods", () => {
         HexString.fromAscii("neo").toBase64()
       );
     });
+
+    test("invokeScript with checkedWitness", async () => {
+      const fromAccount = wallet.accounts[0];
+      const toAccount = wallet.accounts[1];
+      const script = createScript({
+        scriptHash: "9bde8f209c88dd0e7ca3bf0af0f476cdd8207789",
+        operation: "transfer",
+        args: [
+          ContractParam.hash160(fromAccount.address),
+          ContractParam.hash160(toAccount.address),
+          ContractParam.integer(1),
+        ],
+      });
+
+      const result = await client.invokeScript(script, [
+        fromAccount.scriptHash,
+      ]);
+
+      expect(Object.keys(result)).toEqual(
+        expect.arrayContaining(["script", "state", "gas_consumed", "stack"])
+      );
+      expect(result.state).toContain("HALT");
+    });
   });
 
   test("sendRawTransaction", async () => {
@@ -274,7 +317,7 @@ describe("RPC Methods", () => {
       args: [
         ContractParam.hash160(fromAccount.address),
         ContractParam.hash160(toAccount.address),
-        1,
+        ContractParam.integer(1),
       ],
     });
 

--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -150,7 +150,7 @@ describe("static", () => {
     test("no params", () => {
       const result = Query.invokeFunction("hash", "method");
       expect(result.method).toEqual("invokefunction");
-      expect(result.params).toEqual(["hash", "method", []]);
+      expect(result.params).toEqual(["hash", "method", [], []]);
     });
 
     test("multiple params", () => {

--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -157,14 +157,36 @@ describe("static", () => {
       const params = [jest.fn(), jest.fn(), jest.fn()];
       const result = Query.invokeFunction("hash", "method", params);
       expect(result.method).toEqual("invokefunction");
-      expect(result.params).toEqual(["hash", "method", params]);
+      expect(result.params).toEqual(["hash", "method", params, []]);
+    });
+
+    test("multiple params with checkedWitnessHashes", () => {
+      const params = [jest.fn(), jest.fn(), jest.fn()];
+      const result = Query.invokeFunction("hash", "method", params, [
+        "abcdabcdabcdabcdabcd",
+      ]);
+      expect(result.method).toEqual("invokefunction");
+      expect(result.params).toEqual([
+        "hash",
+        "method",
+        params,
+        ["abcdabcdabcdabcdabcd"],
+      ]);
     });
   });
 
   describe("invokeScript", () => {
-    const result = Query.invokeScript("script");
-    expect(result.method).toEqual("invokescript");
-    expect(result.params).toEqual(["script"]);
+    test("script", () => {
+      const result = Query.invokeScript("script");
+      expect(result.method).toEqual("invokescript");
+      expect(result.params).toEqual(["script", []]);
+    });
+
+    test("script with checkWitnessHashes", () => {
+      const result = Query.invokeScript("script", ["abcdabcdabcdabcdabcd"]);
+      expect(result.method).toEqual("invokescript");
+      expect(result.params).toEqual(["script", ["abcdabcdabcdabcdabcd"]]);
+    });
   });
 
   describe("listPlugins", () => {

--- a/packages/neon-core/__tests__/rpc/RPCClient.ts
+++ b/packages/neon-core/__tests__/rpc/RPCClient.ts
@@ -534,7 +534,12 @@ describe("RPC Methods", () => {
         expect(url).toEqual("testUrl");
         expect(data).toMatchObject({
           method: "invokefunction",
-          params: ["hash", "method", [1, "2", randomObj]],
+          params: [
+            "hash",
+            "method",
+            [1, "2", randomObj],
+            ["abcdabcdabcdabcdabcd"],
+          ],
         });
         return {
           data: {
@@ -548,36 +553,9 @@ describe("RPC Methods", () => {
       const result = await client.invokeFunction(
         "hash",
         "method",
-        1,
-        "2",
-        randomObj
+        [1, "2", randomObj],
+        ["abcdabcdabcdabcdabcd"]
       );
-      expect(result).toEqual(expected);
-    });
-
-    test("pass params as array", async () => {
-      const randomObj = jest.fn();
-      const expected = jest.fn();
-      Axios.post.mockImplementationOnce(async (url, data) => {
-        expect(url).toEqual("testUrl");
-        expect(data).toMatchObject({
-          method: "invokefunction",
-          params: ["hash", "method", [1, "2", randomObj]],
-        });
-        return {
-          data: {
-            jsonrpc: "2.0",
-            id: data.id,
-            result: expected,
-          },
-        };
-      });
-
-      const result = await client.invokeFunction("hash", "method", [
-        1,
-        "2",
-        randomObj,
-      ]);
       expect(result).toEqual(expected);
     });
   });
@@ -589,7 +567,7 @@ describe("RPC Methods", () => {
         expect(url).toEqual("testUrl");
         expect(data).toMatchObject({
           method: "invokescript",
-          params: ["script"],
+          params: ["script", ["abcdabcdabcdabcdabcd"]],
         });
         return {
           data: {
@@ -600,7 +578,9 @@ describe("RPC Methods", () => {
         };
       });
 
-      const result = await client.invokeScript("script");
+      const result = await client.invokeScript("script", [
+        "abcdabcdabcdabcdabcd",
+      ]);
       expect(result).toEqual(expected);
     });
   });

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -302,26 +302,32 @@ export class Query<TParams extends unknown[], TResponse> {
    * @param scriptHash hash of contract to test.
    * @param operation name of operation to call (first argument)
    * @param params parameters to pass (second argument)
+   * @param checkedWitnessHashes Scripthashes of witnesses that should sign the transaction containing this script.
    */
   public static invokeFunction(
     scriptHash: string,
     operation: string,
-    params: unknown[] = []
-  ): Query<[string, string, unknown[]], InvokeResult> {
+    params: unknown[] = [],
+    checkedWitnessHashes: string[] = []
+  ): Query<[string, string, unknown[], string[]], InvokeResult> {
     return new Query({
       method: "invokefunction",
-      params: [scriptHash, operation, params],
+      params: [scriptHash, operation, params, checkedWitnessHashes],
     });
   }
 
   /**
    * This Query runs the specific script through the VM.
-   * @param script
+   * @param script VM script as a hexstring.
+   * @param checkedWitnessHashes Scripthashes of witnesses that should sign the transaction containing this script.
    */
-  public static invokeScript(script: string): Query<[string], InvokeResult> {
+  public static invokeScript(
+    script: string,
+    checkedWitnessHashes: string[] = []
+  ): Query<[string, string[]], InvokeResult> {
     return new Query({
       method: "invokescript",
-      params: [script],
+      params: [script, checkedWitnessHashes],
     });
   }
 

--- a/packages/neon-core/src/rpc/RPCClient.ts
+++ b/packages/neon-core/src/rpc/RPCClient.ts
@@ -331,25 +331,22 @@ export class RPCClient {
   public async invokeFunction(
     scriptHash: string,
     operation: string,
-    ...params: unknown[]
+    params: unknown[] = [],
+    checkedWitnessHashes: string[] = []
   ): Promise<InvokeResult> {
-    if (params.length === 1 && Array.isArray(params)) {
-      return await this.execute(
-        Query.invokeFunction(scriptHash, operation, params[0])
-      );
-    }
-
     return await this.execute(
-      Query.invokeFunction(scriptHash, operation, params)
+      Query.invokeFunction(scriptHash, operation, params, checkedWitnessHashes)
     );
   }
 
   /**
    * Submits a script for the node to run. This method is a local invoke, results are not reflected on the blockchain.
    */
-  public async invokeScript(script: string): Promise<InvokeResult> {
-    const response = await this.execute(Query.invokeScript(script));
-    return response;
+  public async invokeScript(
+    script: string,
+    checkedWitnessHashes: string[] = []
+  ): Promise<InvokeResult> {
+    return await this.execute(Query.invokeScript(script, checkedWitnessHashes));
   }
 
   /**


### PR DESCRIPTION
BREAKING CHANGE

- invokeFunction RPC call does not support ...params anymore as we need a new parameter afterwards.
- Add new checkedWitnessHashes param for invokeFunction and invokeScript.

The RPCs accept an extra parameter which is an array of witnesses that we have signatures for. This allows us to run scripts with successful witness checks and return us accurate gas consumption values.