### PR TITLE
fix(tests): Use neocli node as provider for integration tests

### DIFF
--- a/helpers/urls.ts
+++ b/helpers/urls.ts
@@ -13,9 +13,8 @@ const TESTNET_URLS = [
   "http://seed7.ngd.network:20332",
   "http://seed8.ngd.network:20332",
   "http://seed9.ngd.network:20332",
-  "http://seed10.ngd.network:20332"
+  "http://seed10.ngd.network:20332",
 ];
-
 
 const MAINNET_URLS = [
   "http://seed1.ngd.network:10332",
@@ -37,7 +36,7 @@ const MAINNET_URLS = [
   "https://seed6.cityofzion.io:443",
   "https://seed7.cityofzion.io:443",
   "https://seed8.cityofzion.io:443",
-  "https://seed9.cityofzion.io:443"
+  "https://seed9.cityofzion.io:443",
 ];
 
 export function getUrls(net: string): string[] {
@@ -58,7 +57,7 @@ export async function getUrl(net: string): Promise<string> {
   const orderedUrls = getUrls(net);
 
   const slicedUrls = cutArray(orderedUrls);
-  var previousBlockCount = 0;
+  let previousBlockCount = 0;
   for (let i = 0; i < slicedUrls.length; i++) {
     try {
       const res = (await rpc.Query.getBlockCount().execute(slicedUrls[i])) as {

--- a/packages/neon-api/__integration__/funcs/main.ts
+++ b/packages/neon-api/__integration__/funcs/main.ts
@@ -6,7 +6,7 @@ const neonJs = apiPlugin(neonCore);
 const { api, CONST, rpc, sc } = neonJs;
 
 const net = "TestNet";
-const url = "https://neoscan-testnet.io/api/test_net";
+const neoscanUrl = "https://neoscan-testnet.io/api/test_net";
 const testKeys = {
   a: {
     address: "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
@@ -28,15 +28,12 @@ const testKeys = {
 neonCore.settings.networks[net] = new rpc.Network({
   Name: net,
   ExtraConfiguration: {
-    neoscan: url,
+    neoscan: neoscanUrl,
   },
 });
 
-const provider = new api.neoscan.instance("TestNet");
-
-beforeAll(() => {
-  expect(provider.name).toMatch(url);
-});
+const provider = new api.neoCli.instance("http://seed1.ngd.network:20332");
+// const provider = new api.neoscan.instance("TestNet");
 
 describe("sendAsset", () => {
   test("send some NEO with network fee from a to b", async () => {

--- a/packages/neon-api/__integration__/provider/neoscan-testnet.ts
+++ b/packages/neon-api/__integration__/provider/neoscan-testnet.ts
@@ -18,7 +18,7 @@ neonJs.settings.networks[net] = new rpc.Network({
 const provider = new neonJs.api.neoscan.instance("TestNet");
 const invalidAddr = "address";
 
-describe(`Valid Address: ${provider.name}`, () => {
+describe.skip(`Valid Address: ${provider.name}`, () => {
   test("getBalance", async () => {
     const result = await provider.getBalance(addr);
     expect(result).toBeInstanceOf(wallet.Balance);
@@ -59,7 +59,7 @@ describe(`Valid Address: ${provider.name}`, () => {
   });
 });
 
-describe(`Invalid Address: ${provider.name}`, () => {
+describe.skip(`Invalid Address: ${provider.name}`, () => {
   test("getBalance", async () => {
     const result = await provider.getBalance(invalidAddr);
     expect(result).toBeInstanceOf(wallet.Balance);


### PR DESCRIPTION
- Use neo-cli provider instead of neoscan
- Disable testnet neoscan tests since its broken

