### PR TITLE
fix(wallet): Generate public key from verification script

### DIFF
--- a/packages/neon-core/__tests__/wallet/Account.ts
+++ b/packages/neon-core/__tests__/wallet/Account.ts
@@ -1,4 +1,5 @@
 import Account, { AccountJSON } from "../../src/wallet/Account";
+import testWalletJson from "../testWallet.json";
 
 jest.mock("../../src/wallet/nep2");
 
@@ -72,6 +73,15 @@ describe("export", () => {
     const acct = new Account(testObject);
     const result = acct.export();
     expect(result).toEqual(testObject);
+  });
+});
+
+describe("others", () => {
+  test("extract public key from verification script", () => {
+    const acct = new Account(testWalletJson.accounts[0]);
+    expect(acct.publicKey).toBe(
+      "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef"
+    );
   });
 });
 

--- a/packages/neon-core/src/wallet/core.ts
+++ b/packages/neon-core/src/wallet/core.ts
@@ -84,16 +84,14 @@ export function getPublicKeyFromPrivateKey(
  * It is attached as part of the signature when signing a transaction.
  * Thus, the name 'scriptHash' instead of 'keyHash' is because we are hashing the verificationScript and not the PublicKey.
  */
-export const getVerificationScriptFromPublicKey = (
-  publicKey: string
-): string => {
+export function getVerificationScriptFromPublicKey(publicKey: string): string {
   const sb = new ScriptBuilder();
   return sb
     .emit(OpCode.PUSHDATA1, "21" + publicKey)
     .emit(OpCode.PUSHNULL)
     .emitSysCall(InteropServiceCode.NEO_CRYPTO_VERIFYWITHECDSASECP256R1)
     .build();
-};
+}
 
 /**
  * Extracts the public key from the verification script. This only works for single key accounts.
@@ -124,33 +122,33 @@ export function getPublicKeyFromVerificationScript(script: string): string {
 /**
  * Converts a public key to scripthash.
  */
-export const getScriptHashFromPublicKey = (publicKey: string): string => {
+export function getScriptHashFromPublicKey(publicKey: string): string {
   // if unencoded
   if (publicKey.substring(0, 2) === "04") {
     publicKey = getPublicKeyEncoded(publicKey);
   }
   const verificationScript = getVerificationScriptFromPublicKey(publicKey);
   return reverseHex(hash160(verificationScript));
-};
+}
 
 /**
  * Converts a scripthash to address.
  */
-export const getAddressFromScriptHash = (scriptHash: string): string => {
+export function getAddressFromScriptHash(scriptHash: string): string {
   scriptHash = reverseHex(scriptHash);
   const shaChecksum = hash256(ADDR_VERSION + scriptHash).substr(0, 8);
   return base58.encode(
     Buffer.from(ADDR_VERSION + scriptHash + shaChecksum, "hex")
   );
-};
+}
 
 /**
  * Converts an address to scripthash.
  */
-export const getScriptHashFromAddress = (address: string): string => {
+export function getScriptHashFromAddress(address: string): string {
   const hash = ab2hexstring(base58.decode(address));
   return reverseHex(hash.substr(2, 40));
-};
+}
 
 /**
  * Generates a signature of the transaction based on given private key.
@@ -158,13 +156,13 @@ export const getScriptHashFromAddress = (address: string): string => {
  * @param privateKey - private Key
  * @returns Signature. Does not include tx.
  */
-export const generateSignature = (tx: string, privateKey: string): string => {
+export function generateSignature(tx: string, privateKey: string): string {
   return sign(tx, privateKey);
-};
+}
 
 /**
  * Generates a random private key.
  */
-export const generatePrivateKey = (): string => {
+export function generatePrivateKey(): string {
   return ab2hexstring(generateRandomArray(32));
-};
+}


### PR DESCRIPTION
Update public key extraction for Account to attempt to pull the public key from the verification script before falling back to private key. This should allow more flexibility without requiring private key decryption.

- Add getVerificationScriptFromPublicKey method.
- Update publicKey getter to check verification script first.
- Update scriptHash getter to convert verification script to hex first.