### PR TITLE
fix(sc): Fix emitHexString emitting wrong endian

### DIFF
--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -1,5 +1,6 @@
 import Query from "../../src/rpc/Query";
-import { Transaction } from "../../src/tx";
+import { ContractParam } from "../../src/sc";
+import { Transaction, WitnessScope } from "../../src/tx";
 
 describe("constructor", () => {
   test("RPCRequest", () => {
@@ -154,23 +155,44 @@ describe("static", () => {
     });
 
     test("multiple params", () => {
-      const params = [jest.fn(), jest.fn(), jest.fn()];
-      const result = Query.invokeFunction("hash", "method", params);
+      const inputParams = [
+        1,
+        ContractParam.integer(2),
+        { type: "Integer", value: "3" },
+      ];
+      const result = Query.invokeFunction("hash", "method", inputParams);
       expect(result.method).toEqual("invokefunction");
-      expect(result.params).toEqual(["hash", "method", params, []]);
+      expect(result.params).toEqual([
+        "hash",
+        "method",
+        [1, { type: "Integer", value: "2" }, { type: "Integer", value: "3" }],
+        [],
+      ]);
     });
 
-    test("multiple params with checkedWitnessHashes", () => {
-      const params = [jest.fn(), jest.fn(), jest.fn()];
-      const result = Query.invokeFunction("hash", "method", params, [
-        "abcdabcdabcdabcdabcd",
+    test("multiple params with signers", () => {
+      const inputParams = [
+        1,
+        ContractParam.integer(2),
+        { type: "Integer", value: "3" },
+      ];
+      const result = Query.invokeFunction("hash", "method", inputParams, [
+        {
+          account: "ab".repeat(20),
+          scopes: "CalledByEntry",
+        },
       ]);
       expect(result.method).toEqual("invokefunction");
       expect(result.params).toEqual([
         "hash",
         "method",
-        params,
-        ["abcdabcdabcdabcdabcd"],
+        [1, { type: "Integer", value: "2" }, { type: "Integer", value: "3" }],
+        [
+          {
+            account: "ab".repeat(20),
+            scopes: "CalledByEntry",
+          },
+        ],
       ]);
     });
   });

--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -190,7 +190,7 @@ describe("static", () => {
         [1, { type: "Integer", value: "2" }, { type: "Integer", value: "3" }],
         [
           {
-            account: "ab".repeat(20),
+            account: "0x" + "ab".repeat(20),
             scopes: "FeeOnly",
           },
           {
@@ -222,7 +222,7 @@ describe("static", () => {
         "script",
         [
           {
-            account: "ab".repeat(20),
+            account: "0x" + "ab".repeat(20),
             scopes: "FeeOnly",
           },
           {

--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -1,6 +1,6 @@
 import Query from "../../src/rpc/Query";
 import { ContractParam } from "../../src/sc";
-import { Transaction, WitnessScope } from "../../src/tx";
+import { Transaction, Signer } from "../../src/tx";
 
 describe("constructor", () => {
   test("RPCRequest", () => {
@@ -177,8 +177,9 @@ describe("static", () => {
         { type: "Integer", value: "3" },
       ];
       const result = Query.invokeFunction("hash", "method", inputParams, [
+        new Signer({ account: "ab".repeat(20) }),
         {
-          account: "ab".repeat(20),
+          account: "cd".repeat(20),
           scopes: "CalledByEntry",
         },
       ]);
@@ -190,6 +191,10 @@ describe("static", () => {
         [
           {
             account: "ab".repeat(20),
+            scopes: "FeeOnly",
+          },
+          {
+            account: "cd".repeat(20),
             scopes: "CalledByEntry",
           },
         ],
@@ -204,10 +209,28 @@ describe("static", () => {
       expect(result.params).toEqual(["script", []]);
     });
 
-    test("script with checkWitnessHashes", () => {
-      const result = Query.invokeScript("script", ["abcdabcdabcdabcdabcd"]);
+    test("script with signers", () => {
+      const result = Query.invokeScript("script", [
+        new Signer({ account: "ab".repeat(20) }),
+        {
+          account: "cd".repeat(20),
+          scopes: "CalledByEntry",
+        },
+      ]);
       expect(result.method).toEqual("invokescript");
-      expect(result.params).toEqual(["script", ["abcdabcdabcdabcdabcd"]]);
+      expect(result.params).toEqual([
+        "script",
+        [
+          {
+            account: "ab".repeat(20),
+            scopes: "FeeOnly",
+          },
+          {
+            account: "cd".repeat(20),
+            scopes: "CalledByEntry",
+          },
+        ],
+      ]);
     });
   });
 

--- a/packages/neon-core/__tests__/sc/ContractParam.ts
+++ b/packages/neon-core/__tests__/sc/ContractParam.ts
@@ -1,8 +1,10 @@
-import ContractParam, {
+import {
+  ContractParam,
   ContractParamType,
   likeContractParam,
   ContractParamLike,
 } from "../../src/sc/ContractParam";
+import { HexString } from "../../src/u";
 
 describe("constructor", () => {
   test("ContractParamLike", () => {
@@ -95,7 +97,9 @@ describe("Static constructors", () => {
 
       expect(result instanceof ContractParam).toBeTruthy();
       expect(result.type).toBe(ContractParamType.Hash160);
-      expect(result.value).toBe(expected);
+      expect(result.value).toBeInstanceOf(HexString);
+      const hexStringValue = result.value as HexString;
+      expect(hexStringValue.toBigEndian()).toBe(expected);
     });
 
     test("Errors on non-address or scripthash", () => {
@@ -157,7 +161,9 @@ describe("Static constructors", () => {
 
     expect(result instanceof ContractParam).toBeTruthy();
     expect(result.type).toBe(ContractParamType.PublicKey);
-    expect(result.value).toBe(
+    expect(result.value).toBeInstanceOf(HexString);
+    const hexStringValue = result.value as HexString;
+    expect(hexStringValue.toBigEndian()).toBe(
       "026d3ca98c83dd2490a134ba4f874b59292afaac8abc2f9b34b690fcd2b44648ee"
     );
   });

--- a/packages/neon-core/__tests__/sc/ScriptBuilder.ts
+++ b/packages/neon-core/__tests__/sc/ScriptBuilder.ts
@@ -59,7 +59,7 @@ describe("emitSysCall", () => {
 });
 
 describe("emitAppCall", () => {
-  test.only.each([
+  test.each([
     [
       "simple emitAppCall",
       {
@@ -165,7 +165,9 @@ describe("emitString", () => {
 describe("emitHexString", () => {
   test.each([
     ["null", "", "0c00"],
-    ["basic", "0102030405", "0c050504030201"],
+    ["string input", "0102030405", "0c050102030405"],
+    ["string input", HexString.fromHex("0102030405", true), "0c050102030405"],
+    ["string input", HexString.fromHex("0102030405", false), "0c050504030201"],
   ])("%s", (_msg: string, data: string | HexString, expected: string) => {
     const sb = new ScriptBuilder();
     sb.emitHexString(data);

--- a/packages/neon-core/__tests__/sc/ScriptBuilder.ts
+++ b/packages/neon-core/__tests__/sc/ScriptBuilder.ts
@@ -59,7 +59,7 @@ describe("emitSysCall", () => {
 });
 
 describe("emitAppCall", () => {
-  test.each([
+  test.only.each([
     [
       "simple emitAppCall",
       {
@@ -72,16 +72,16 @@ describe("emitAppCall", () => {
     [
       "emitAppCall with args",
       {
-        scriptHash: "9bde8f209c88dd0e7ca3bf0af0f476cdd8207789",
+        scriptHash: "de5f57d430d3dece511cf975a8d37848cb9e0525",
         operation: "balanceOf",
         args: [
           {
             type: "Hash160",
-            value: "a7213b15cc18d19c810f644e37411d882ee561ca",
+            value: "4120c7c8443dd30af91a8280d151fd38d1b9be91",
           },
         ],
       },
-      "0c14ca61e52e881d41374e640f819cd118cc153b21a711c00c0962616c616e63654f660c14897720d8cd76f4f00abfa37c0edd889c208fde9b41627d5b52",
+      "0c1491beb9d138fd51d180821af90ad33d44c8c7204111c00c0962616c616e63654f660c1425059ecb4878d3a875f91c51ceded330d4575fde41627d5b52",
     ],
   ] as [string, ScriptIntent, string][])(
     "%s",
@@ -144,6 +144,7 @@ describe("emitString", () => {
       "simple string",
       "0c" + "0d" + "73696d706c6520737472696e67",
     ],
+    ["12345", "12345", "0c053132333435"],
     ["256 byte string", "a".repeat(0x100), "0d" + "0001" + "61".repeat(0x100)],
     [
       "65536 byte string",
@@ -159,6 +160,19 @@ describe("emitString", () => {
   });
 
   // Difficult to test throw when string too large due to string buffer smaller than limit
+});
+
+describe("emitHexString", () => {
+  test.each([
+    ["null", "", "0c00"],
+    ["basic", "0102030405", "0c050504030201"],
+  ])("%s", (_msg: string, data: string | HexString, expected: string) => {
+    const sb = new ScriptBuilder();
+    sb.emitHexString(data);
+    // Check initial slice to fail early and print less
+    expect(sb.build().substr(0, 10)).toBe(expected.substr(0, 10));
+    expect(sb.build()).toBe(expected);
+  });
 });
 
 describe("emitNumber", () => {

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_REQ } from "../consts";
 import { Transaction, TransactionJson, Signer, SignerJson } from "../tx";
-import { ContractManifestLike, StackItemJson } from "../sc";
+import { ContractManifestLike, ContractParam, StackItemJson } from "../sc";
 import { BlockJson, Validator, BlockHeaderJson } from "../types";
 
 export type BooleanLikeParam = 0 | 1 | boolean;
@@ -387,8 +387,8 @@ export class Query<TParams extends unknown[], TResponse> {
    * This Query invokes the VM to run the specific contract with the provided operation and params. Do note that this function only suits contracts with a Main(string, args[]) entry method.
    * @param scriptHash - hash of contract to test.
    * @param operation - name of operation to call (first argument)
-   * @param params - parameters to pass (second argument)
-   * @param signers - scripthashes of witnesses that should sign the transaction containing this script.
+   * @param params - parameters to pass (second argument). ContractParam objects will be exported to JSON format.
+   * @param signers - scripthashes of witnesses that should sign the transaction containing this script. Signers will be exported to JSON format.
    */
   public static invokeFunction(
     scriptHash: string,
@@ -401,7 +401,7 @@ export class Query<TParams extends unknown[], TResponse> {
       params: [
         scriptHash,
         operation,
-        params,
+        params.map((p) => (p instanceof ContractParam ? p.export() : p)),
         signers.map((s) => (s instanceof Signer ? s.toJson() : s)),
       ],
     });

--- a/packages/neon-core/src/sc/ContractParam.ts
+++ b/packages/neon-core/src/sc/ContractParam.ts
@@ -186,9 +186,11 @@ export class ContractParam implements NeonObject<ContractParamLike> {
         case ContractParamType.Hash256:
         case ContractParamType.PublicKey:
           this.value = HexString.fromHex(input.value as string);
+          return;
         case ContractParamType.Integer:
         case ContractParamType.String:
           this.value = input.value as number | string;
+          return;
         case ContractParamType.Any:
           this.value =
             typeof input.value === "object"

--- a/packages/neon-core/src/sc/ContractParam.ts
+++ b/packages/neon-core/src/sc/ContractParam.ts
@@ -272,6 +272,16 @@ export class ContractParam implements NeonObject<ContractParamLike> {
           return false;
         case ContractParamType.Void:
           return true;
+        case ContractParamType.Hash160:
+        case ContractParamType.Hash256:
+        case ContractParamType.PublicKey:
+          if (
+            other.value instanceof HexString ||
+            typeof other.value === "string"
+          ) {
+            return (this.value as HexString).equals(other.value);
+          }
+          return false;
         default:
           return this.value === other.value;
       }

--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -65,7 +65,7 @@ export class ScriptBuilder extends StringStream {
     }
 
     return this.emitString(operation)
-      .emitHexstring(HexString.fromHex(scriptHash))
+      .emitHexString(HexString.fromHex(scriptHash))
       .emitSysCall(InteropServiceCode.SYSTEM_CONTRACT_CALL);
   }
 
@@ -93,7 +93,7 @@ export class ScriptBuilder extends StringStream {
         if (Array.isArray(data)) {
           return this.emitArray(data);
         } else if (data instanceof HexString) {
-          return this.emitHexstring(data);
+          return this.emitHexString(data);
         } else if (data === null) {
           return this.emitPush(false);
         } else if (likeContractParam(data)) {
@@ -127,7 +127,7 @@ export class ScriptBuilder extends StringStream {
    * Appends a bytearray.
    */
   public emitBytes(byteArray: ArrayBuffer | ArrayLike<number>): this {
-    return this.emitHexstring(HexString.fromArrayBuffer(byteArray, true));
+    return this.emitHexString(HexString.fromArrayBuffer(byteArray, true));
   }
 
   /**
@@ -141,10 +141,14 @@ export class ScriptBuilder extends StringStream {
 
   /**
    * Appends a hexstring.
+   *
+   * @remarks
+   * If a Javascript string is provided, it is emitted as it is.
+   * If a HexString is provided, it is emitted as little-endian.
    */
-  public emitHexstring(hexstr: string | HexString): this {
+  public emitHexString(hexstr: string | HexString): this {
     if (typeof hexstr === "string") {
-      hexstr = HexString.fromHex(hexstr);
+      hexstr = HexString.fromHex(hexstr, true);
     }
     const littleEndianHex = hexstr.toLittleEndian();
     const size = hexstr.byteLength;
@@ -272,13 +276,14 @@ export class ScriptBuilder extends StringStream {
       case ContractParamType.Integer:
         return this.emitNumber(param.value as number | string);
       case ContractParamType.ByteArray:
-        return this.emitHexstring(param.value as string);
+        return this.emitHexString(param.value as string);
       case ContractParamType.Array:
         return this.emitArray(param.value as ContractParam[]);
       case ContractParamType.Hash160:
       case ContractParamType.Hash256:
+        return this.emitHexString(param.value as HexString);
       case ContractParamType.PublicKey:
-        return this.emitHexstring(param.value as HexString);
+        return this.emitPublicKey(param.value as string);
       default:
         throw new Error(`Unaccounted ContractParamType!: ${param.type}`);
     }


### PR DESCRIPTION
- Fix ContractParam not exiting upon seeing Hash160
- Fix Query.invokeFunction not exporting inputs correctly.
- Adjust emitHexString to choose endianness on seeing type.