### PR TITLE
feat(rpc): Add plugin methods

### DIFF
--- a/docs/structure.md
+++ b/docs/structure.md
@@ -8,7 +8,7 @@ different functionality.
 
 ## Core
 
-The core package is `neon-core`, comprising of the following packages:
+The core package is `neon-core`, comprising of the following folders:
 
 - `rpc`
 - `sc`
@@ -25,7 +25,7 @@ package:
 
 ```js
 import { tx, wallet, settings } from "@cityofzion/neon-core";
-const t = new tx.ClaimTransaction();
+const t = new tx.Transaction();
 const acct = new wallet.Account();
 
 console.log(settings.networks); // {} (empty object as there are no defaults)

--- a/packages/neon-core/__integration__/rpc/RPCClient.ts
+++ b/packages/neon-core/__integration__/rpc/RPCClient.ts
@@ -1,4 +1,4 @@
-import { rpc } from "../../src/index";
+import { rpc } from "../../src";
 import {
   ContractParam,
   createScript,
@@ -60,7 +60,6 @@ beforeAll(async () => {
     throw new Error("No good endpoint found");
   }
   client = new rpc.RPCClient(best.url);
-
   const firstBlock = await client.getBlock(0, true);
   expect(firstBlock.tx.length).toBe(1);
   blockhash = firstBlock.hash;

--- a/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
@@ -1,0 +1,343 @@
+import { rpc, sc, tx, u, CONST, wallet } from "../../../src";
+import * as TestHelpers from "../../../../../testHelpers";
+import testWalletJson from "../../../__tests__/testWallet.json";
+
+const testWallet = new wallet.Wallet(testWalletJson);
+
+let client: rpc.NeoServerRpcClient;
+const address = testWallet.accounts[0].address;
+
+// NEO contract hash. Should be same across TestNet or LocalNet.
+const contractHash = CONST.ASSET_ID["NEO"];
+let txid: string;
+let blockhash: string;
+
+beforeAll(async () => {
+  await testWallet.decryptAll("wallet");
+  const url = await TestHelpers.getIntegrationEnvUrl();
+  client = new rpc.NeoServerRpcClient(url);
+  const firstBlock = await client.getBlock(0, true);
+  expect(firstBlock.tx.length).toBe(1);
+  blockhash = firstBlock.hash;
+  txid = firstBlock.tx[0].hash;
+}, 20000);
+
+describe("NeoServerRpcClient", () => {
+  describe("getBlock", () => {
+    test("height as index, verbose = 0", async () => {
+      const result = await client.getBlock(0);
+      expect(result).toBeDefined();
+    });
+
+    test("height as index, verbose = true", async () => {
+      const result = await client.getBlock(0, true);
+      expect(Object.keys(result).sort()).toEqual(
+        [
+          "hash",
+          "size",
+          "version",
+          "previousblockhash",
+          "merkleroot",
+          "time",
+          "index",
+          "nextconsensus",
+          "witnesses",
+          "consensusdata",
+          "tx",
+          "confirmations",
+          "nextblockhash",
+        ].sort()
+      );
+    });
+
+    test("hash as index, verbose = 1", async () => {
+      const result = await client.getBlock(blockhash, 1);
+      expect(result.hash).toEqual(blockhash);
+    });
+  });
+
+  test("getBlockHash", async () => {
+    const result = await client.getBlockHash(1);
+    expect(typeof result).toBe("string");
+  });
+
+  test("getBestBlockHash", async () => {
+    const result = await client.getBestBlockHash();
+    expect(typeof result).toBe("string");
+  });
+
+  test("getBlockCount", async () => {
+    const result = await client.getBlockCount();
+    expect(typeof result).toBe("number");
+  });
+
+  describe("getBlockHeader", () => {
+    test("height as index, verbose = 0", async () => {
+      const result = await client.getBlockHeader(0);
+      expect(result).toBeDefined();
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    test("hash as index, verbose = 1", async () => {
+      const result = await client.getBlockHeader(blockhash, 1);
+      expect(result.hash).toBe(blockhash);
+      expect(Object.keys(result)).toEqual([
+        "hash",
+        "size",
+        "version",
+        "previousblockhash",
+        "merkleroot",
+        "time",
+        "index",
+        "nextconsensus",
+        "witnesses",
+        "confirmations",
+        "nextblockhash",
+      ]);
+    });
+  });
+
+  test("getConnectionCount", async () => {
+    const result = await client.getConnectionCount();
+    expect(typeof result).toBe("number");
+  });
+
+  test("getContractState", async () => {
+    const result = await client.getContractState(contractHash);
+    expect(result).toBeInstanceOf(sc.ContractManifest);
+  });
+
+  test("getPeers", async () => {
+    const result = await client.getPeers();
+    expect(Object.keys(result)).toEqual(
+      expect.arrayContaining(["unconnected", "connected", "bad"])
+    );
+  });
+
+  describe("getRawMemPool", () => {
+    test("get comfirmed only", async () => {
+      const result = await client.getRawMemPool();
+      expect(Array.isArray(result)).toBeTruthy();
+    });
+
+    test("get comfirmed and unconfirmed", async () => {
+      const result = await client.getRawMemPool(true);
+      expect(Object.keys(result)).toEqual(
+        expect.arrayContaining(["height", "verified", "unverified"])
+      );
+    });
+  });
+
+  describe("getRawTransaction", () => {
+    test("verbose", async () => {
+      const result = await client.getRawTransaction(txid, 1);
+      expect(result).toBeDefined();
+      const resultTx = tx.Transaction.fromJson(result);
+      expect(resultTx).toBeDefined();
+    });
+
+    test("non-verbose", async () => {
+      const result = await client.getRawTransaction(txid);
+      expect(typeof result).toBe("string");
+
+      const deserializedTx = tx.Transaction.deserialize(result);
+      expect(deserializedTx).toBeDefined();
+    });
+  });
+
+  test("getStorage", async () => {
+    const result = await client.getStorage(contractHash, "0b");
+
+    // This storage is totalSupply of NEO. Should be safe and static for usage.
+    expect(result).toBe("00e1f505");
+  });
+
+  test("getTransactionHeight", async () => {
+    const result = await client.getTransactionHeight(txid);
+    expect(result).toBe(0);
+  });
+
+  test("getValidators", async () => {
+    const result = await client.getValidators();
+    result.map((v) =>
+      expect(v).toMatchObject({
+        publickey: expect.any(String),
+        active: expect.any(Boolean),
+        votes: expect.any(String),
+      })
+    );
+  });
+
+  test("getVersion", async () => {
+    const result = await client.getVersion();
+    expect(result).toMatch(/\d+\.\d+\.\d+-?.*/);
+  });
+
+  test("listPlugins", async () => {
+    const result = await client.listPlugins();
+    expect(result.length).toBeGreaterThan(0);
+    result.forEach((element) => {
+      expect(element).toMatchObject({
+        name: expect.any(String),
+        version: expect.any(String),
+        interfaces: expect.any(Array),
+      });
+    });
+  });
+
+  describe("Invocation methods", () => {
+    test("invokeFunction", async () => {
+      const result = await client.invokeFunction(contractHash, "name");
+
+      expect(Object.keys(result)).toEqual(
+        expect.arrayContaining([
+          "script",
+          "state",
+          "gasconsumed",
+          "stack",
+          "tx",
+        ])
+      );
+      expect(result.state).toContain("HALT");
+    });
+
+    test("invokeFunction with signers", async () => {
+      const fromAccount = testWallet.accounts[0];
+      const toAccount = testWallet.accounts[1];
+      const result = await client.invokeFunction(
+        contractHash,
+        "transfer",
+        [
+          sc.ContractParam.hash160(fromAccount.address),
+          sc.ContractParam.hash160(toAccount.address),
+          sc.ContractParam.integer(1),
+        ],
+        [
+          new tx.Signer({
+            account: fromAccount.scriptHash,
+            scopes: tx.WitnessScope.CalledByEntry,
+          }),
+        ]
+      );
+
+      expect(Object.keys(result)).toEqual(
+        expect.arrayContaining([
+          "script",
+          "state",
+          "gasconsumed",
+          "stack",
+          "tx",
+        ])
+      );
+      expect(result.state).toContain("HALT");
+    });
+
+    test("invokeScript", async () => {
+      const result = await client.invokeScript(
+        new sc.ScriptBuilder()
+          .emitAppCall(contractHash, "name")
+          .emitAppCall(contractHash, "symbol")
+          .build()
+      );
+      expect(Object.keys(result)).toEqual(
+        expect.arrayContaining([
+          "script",
+          "state",
+          "gasconsumed",
+          "stack",
+          "tx",
+        ])
+      );
+      expect(result.state).toContain("HALT");
+      expect(result.stack.length).toEqual(2);
+      expect(result.stack[0].value).toEqual(
+        u.HexString.fromAscii("NEO").toBase64()
+      );
+      expect(result.stack[1].value).toEqual(
+        u.HexString.fromAscii("neo").toBase64()
+      );
+    });
+
+    test("invokeScript with signers", async () => {
+      const fromAccount = testWallet.accounts[0];
+      const toAccount = testWallet.accounts[1];
+      const script = sc.createScript({
+        scriptHash: contractHash,
+        operation: "transfer",
+        args: [
+          sc.ContractParam.hash160(fromAccount.address),
+          sc.ContractParam.hash160(toAccount.address),
+          sc.ContractParam.integer(1),
+        ],
+      });
+
+      const result = await client.invokeScript(script, [
+        new tx.Signer({
+          account: fromAccount.scriptHash,
+          scopes: tx.WitnessScope.CalledByEntry,
+        }),
+      ]);
+
+      expect(Object.keys(result)).toEqual(
+        expect.arrayContaining([
+          "script",
+          "state",
+          "gasconsumed",
+          "stack",
+          "tx",
+        ])
+      );
+      expect(result.state).toContain("HALT");
+    });
+  });
+
+  test("sendRawTransaction", async () => {
+    const fromAccount = testWallet.accounts[0];
+    const toAccount = testWallet.accounts[1];
+    const script = sc.createScript({
+      scriptHash: "9bde8f209c88dd0e7ca3bf0af0f476cdd8207789",
+      operation: "transfer",
+      args: [
+        sc.ContractParam.hash160(fromAccount.address),
+        sc.ContractParam.hash160(toAccount.address),
+        sc.ContractParam.integer(1),
+      ],
+    });
+
+    const currentHeight = await client.getBlockCount();
+    const transaction = new tx.Transaction({
+      signers: [
+        {
+          account: fromAccount.scriptHash,
+          scopes: tx.WitnessScope.CalledByEntry,
+        },
+      ],
+      validUntilBlock: currentHeight + 1000000,
+      systemFee: 1,
+      networkFee: 1,
+      script: script,
+    }).sign(fromAccount, 1234567890);
+    const result = await client.sendRawTransaction(transaction.serialize(true));
+    expect(typeof result).toBe("string");
+  }, 10000);
+
+  test.skip("submitBlock", () => {
+    const alreadyExistedBlock =
+      "000000003d8ee950672593017c40d8469571e3b1ad97a78dbaf3b1f41d3601f7a7f4d65f6f91255ed97c70a24d0a0cd2e23fc73c127f7b3fbe93b5efb973a54acb3f4091aa48063a6d010000640000003991af1bc2546596d3e129df102e2ac011d2ab5901fd4501405b10d7050286170b716e2c167b7cdf6b04a9985f20d5d5848617e27f4cb7a0ab1b93c85f4561f3aa6bbd5d1da15ceb1f1670a840239bbfa1acb598507834d0c040a38b8ad2d1e314e0f517947b3d9a7a9fa3a76a76c7c4846de75bddcb034ccd071ad9af2c581c2521acbe5ddab4bf1c04285819c16cfe5fba9d64d141571e6055400c56c276e4bed164781beb75f20d42e3744e0ae30125581da2cea1215655fadeacafb56c66b3f9c36b22ac25cc222d20e4a435608d801b7a7feac232c6520a2c40ce923ee4aff98a21e8640b56cb7c989a1568cecb2813b1ec8e13bb9b16e8f4fd4a9f53520c58d17f2dfc95efca4ab3158696e6b9fc4e4a79e4e9286cb338b9214021ae5c51c119e8b65fb5d78640b1161d722634b1dcee89f6252c88d393e9115fbfc3a0d52d2acd233d8de407b1840ae2462e6c0001a9da0babc56c37e04fc3bdf5552103009b7540e10f2562e5fd8fac9eaec25166a58b26e412348ff5a86927bfac22a221030205e9cefaea5a1dfc580af20c8d5aa2468bb0148f1a5e4605fc622c80e604ba210214baf0ceea3a66f17e7e1e839ea25fd8bed6cd82e6bb6e68250189065f44ff0121023e9b32ea89b94d066e649b124fd50e396ee91369e8e2a6ae1b11c170d022256d2103408dcd416396f64783ac587ea1e1593c57d9fea880c8a6a1920e92a2594778062102a7834be9b32e2981d157cb5bbd3acb42cfd11ea5c3b10224d7a44e98c5910f1b2102ba2c70f5996f357a43198705859fae2cfea13e1172962800772b3d588a9d4abd5768c7c34cba0102416f54b693afc926";
+
+    expect(client.submitBlock(alreadyExistedBlock)).rejects.toThrow();
+  }, 10000);
+
+  describe("validateAddress", () => {
+    test("valid", async () => {
+      const result = await client.validateAddress(address);
+      expect(result).toBe(true);
+    });
+
+    test("invalid", async () => {
+      const result = await client.validateAddress("wrongaddress");
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/neon-core/__integration__/rpc/clients/Nep5TrackerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/Nep5TrackerRpcClient.ts
@@ -5,7 +5,7 @@ import testWalletJson from "../../../__tests__/testWallet.json";
 const testWallet = new wallet.Wallet(testWalletJson);
 
 let client: rpc.Nep5TrackerRpcClient;
-const address = testWallet.accounts[0].address;
+const address = "NZCbeSDnadGsacF69zVvfaB4zDKMioMHJV";
 
 beforeAll(async () => {
   await testWallet.decryptAll("wallet");

--- a/packages/neon-core/__integration__/rpc/clients/Nep5TrackerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/Nep5TrackerRpcClient.ts
@@ -1,0 +1,81 @@
+import { rpc, wallet } from "../../../src";
+import * as TestHelpers from "../../../../../testHelpers";
+import testWalletJson from "../../../__tests__/testWallet.json";
+
+const testWallet = new wallet.Wallet(testWalletJson);
+
+let client: rpc.Nep5TrackerRpcClient;
+const address = testWallet.accounts[0].address;
+
+beforeAll(async () => {
+  await testWallet.decryptAll("wallet");
+  const url = await TestHelpers.getIntegrationEnvUrl();
+  client = new rpc.Nep5TrackerRpcClient(url);
+}, 20000);
+
+describe("Nep5TrackerRpcClient", () => {
+  describe("getNep5Transfers", () => {
+    test("empty address", async () => {
+      const result = await client.getNep5Transfers("0".repeat(40));
+      expect(result.received.length).toBe(0);
+      expect(result.sent.length).toBe(0);
+    });
+
+    // We set startTime to beginning of UTC to get all transactions.
+    test("address with endtime", async () => {
+      const result = await client.getNep5Transfers(
+        address,
+        "0",
+        Date.now().toString()
+      );
+      expect(result.address).toBe(address);
+      expect(result.received.length).toBeGreaterThan(0);
+      expect(result.sent.length).toBeGreaterThan(0);
+
+      result.received.forEach((i) => {
+        expect(Object.keys(i)).toEqual(
+          expect.arrayContaining([
+            "timestamp",
+            "assethash",
+            "transferaddress",
+            "amount",
+            "blockindex",
+            "transfernotifyindex",
+            "txhash",
+          ])
+        );
+      });
+      result.sent.forEach((i) => {
+        expect(Object.keys(i)).toEqual(
+          expect.arrayContaining([
+            "timestamp",
+            "assethash",
+            "transferaddress",
+            "amount",
+            "blockindex",
+            "transfernotifyindex",
+            "txhash",
+          ])
+        );
+      });
+    });
+  });
+
+  describe("getNep5Balances", () => {
+    test("empty address", async () => {
+      const result = await client.getNep5Balances("0".repeat(40));
+      expect(result.balance.length).toBe(0);
+    });
+
+    test("address with some assets", async () => {
+      const result = await client.getNep5Balances(address);
+      expect(result.address).toBe(address);
+      expect(result.balance.length).toBeGreaterThan(0);
+      result.balance.forEach((b) => {
+        expect(Object.keys(b)).toEqual(
+          expect.arrayContaining(["assethash", "lastupdatedblock", "amount"])
+        );
+      });
+    });
+  });
+});

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -23,6 +23,21 @@ export interface RPCErrorResponse {
   message: string;
 }
 
+export interface ApplicationLog {
+  txid: string;
+  trigger: string;
+  vmstate: string;
+  gasconsumed: string;
+  stack?: StackItemJson[];
+  notifications: {
+    contract: string;
+    eventname: string;
+    state: string;
+  }[];
+}
+
+export type GetApplicationLogsResult = ApplicationLog[];
+
 /**
  * Result from calling invokescript or invokefunction.
  */
@@ -42,6 +57,31 @@ export interface GetContractStateResult {
   hash: string;
   script: string;
   manifest: ContractManifestLike;
+}
+
+export interface GetNep5TransfersResult {
+  sent: Nep5TransferEvent[];
+  received: Nep5TransferEvent[];
+  address: string;
+}
+
+export interface Nep5TransferEvent {
+  timestamp: number;
+  assethash: string;
+  transferaddress: string;
+  amount: string;
+  blockindex: number;
+  transfernotifyindex: number;
+  txhash: string;
+}
+
+export interface GetNep5BalancesResult {
+  address: string;
+  balance: {
+    assethash: string;
+    amount: string;
+    lastupdatedblock: number;
+  }[];
 }
 
 export interface GetPeersResult {
@@ -106,6 +146,18 @@ export class Query<TParams extends unknown[], TResponse> {
   public static getBestBlockHash(): Query<[], string> {
     return new Query({
       method: "getbestblockhash",
+    });
+  }
+
+  /**
+   * Query returning the application log.
+   */
+  public static getApplicationLogs(
+    hash: string
+  ): Query<[string], GetApplicationLogsResult> {
+    return new Query({
+      method: "getapplicationlogs",
+      params: [hash],
     });
   }
 
@@ -195,6 +247,39 @@ export class Query<TParams extends unknown[], TResponse> {
     return new Query({
       method: "getcontractstate",
       params: [scriptHash],
+    });
+  }
+
+  /**
+   * Query returning the nep5 transfer history of an account. Defaults of 1 week of history.
+   * @param accountIdentifer - address or scriptHash of account
+   * @param startTime - millisecond Unix timestamp
+   * @param endTime - millisecond Unix timestamp
+   */
+  public static getNep5Transfers(
+    accountIdentifer: string,
+    startTime?: string,
+    endTime?: string
+  ): Query<[string, string?, string?], GetNep5TransfersResult> {
+    const params: [string, string?, string?] = [accountIdentifer];
+    if (startTime) params.push(startTime);
+    if (endTime) params.push(endTime);
+    return new Query({
+      method: "getnep5transfers",
+      params,
+    });
+  }
+
+  /**
+   * Query returning the nep5 balance of an account.
+   * @param accountIdentifer - address or scriptHash of account
+   */
+  public static getNep5Balances(
+    accountIdentifer: string
+  ): Query<[string], GetNep5BalancesResult> {
+    return new Query({
+      method: "getnep5balances",
+      params: [accountIdentifer],
     });
   }
 

--- a/packages/neon-core/src/rpc/RPCClient.ts
+++ b/packages/neon-core/src/rpc/RPCClient.ts
@@ -1,47 +1,34 @@
-import Axios, { AxiosRequestConfig } from "axios";
 import { DEFAULT_RPC, NEO_NETWORK, RPC_VERSION } from "../consts";
-import logger from "../logging";
 import { timeout } from "../settings";
-import { Transaction, Signer, SignerJson } from "../tx";
+import { NeoServerRpcMixin } from "./clients/NeoServerRpcClient";
 import {
-  Query,
-  CliPlugin,
-  GetPeersResult,
-  GetRawMemPoolResult,
-  GetRawTransactionResult,
-  InvokeResult,
-  RPCResponse,
-  BooleanLikeParam,
-  QueryLike,
-} from "./Query";
-import { ContractManifest } from "../sc";
-import { BlockJson, BlockHeaderJson, Validator } from "../types";
+  RpcDispatcher,
+  ApplicationLogsRpcMixin,
+  Nep5TrackerRpcMixin,
+} from "./clients";
+import { Query } from "./Query";
 
-const log = logger("rpc");
+function parseNetwork(net: string): string {
+  if (net === NEO_NETWORK.MAIN) {
+    return DEFAULT_RPC.MAIN;
+  } else if (net === NEO_NETWORK.TEST) {
+    return DEFAULT_RPC.TEST;
+  } else {
+    return net;
+  }
+}
 
-export async function sendQuery<TResponse>(
-  url: string,
-  query: Query<unknown[], TResponse>,
-  config: AxiosRequestConfig = {}
-): Promise<RPCResponse<TResponse>> {
-  log.info(`RPC: ${url} executing Query[${query.method}]`);
-  const conf = Object.assign(
-    {
-      headers: {
-        "Content-Type": "application/json",
-      },
-      timeout: timeout.rpc,
-    },
-    config
-  );
-
-  const response = await Axios.post(url, query.export(), conf);
-  return response.data as RPCResponse<TResponse>;
+class FullRpcClient extends Nep5TrackerRpcMixin(
+  ApplicationLogsRpcMixin(NeoServerRpcMixin(RpcDispatcher))
+) {
+  public get [Symbol.toStringTag](): string {
+    return `FullRpcClient(${this.url})`;
+  }
 }
 /**
  * RPC Client model to query a NEO node. Contains built-in methods to query using RPC calls.
  */
-export class RPCClient {
+export class RPCClient extends FullRpcClient {
   public net: string;
   public history: Query<unknown[], unknown>[];
   public lastSeenHeight: number;
@@ -53,13 +40,9 @@ export class RPCClient {
    * @param version - version of NEO node. Used to check if RPC methods have been implemented. it will default to DEFAULT_RPC found in CONST
    */
   public constructor(net: string, version = RPC_VERSION) {
-    if (net === NEO_NETWORK.MAIN) {
-      this.net = DEFAULT_RPC.MAIN;
-    } else if (net === NEO_NETWORK.TEST) {
-      this.net = DEFAULT_RPC.TEST;
-    } else {
-      this.net = net;
-    }
+    const url = parseNetwork(net);
+    super(url);
+    this.net = url;
 
     this.history = [];
     this.lastSeenHeight = 0;
@@ -69,7 +52,7 @@ export class RPCClient {
   }
 
   public get [Symbol.toStringTag](): string {
-    return "RPC Client";
+    return `RPC Client(${this.net})`;
   }
 
   public get latency(): number {
@@ -93,9 +76,8 @@ export class RPCClient {
    */
   public async ping(): Promise<number> {
     const timeStart = Date.now();
-    const query = Query.getBlockCount();
     try {
-      const response = await this.execute(query, { timeout: timeout.ping });
+      const response = await this.getBlockCount();
       this.lastSeenHeight = response;
       const newPing = Date.now() - timeStart;
       this.latency = newPing;
@@ -104,279 +86,6 @@ export class RPCClient {
       this.latency = timeout.ping;
       return timeout.ping;
     }
-  }
-
-  /**
-   * Takes an Query object and executes it. Throws if error is encountered.
-   */
-  public async execute<TResponse>(
-    query: Query<unknown[], TResponse>,
-    config?: AxiosRequestConfig
-  ): Promise<TResponse> {
-    const rpcResponse = await sendQuery(this.net, query, config ?? {});
-    if (rpcResponse.error) {
-      throw new Error(rpcResponse.error.message);
-    }
-    return rpcResponse.result;
-  }
-
-  /**
-   * Creates a query with the given req and immediately executes it.
-   */
-  public query(
-    req: QueryLike<unknown[]>,
-    config?: AxiosRequestConfig
-  ): Promise<unknown> {
-    const query = new Query(req);
-    return this.execute(query, config);
-  }
-
-  /**
-   * Get the latest block hash.
-   */
-  public async getBestBlockHash(): Promise<string> {
-    const response = await this.execute(Query.getBestBlockHash());
-    return response;
-  }
-
-  /**
-   * Gets the block at a given height or hash.
-   * @param indexOrHash - height or hash of desired block;
-   * @param verbose - 0 for serialized block in hex, 1 for json format, defaults to 0
-   * @returns string or block object according to verbose
-   */
-  public async getBlock(
-    indexOrHash: number | string,
-    verbose?: 0 | false
-  ): Promise<string>;
-  public async getBlock(
-    indexOrHash: number | string,
-    verbose: 1 | true
-  ): Promise<BlockJson>;
-  public async getBlock(
-    indexOrHash: number | string,
-    verbose?: BooleanLikeParam
-  ): Promise<string | BlockJson> {
-    return verbose
-      ? await this.execute(Query.getBlock(indexOrHash, 1))
-      : await this.execute(Query.getBlock(indexOrHash, 0));
-  }
-
-  /**
-   * Gets the block hash at a given height.
-   */
-  public async getBlockHash(index: number): Promise<string> {
-    const response = await this.execute(Query.getBlockHash(index));
-    return response;
-  }
-
-  /**
-   * Get the current block height.
-   */
-  public async getBlockCount(): Promise<number> {
-    const response = await this.execute(Query.getBlockCount());
-    return response;
-  }
-
-  /**
-   * Get the corresponding block header information according to the specified script hash.
-   * @param indexOrHash - height or hash of desired block
-   * @param verbose - 0 for serialized block in hex, 1 for json format, defaults to 0
-   * @returns verbose = 0, blocker header hex string; verbose = 1, block header info in json
-   */
-  public async getBlockHeader(
-    indexOrHash: number | string,
-    verbose?: 0
-  ): Promise<string>;
-  public async getBlockHeader(
-    indexOrHash: number | string,
-    verbose: 1
-  ): Promise<BlockHeaderJson>;
-  public async getBlockHeader(
-    indexOrHash: number | string,
-    verbose?: 0 | 1
-  ): Promise<string | BlockHeaderJson> {
-    return verbose
-      ? await this.execute(Query.getBlockHeader(indexOrHash, 1))
-      : await this.execute(Query.getBlockHeader(indexOrHash, 0));
-  }
-
-  /**
-   * Gets the number of peers this node is connected to.
-   */
-  public async getConnectionCount(): Promise<number> {
-    const response = await this.execute(Query.getConnectionCount());
-    return response;
-  }
-
-  /**
-   * Gets the state of the contract at the given scriptHash.
-   */
-  public async getContractState(scriptHash: string): Promise<ContractManifest> {
-    const response = await this.execute(Query.getContractState(scriptHash));
-    return new ContractManifest(response.manifest);
-  }
-
-  /**
-   * Gets a list of all peers that this node has discovered.
-   */
-  public async getPeers(): Promise<GetPeersResult> {
-    const response = await this.execute(Query.getPeers());
-    return response;
-  }
-
-  /**
-   * This Query returns the transaction hashes of the transactions confirmed or unconfirmed.
-   * @param shouldGetUnverified - shouldGetUnverified Optional. Default is 0.
-   * shouldGetUnverified = 0, get confirmed transaction hashes
-   * shouldGetUnverified = 1, get current block height and confirmed and unconfirmed tx hash
-   */
-  public async getRawMemPool(
-    shouldGetUnverified?: 0 | false
-  ): Promise<string[]>;
-  public async getRawMemPool(
-    shouldGetUnverified: 1 | true
-  ): Promise<GetRawMemPoolResult>;
-  public async getRawMemPool(
-    shouldGetUnverified: BooleanLikeParam = 0
-  ): Promise<string[] | GetRawMemPoolResult> {
-    return shouldGetUnverified
-      ? await this.execute(Query.getRawMemPool(1))
-      : await this.execute(Query.getRawMemPool(0));
-  }
-
-  /**
-   * Gets a transaction based on its hash.
-   * @param txid - transaction id
-   * @param verbose - 0, will query transaction in hex string; 1 will query for transaction object. defaults to 0
-   * @returns transaction hex or object
-   */
-  public async getRawTransaction(
-    txid: string,
-    verbose?: 0 | false
-  ): Promise<string>;
-  public async getRawTransaction(
-    txid: string,
-    verbose: 1 | true
-  ): Promise<GetRawTransactionResult>;
-  public async getRawTransaction(
-    txid: string,
-    verbose?: BooleanLikeParam
-  ): Promise<string | GetRawTransactionResult> {
-    return verbose
-      ? await this.execute(Query.getRawTransaction(txid, 1))
-      : await this.execute(Query.getRawTransaction(txid, 0));
-  }
-
-  /**
-   * Gets the corresponding value of a key in the storage of a contract address.
-   */
-  public async getStorage(scriptHash: string, key: string): Promise<string> {
-    const response = await this.execute(Query.getStorage(scriptHash, key));
-    return response;
-  }
-
-  /**
-   * Gets the block index in which the transaction is found.
-   * @param txid - hash of the specific transaction.
-   */
-  public async getTransactionHeight(txid: string): Promise<number> {
-    const response = await this.execute(Query.getTransactionHeight(txid));
-    return response;
-  }
-
-  /**
-   * Gets the list of validators available for voting.
-   */
-  public async getValidators(): Promise<Validator[]> {
-    const response = await this.execute(Query.getValidators());
-    return response;
-  }
-  /**
-   * Gets the version of the NEO node. This method will never be blocked by version. This method will also update the current Client's version to the one received.
-   */
-  public async getVersion(): Promise<string> {
-    try {
-      const response = await this.execute(Query.getVersion());
-      if (response?.useragent) {
-        const useragent = response.useragent;
-        const responseLength = useragent.length;
-        const strippedResponse = useragent.substring(1, responseLength - 1);
-        this.version = strippedResponse.split(":")[1];
-      } else {
-        throw new Error(
-          `Empty or unexpected version pattern. Got ${JSON.stringify(response)}`
-        );
-      }
-      return this.version;
-    } catch (err) {
-      if (err.message.includes("Method not found")) {
-        this.version = RPC_VERSION;
-        return this.version;
-      } else {
-        throw err;
-      }
-    }
-  }
-
-  /**
-   * This Query returns a list of plugins loaded by the node.
-   */
-  public async listPlugins(): Promise<CliPlugin[]> {
-    const response = await this.execute(Query.listPlugins());
-    return response;
-  }
-
-  /**
-   * Submits a contract method call with parameters for the node to run. This method is a local invoke, results are not reflected on the blockchain.
-   */
-  public async invokeFunction(
-    scriptHash: string,
-    operation: string,
-    params: unknown[] = [],
-    signers: (Signer | SignerJson)[] = []
-  ): Promise<InvokeResult> {
-    return await this.execute(
-      Query.invokeFunction(scriptHash, operation, params, signers)
-    );
-  }
-
-  /**
-   * Submits a script for the node to run. This method is a local invoke, results are not reflected on the blockchain.
-   */
-  public async invokeScript(
-    script: string,
-    signers: (Signer | SignerJson)[] = []
-  ): Promise<InvokeResult> {
-    return await this.execute(Query.invokeScript(script, signers));
-  }
-
-  /**
-   * Sends a serialized transaction to the network.
-   * @returns transaction id
-   */
-  public async sendRawTransaction(
-    transaction: Transaction | string
-  ): Promise<string> {
-    const response = await this.execute(Query.sendRawTransaction(transaction));
-    return response.hash;
-  }
-
-  /**
-   * Submits a serialized block to the network.
-   * @returns block hash if success
-   */
-  public async submitBlock(block: string): Promise<string> {
-    const response = await this.execute(Query.submitBlock(block));
-    return response.hash;
-  }
-
-  /**
-   * Checks if the provided address is a valid NEO address.
-   */
-  public async validateAddress(addr: string): Promise<boolean> {
-    const response = await this.execute(Query.validateAddress(addr));
-    return response.isvalid;
   }
 }
 

--- a/packages/neon-core/src/rpc/clients/ApplicationLogsRpcClient.ts
+++ b/packages/neon-core/src/rpc/clients/ApplicationLogsRpcClient.ts
@@ -1,0 +1,23 @@
+import Query, { GetApplicationLogsResult } from "../Query";
+import { RpcDispatcher, RpcDispatcherMixin } from "./RpcDispatcher";
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
+export function ApplicationLogsRpcMixin<TBase extends RpcDispatcherMixin>(
+  base: TBase
+) {
+  return class extends base {
+    public async getApplicationLog(
+      blockHash: string
+    ): Promise<GetApplicationLogsResult> {
+      return await this.execute(Query.getApplicationLogs(blockHash));
+    }
+  };
+}
+
+export class ApplicationLogsRpcClient extends ApplicationLogsRpcMixin(
+  RpcDispatcher
+) {
+  public get [Symbol.toStringTag](): string {
+    return `ApplicationLogsRpcClient(${this.url})`;
+  }
+}

--- a/packages/neon-core/src/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/src/rpc/clients/NeoServerRpcClient.ts
@@ -1,0 +1,271 @@
+import { Transaction, Signer, SignerJson } from "../../tx";
+import {
+  Query,
+  CliPlugin,
+  GetPeersResult,
+  GetRawMemPoolResult,
+  GetRawTransactionResult,
+  InvokeResult,
+  BooleanLikeParam,
+} from "../Query";
+import { ContractManifest } from "../../sc";
+import { BlockJson, BlockHeaderJson, Validator } from "../../types";
+import { RpcDispatcher, RpcDispatcherMixin } from "./RpcDispatcher";
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
+export function NeoServerRpcMixin<TBase extends RpcDispatcherMixin>(
+  base: TBase
+) {
+  return class NeoServerRpcInterface extends base {
+    /**
+     * Get the latest block hash.
+     */
+    public async getBestBlockHash(): Promise<string> {
+      const response = await this.execute(Query.getBestBlockHash());
+      return response;
+    }
+
+    /**
+     * Gets the block at a given height or hash.
+     * @param indexOrHash - height or hash of desired block;
+     * @param verbose - 0 for serialized block in hex, 1 for json format, defaults to 0
+     * @returns string or block object according to verbose
+     */
+    public async getBlock(
+      indexOrHash: number | string,
+      verbose?: 0 | false
+    ): Promise<string>;
+    public async getBlock(
+      indexOrHash: number | string,
+      verbose: 1 | true
+    ): Promise<BlockJson>;
+    public async getBlock(
+      indexOrHash: number | string,
+      verbose?: BooleanLikeParam
+    ): Promise<string | BlockJson> {
+      return verbose
+        ? await this.execute(Query.getBlock(indexOrHash, 1))
+        : await this.execute(Query.getBlock(indexOrHash, 0));
+    }
+
+    /**
+     * Gets the block hash at a given height.
+     */
+    public async getBlockHash(index: number): Promise<string> {
+      const response = await this.execute(Query.getBlockHash(index));
+      return response;
+    }
+
+    /**
+     * Get the current block height.
+     */
+    public async getBlockCount(): Promise<number> {
+      const response = await this.execute(Query.getBlockCount());
+      return response;
+    }
+
+    /**
+     * Get the corresponding block header information according to the specified script hash.
+     * @param indexOrHash - height or hash of desired block
+     * @param verbose - 0 for serialized block in hex, 1 for json format, defaults to 0
+     * @returns verbose = 0, blocker header hex string; verbose = 1, block header info in json
+     */
+    public async getBlockHeader(
+      indexOrHash: number | string,
+      verbose?: 0
+    ): Promise<string>;
+    public async getBlockHeader(
+      indexOrHash: number | string,
+      verbose: 1
+    ): Promise<BlockHeaderJson>;
+    public async getBlockHeader(
+      indexOrHash: number | string,
+      verbose?: 0 | 1
+    ): Promise<string | BlockHeaderJson> {
+      return verbose
+        ? await this.execute(Query.getBlockHeader(indexOrHash, 1))
+        : await this.execute(Query.getBlockHeader(indexOrHash, 0));
+    }
+
+    /**
+     * Gets the number of peers this node is connected to.
+     */
+    public async getConnectionCount(): Promise<number> {
+      const response = await this.execute(Query.getConnectionCount());
+      return response;
+    }
+
+    /**
+     * Gets the state of the contract at the given scriptHash.
+     */
+    public async getContractState(
+      scriptHash: string
+    ): Promise<ContractManifest> {
+      const response = await this.execute(Query.getContractState(scriptHash));
+      return new ContractManifest(response.manifest);
+    }
+
+    /**
+     * Gets a list of all peers that this node has discovered.
+     */
+    public async getPeers(): Promise<GetPeersResult> {
+      const response = await this.execute(Query.getPeers());
+      return response;
+    }
+
+    /**
+     * This Query returns the transaction hashes of the transactions confirmed or unconfirmed.
+     * @param shouldGetUnverified - shouldGetUnverified Optional. Default is 0.
+     * shouldGetUnverified = 0, get confirmed transaction hashes
+     * shouldGetUnverified = 1, get current block height and confirmed and unconfirmed tx hash
+     */
+    public async getRawMemPool(
+      shouldGetUnverified?: 0 | false
+    ): Promise<string[]>;
+    public async getRawMemPool(
+      shouldGetUnverified: 1 | true
+    ): Promise<GetRawMemPoolResult>;
+    public async getRawMemPool(
+      shouldGetUnverified: BooleanLikeParam = 0
+    ): Promise<string[] | GetRawMemPoolResult> {
+      return shouldGetUnverified
+        ? await this.execute(Query.getRawMemPool(1))
+        : await this.execute(Query.getRawMemPool(0));
+    }
+
+    /**
+     * Gets a transaction based on its hash.
+     * @param txid - transaction id
+     * @param verbose - 0, will query transaction in hex string; 1 will query for transaction object. defaults to 0
+     * @returns transaction hex or object
+     */
+    public async getRawTransaction(
+      txid: string,
+      verbose?: 0 | false
+    ): Promise<string>;
+    public async getRawTransaction(
+      txid: string,
+      verbose: 1 | true
+    ): Promise<GetRawTransactionResult>;
+    public async getRawTransaction(
+      txid: string,
+      verbose?: BooleanLikeParam
+    ): Promise<string | GetRawTransactionResult> {
+      return verbose
+        ? await this.execute(Query.getRawTransaction(txid, 1))
+        : await this.execute(Query.getRawTransaction(txid, 0));
+    }
+
+    /**
+     * Gets the corresponding value of a key in the storage of a contract address.
+     */
+    public async getStorage(scriptHash: string, key: string): Promise<string> {
+      const response = await this.execute(Query.getStorage(scriptHash, key));
+      return response;
+    }
+
+    /**
+     * Gets the block index in which the transaction is found.
+     * @param txid - hash of the specific transaction.
+     */
+    public async getTransactionHeight(txid: string): Promise<number> {
+      const response = await this.execute(Query.getTransactionHeight(txid));
+      return response;
+    }
+
+    /**
+     * Gets the list of validators available for voting.
+     */
+    public async getValidators(): Promise<Validator[]> {
+      const response = await this.execute(Query.getValidators());
+      return response;
+    }
+    /**
+     * Gets the version of the NEO node. This method will never be blocked by version. This method will also update the current Client's version to the one received.
+     */
+    public async getVersion(): Promise<string> {
+      const response = await this.execute(Query.getVersion());
+      if (response?.useragent) {
+        const useragent = response.useragent;
+        const responseLength = useragent.length;
+        const strippedResponse = useragent.substring(1, responseLength - 1);
+        return strippedResponse.split(":")[1];
+      } else {
+        throw new Error(
+          `Empty or unexpected version pattern. Got ${JSON.stringify(response)}`
+        );
+      }
+    }
+
+    /**
+     * Returns a list of plugins loaded by the node.
+     */
+    public async listPlugins(): Promise<CliPlugin[]> {
+      const response = await this.execute(Query.listPlugins());
+      return response;
+    }
+
+    /**
+     * Submits a contract method call with parameters for the node to run. This method is a local invoke, results are not reflected on the blockchain.
+     */
+    public async invokeFunction(
+      scriptHash: string,
+      operation: string,
+      params: unknown[] = [],
+      signers: (Signer | SignerJson)[] = []
+    ): Promise<InvokeResult> {
+      return await this.execute(
+        Query.invokeFunction(scriptHash, operation, params, signers)
+      );
+    }
+
+    /**
+     * Submits a script for the node to run. This method is a local invoke, results are not reflected on the blockchain.
+     */
+    public async invokeScript(
+      script: string,
+      signers: (Signer | SignerJson)[] = []
+    ): Promise<InvokeResult> {
+      return await this.execute(Query.invokeScript(script, signers));
+    }
+
+    /**
+     * Sends a serialized transaction to the network.
+     * @returns transaction id
+     */
+    public async sendRawTransaction(
+      transaction: Transaction | string
+    ): Promise<string> {
+      const response = await this.execute(
+        Query.sendRawTransaction(transaction)
+      );
+      return response.hash;
+    }
+
+    /**
+     * Submits a serialized block to the network.
+     * @returns block hash if success
+     */
+    public async submitBlock(block: string): Promise<string> {
+      const response = await this.execute(Query.submitBlock(block));
+      return response.hash;
+    }
+
+    /**
+     * Checks if the provided address is a valid NEO address.
+     */
+    public async validateAddress(addr: string): Promise<boolean> {
+      const response = await this.execute(Query.validateAddress(addr));
+      return response.isvalid;
+    }
+  };
+}
+
+/**
+ * RPC Client model to query a NEO node. Contains built-in methods to query using RPC calls.
+ */
+export class NeoServerRpcClient extends NeoServerRpcMixin(RpcDispatcher) {
+  public get [Symbol.toStringTag](): string {
+    return `NeoServerRpcClient(${this.url})`;
+  }
+}

--- a/packages/neon-core/src/rpc/clients/Nep5TrackerRpcClient.ts
+++ b/packages/neon-core/src/rpc/clients/Nep5TrackerRpcClient.ts
@@ -1,0 +1,30 @@
+import { Query, GetNep5BalancesResult, GetNep5TransfersResult } from "../Query";
+import { RpcDispatcher, RpcDispatcherMixin } from "./RpcDispatcher";
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
+export function Nep5TrackerRpcMixin<TBase extends RpcDispatcherMixin>(
+  base: TBase
+) {
+  return class Nep5TrackerRpcInterface extends base {
+    public async getNep5Transfers(
+      accountIdentifier: string,
+      startTime?: string,
+      endTime?: string
+    ): Promise<GetNep5TransfersResult> {
+      return this.execute(
+        Query.getNep5Transfers(accountIdentifier, startTime, endTime)
+      );
+    }
+    public async getNep5Balances(
+      accountIdentifier: string
+    ): Promise<GetNep5BalancesResult> {
+      return this.execute(Query.getNep5Balances(accountIdentifier));
+    }
+  };
+}
+
+export class Nep5TrackerRpcClient extends Nep5TrackerRpcMixin(RpcDispatcher) {
+  public get [Symbol.toStringTag](): string {
+    return `Nep5TrackerRpcClient(${this.url})`;
+  }
+}

--- a/packages/neon-core/src/rpc/clients/RpcDispatcher.ts
+++ b/packages/neon-core/src/rpc/clients/RpcDispatcher.ts
@@ -1,0 +1,77 @@
+import { Query, RPCResponse, RPCErrorResponse } from "../Query";
+import logger from "../../logging";
+import Axios, { AxiosRequestConfig } from "axios";
+import { timeout } from "../../settings";
+
+const log = logger("rpc");
+
+export interface RpcConfig {
+  // Timeout in ms
+  timeout?: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
+export type GConstructor<T = {}> = new (...args: any[]) => T;
+export type RpcDispatcherMixin = GConstructor<RpcDispatcher>;
+
+export async function sendQuery<TResponse>(
+  url: string,
+  query: Query<unknown[], TResponse>,
+  config: RpcConfig = {}
+): Promise<RPCResponse<TResponse>> {
+  log.info(`RPC: ${url} executing Query[${query.method}]`);
+  const conf = Object.assign(
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      timeout: timeout.rpc,
+    },
+    config
+  );
+
+  const response = await Axios.post(url, query.export(), conf);
+  return response.data as RPCResponse<TResponse>;
+}
+
+/**
+ * Basic JSON-RPC 2.0 Dispatcher. Contains the basic infrastructure to send out JSON-RPC 2.0 methods.
+ * Client interfaces should accept this RpcDispatcher as a constructor parameter.
+ *
+ * @example
+ *
+ * ```ts
+ * const dispatcher = new RpcDispatcher("http://www.example.com");
+ * const result = await dispatcher.execute(new Query({"method": "listplugins"}));
+ * ```
+ */
+export class RpcDispatcher {
+  public url: string;
+
+  public constructor(url: string) {
+    this.url = url;
+  }
+
+  /**
+   * Takes an Query object and executes it. Throws if error is encountered.
+   */
+  public async execute<TResponse>(
+    query: Query<unknown[], TResponse>,
+    config?: AxiosRequestConfig
+  ): Promise<TResponse> {
+    const rpcResponse = await sendQuery(this.url, query, config ?? {});
+    if (rpcResponse.error) {
+      throw new RpcError(rpcResponse.error);
+    }
+    return rpcResponse.result;
+  }
+}
+
+export class RpcError extends Error {
+  public code: number;
+
+  constructor(errResponse: RPCErrorResponse) {
+    super(errResponse.message);
+    this.code = errResponse.code;
+  }
+}

--- a/packages/neon-core/src/rpc/clients/index.ts
+++ b/packages/neon-core/src/rpc/clients/index.ts
@@ -1,0 +1,4 @@
+export * from "./RpcDispatcher";
+export * from "./ApplicationLogsRpcClient";
+export * from "./Nep5TrackerRpcClient";
+export * from "./NeoServerRpcClient";

--- a/packages/neon-core/src/rpc/index.ts
+++ b/packages/neon-core/src/rpc/index.ts
@@ -3,3 +3,4 @@ export * from "./Protocol";
 export * from "./Query";
 export * from "./RPCClient";
 export * from "./parse";
+export * from "./clients";

--- a/testHelpers.ts
+++ b/testHelpers.ts
@@ -1,0 +1,44 @@
+import { rpc } from "./packages/neon-core/src";
+
+export const TESTNET_URLS = [
+  "http://seed1t.neo.org:20332",
+  "http://seed2t.neo.org:20332",
+  "http://seed3t.neo.org:20332",
+  "http://seed4t.neo.org:20332",
+  "http://seed5t.neo.org:20332",
+];
+
+export const LOCALNET_URLS = ["http://localhost:20332"];
+
+export async function getIntegrationEnvUrl(): Promise<string> {
+  const urls = isTestNet() ? TESTNET_URLS : LOCALNET_URLS;
+  return await getBestUrl(urls);
+}
+
+export function isTestNet(): boolean {
+  return (global["__TARGETNET__"] as string).toLowerCase() === "testnet";
+}
+
+export async function getBestUrl(urls: string[]): Promise<string> {
+  const data = await Promise.all(urls.map((url) => safelyCheckHeight(url)));
+  const heights = data.map((h, i) => ({ height: h, url: urls[i] }));
+  const best = heights.reduce(
+    (bestSoFar, h) => (bestSoFar.height >= h.height ? bestSoFar : h),
+    { height: -1, url: "" }
+  );
+  if (!best.url) {
+    throw new Error("No good endpoint found");
+  }
+  return best.url;
+}
+
+async function safelyCheckHeight(url: string): Promise<number> {
+  try {
+    const res = await rpc.sendQuery(url, rpc.Query.getBlockCount(), {
+      timeout: 10000,
+    });
+    return res.result;
+  } catch (_e) {
+    return -1;
+  }
+}


### PR DESCRIPTION
Utilizing the mixin pattern, I am able to break out the RPC API into separate interfaces.

- RpcDispatcher now contains the core logic for sending out the rpc payload.
- Add support for NEP5Tracker and ApplicationLog RPC calls.
- Moved implementation from RPCClient to NeoServerRpcClient.
- RPCClient old functionality is retained for now. Added the new supported calls.
- We are still missing wallet methods but this is intentional. I do not expect much benefits for the normal consumer.