### PR TITLE
chore(docs): Change get started link to overview

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -82,7 +82,7 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle />
           <PromoSection>
-            <Button href={docUrl('installation.html', language)}><translate>Get Started</translate></Button>
+            <Button href={docUrl('overview.html.html', language)}><translate>Get Started</translate></Button>
             <Button href={docUrl('guides/basic/sendasset.html', language)}><translate>Tutorial</translate></Button>
             <Button href={docUrl('api/index.html', language)}><translate>API</translate></Button>
             <Button href={docUrl('examples/index.html', language)}><translate>Examples</translate></Button>


### PR DESCRIPTION
As a first time `neon-js` user I'm going through the website and wanted to "get started". The link originally points to the "installation" page which is actually the 2nd page of the "Get Started" section. The first would be the `overview` page, which I actually found to contain useful information. 

This PR changes the link to point to the first page of the get started section.   