### PR TITLE
feat(u): Add getVarSize helper function

### DIFF
--- a/packages/neon-core/__tests__/u/misc.ts
+++ b/packages/neon-core/__tests__/u/misc.ts
@@ -1,6 +1,6 @@
 import * as misc from "../../src/u/misc";
 import { HexString } from "../../src/u/HexString";
-import { getVarSize } from "../../src/u/misc";
+import { getSerializedSize } from "../../src/u/misc";
 
 describe("hexXor", () => {
   test("throws if inputs of different length", () => {
@@ -58,48 +58,48 @@ class SerializableObject {
 describe("getVarSize", () => {
   test("size of HexString", () => {
     const input = HexString.fromHex("112233");
-    const result = getVarSize(input);
+    const result = getSerializedSize(input);
     expect(result).toBe(4);
   });
 
   test("size of number < 0xfd", () => {
-    const result = getVarSize(0xfc);
+    const result = getSerializedSize(0xfc);
     expect(result).toBe(1);
   });
 
   test("size of number <= 0xffff", () => {
     // lower boundary
-    let result = getVarSize(0xfd);
+    let result = getSerializedSize(0xfd);
     expect(result).toBe(3);
     // upper boundary
-    result = getVarSize(0xffff);
+    result = getSerializedSize(0xffff);
     expect(result).toBe(3);
   });
 
   test("size of number > 0xffff", () => {
-    const result = getVarSize(0xffff + 1);
+    const result = getSerializedSize(0xffff + 1);
     expect(result).toBe(5);
   });
 
   test("array of serializable objects", () => {
     const input = [new SerializableObject(), new SerializableObject()];
-    const result = getVarSize(input);
+    const result = getSerializedSize(input);
     expect(result).toBe(5);
   });
 
   test("array of hexstring objects", () => {
     const input = [HexString.fromHex("0102"), HexString.fromHex("0304")];
-    const result = getVarSize(input);
+    const result = getSerializedSize(input);
     expect(result).toBe(5);
   });
 
   test("array of unsupported objects throws", () => {
-    expect(() => getVarSize([{}, {}])).toThrow(
+    expect(() => getSerializedSize([{}, {}])).toThrow(
       "Unsupported value type: object"
     );
   });
 
   test("unsupported value throws", () => {
-    expect(() => getVarSize({})).toThrow("Unsupported value type: object");
+    expect(() => getSerializedSize({})).toThrow("Unsupported value type: object");
   });
 });

--- a/packages/neon-core/__tests__/u/misc.ts
+++ b/packages/neon-core/__tests__/u/misc.ts
@@ -95,7 +95,7 @@ describe("getVarSize", () => {
 
   test("array of unsupported objects throws", () => {
     expect(() => getVarSize([{}, {}])).toThrow(
-      "Unsupported value type in array: object"
+      "Unsupported value type: object"
     );
   });
 

--- a/packages/neon-core/src/u/misc.ts
+++ b/packages/neon-core/src/u/misc.ts
@@ -1,4 +1,5 @@
 import { ab2hexstring } from "./convert";
+import { HexString } from "./HexString";
 
 const hexRegex = /^([0-9A-Fa-f]{2})*$/;
 
@@ -77,4 +78,40 @@ export function reverseHex(hex: string): string {
     out += hex.substr(i, 2);
   }
   return out;
+}
+
+/**
+ * Calculates the byte size of any supported input following NEO's variable int format.
+ */
+export function getVarSize(value: any): number {
+  if (typeof value === "object" && value instanceof HexString) {
+    const size = value.byteLength;
+    return getVarSize(size) + size;
+  } else if (typeof value === "number") {
+    if (value < 0xfd) return 1;
+    else if (value <= 0xffff) return 3;
+    else return 5;
+  } else if (Array.isArray(value)) {
+    const array_length = value.length;
+    let size = 0;
+    if (array_length > 0) {
+      const tmp = value.map((item) => {
+        // in lack of an ISerializable interface, we check it like this
+        if (
+          typeof item.size === "number" &&
+          typeof item.serialize === "function"
+        ) {
+          return item.size;
+        } else if (typeof item === "object" && item instanceof HexString) {
+          return item.byteLength;
+        } else {
+          throw new Error("Unsupported value type in array: " + typeof value);
+        }
+      });
+      size = tmp.reduce((a, b) => a + b);
+    }
+    return getVarSize(array_length) + size;
+  } else {
+    throw new Error("Unsupported value type: " + typeof value);
+  }
 }

--- a/packages/neon-core/src/u/misc.ts
+++ b/packages/neon-core/src/u/misc.ts
@@ -83,7 +83,7 @@ export function reverseHex(hex: string): string {
 /**
  * Calculates the byte size of any supported input following NEO's variable int format.
  */
-export function getVarSize(value: any): number {
+export function getSerializedSize(value: any): number {
   console.log(typeof value);
   switch (typeof value) {
     case "number": {
@@ -94,22 +94,22 @@ export function getVarSize(value: any): number {
     case "object": {
       if (value instanceof HexString) {
         const size = value.byteLength;
-        return getVarSize(size) + size;
+        return getSerializedSize(size) + size;
       } else if (
         typeof value.size === "number" &&
         typeof value.serialize === "function"
       ) {
-        return getVarSize(value.size) + value.size;
+        return getSerializedSize(value.size) + value.size;
       } else if (Array.isArray(value)) {
         const array_length = value.length;
         let size = 0;
         if (array_length > 0) {
           size =
             value
-              .map((item) => getVarSize(item))
+              .map((item) => getSerializedSize(item))
               .reduce((prev, curr) => prev + curr, 0) - array_length;
         }
-        return getVarSize(array_length) + size;
+        return getSerializedSize(array_length) + size;
       }
       // do not break here so we fall through to the default
     }


### PR DESCRIPTION
This function is necessary to help resolve the network fee calculation issue #581. The previously [suggested alternative](https://github.com/CityOfZion/neon-js/issues/571#issuecomment-699088064) of first serializing the object and taking the length cannot be used for the mentioned use case because part of the gas calculation is as follows:
```C#
int size = Transaction.HeaderSize + tx.Signers.GetVarSize() + tx.Attributes.GetVarSize() + tx.Script.GetVarSize() + IO.Helper.GetVarSize(hashes.Length);
```
Note how witnesses are not part of the size calculation where they would be if we called `size()` on the Transaction object. The exact reason of why the calculation is like it is can be found in the 2nd paragraph [here](https://github.com/neo-project/neo/issues/840#issue-457034133)

