### PR TITLE
feat(sc): A SmartContract base class

### DIFF
--- a/packages/neon-core/__integration__/sc/contracts/Nep5Contract.ts
+++ b/packages/neon-core/__integration__/sc/contracts/Nep5Contract.ts
@@ -1,0 +1,106 @@
+import { getIntegrationEnvUrl } from "../../../../../testHelpers";
+import { NATIVE_CONTRACTS } from "../../../src/consts";
+import { RPCClient } from "../../../src/rpc";
+import { Nep5Contract } from "../../../src/sc/contracts/Nep5Contract";
+import testWallet from "../../../__tests__/testWallet.json";
+
+let rpcClient: RPCClient;
+beforeAll(async () => {
+  const url = await getIntegrationEnvUrl();
+  rpcClient = new RPCClient(url);
+});
+
+describe("Nep5Contract", () => {
+  test("name", async () => {
+    const neoContract = new Nep5Contract(NATIVE_CONTRACTS.NEO);
+    const contractCall = neoContract.name();
+
+    const result = await rpcClient.invokeFunction(
+      contractCall.scriptHash,
+      contractCall.operation,
+      contractCall.args
+    );
+
+    expect(result.state).toBe("HALT");
+    expect(result.stack).toStrictEqual([
+      {
+        type: "ByteString",
+        value: "TkVP",
+      },
+    ]);
+  });
+
+  test("totalSupply", async () => {
+    const neoContract = new Nep5Contract(NATIVE_CONTRACTS.NEO);
+    const contractCall = neoContract.totalSupply();
+
+    const result = await rpcClient.invokeFunction(
+      contractCall.scriptHash,
+      contractCall.operation,
+      contractCall.args
+    );
+
+    expect(result.state).toBe("HALT");
+    expect(result.stack).toStrictEqual([
+      {
+        type: "Integer",
+        value: "100000000",
+      },
+    ]);
+  });
+
+  test("symbol", async () => {
+    const neoContract = new Nep5Contract(NATIVE_CONTRACTS.NEO);
+    const contractCall = neoContract.symbol();
+
+    const result = await rpcClient.invokeFunction(
+      contractCall.scriptHash,
+      contractCall.operation,
+      contractCall.args
+    );
+
+    expect(result.state).toBe("HALT");
+    expect(result.stack).toStrictEqual([
+      {
+        type: "ByteString",
+        value: "bmVv",
+      },
+    ]);
+  });
+
+  test("decimals", async () => {
+    const neoContract = new Nep5Contract(NATIVE_CONTRACTS.GAS);
+    const contractCall = neoContract.decimals();
+
+    const result = await rpcClient.invokeFunction(
+      contractCall.scriptHash,
+      contractCall.operation,
+      contractCall.args
+    );
+
+    expect(result.state).toBe("HALT");
+    expect(result.stack).toStrictEqual([
+      {
+        type: "Integer",
+        value: "8",
+      },
+    ]);
+  });
+
+  test("balanceOf", async () => {
+    const neoContract = new Nep5Contract(NATIVE_CONTRACTS.GAS);
+    const contractCall = neoContract.balanceOf(testWallet.accounts[0].address);
+
+    const result = await rpcClient.invokeFunction(
+      contractCall.scriptHash,
+      contractCall.operation,
+      contractCall.args
+    );
+
+    expect(result.state).toBe("HALT");
+    expect(result.stack).toHaveLength(1);
+
+    expect(result.stack[0].type).toBe("Integer");
+    expect(parseInt(result.stack[0].value as string)).toBeGreaterThan(0);
+  });
+});

--- a/packages/neon-core/__tests__/sc/contracts/BaseContract.ts
+++ b/packages/neon-core/__tests__/sc/contracts/BaseContract.ts
@@ -1,0 +1,98 @@
+import {
+  ContractMethodDefinition,
+  ContractParam,
+  ContractParamType,
+} from "../../../src/sc";
+import { BaseContract } from "../../../src/sc/contracts/BaseContract";
+
+const scriptHash = "";
+
+describe("call", () => {
+  test("no args", () => {
+    const contract = new BaseContract(scriptHash, [
+      new ContractMethodDefinition({
+        name: "customMethod",
+      }),
+    ]);
+
+    const result = contract.call("customMethod");
+
+    expect(result).toEqual({
+      scriptHash,
+      operation: "customMethod",
+      args: [],
+    });
+  });
+
+  test("method with single bool arg", () => {
+    const contract = new BaseContract(scriptHash, [
+      new ContractMethodDefinition({
+        name: "boolMethod",
+        parameters: [{ name: "arg1", type: ContractParamType.Boolean }],
+      }),
+    ]);
+
+    const result = contract.call("boolMethod", false);
+
+    expect(result).toEqual({
+      scriptHash,
+      operation: "boolMethod",
+      args: [ContractParam.boolean(false)],
+    });
+  });
+
+  test("method throws when insufficient arguments", () => {
+    const contract = new BaseContract(scriptHash, [
+      new ContractMethodDefinition({
+        name: "boolMethod",
+        parameters: [{ name: "arg1", type: ContractParamType.Boolean }],
+      }),
+    ]);
+
+    expect(() => contract.call("boolMethod")).toThrow(
+      "Invalid number of parameters"
+    );
+  });
+
+  test("method throws when method is not found", () => {
+    const contract = new BaseContract(scriptHash, [
+      new ContractMethodDefinition({
+        name: "boolMethod",
+        parameters: [{ name: "arg1", type: ContractParamType.Boolean }],
+      }),
+    ]);
+
+    expect(() => contract.call("notexists")).toThrow();
+  });
+
+  test("method throws when incompatible type", () => {
+    const contract = new BaseContract(scriptHash, [
+      new ContractMethodDefinition({
+        name: "intMethod",
+        parameters: [{ name: "arg1", type: ContractParamType.Integer }],
+      }),
+    ]);
+
+    expect(() => contract.call("intMethod", false)).toThrow("not convertable");
+  });
+
+  test("accepts hash160 in place of bytearray", () => {
+    const contract = new BaseContract(scriptHash, [
+      new ContractMethodDefinition({
+        name: "byteArrayMethod",
+        parameters: [{ name: "arg1", type: ContractParamType.ByteArray }],
+      }),
+    ]);
+
+    const result = contract.call("byteArrayMethod", {
+      type: "Hash160",
+      value: "abcd".repeat(10),
+    });
+
+    expect(result).toEqual({
+      scriptHash,
+      operation: "byteArrayMethod",
+      args: [ContractParam.hash160("abcd".repeat(10))],
+    });
+  });
+});

--- a/packages/neon-core/__tests__/sc/contracts/Nep5Contract.ts
+++ b/packages/neon-core/__tests__/sc/contracts/Nep5Contract.ts
@@ -1,0 +1,78 @@
+import { ContractParam } from "../../../src/sc";
+import { Nep5Contract } from "../../../src/sc/contracts/Nep5Contract";
+import testWallet from "../../testWallet.json";
+
+const scriptHash = "de5f57d430d3dece511cf975a8d37848cb9e0525";
+const contract = new Nep5Contract(scriptHash);
+
+const address = testWallet.accounts[0].address;
+const addressScriptHash = testWallet.accounts[0].extra.scriptHash;
+
+const addressTwo = testWallet.accounts[1].address;
+const addressTwoScriptHash = testWallet.accounts[1].extra.scriptHash;
+
+describe("default methods", () => {
+  test("name", () => {
+    const result = contract.name();
+
+    expect(result).toEqual({
+      scriptHash,
+      operation: "name",
+      args: [],
+    });
+  });
+
+  test("totalSupply", () => {
+    const result = contract.totalSupply();
+
+    expect(result).toEqual({
+      scriptHash,
+      operation: "totalSupply",
+      args: [],
+    });
+  });
+
+  test("decimals", () => {
+    const result = contract.decimals();
+
+    expect(result).toEqual({
+      scriptHash,
+      operation: "decimals",
+      args: [],
+    });
+  });
+
+  test("symbol", () => {
+    const result = contract.symbol();
+
+    expect(result).toEqual({
+      scriptHash,
+      operation: "symbol",
+      args: [],
+    });
+  });
+
+  test("balanceOf", () => {
+    const result = contract.balanceOf(address);
+
+    expect(result).toEqual({
+      scriptHash,
+      operation: "balanceOf",
+      args: [ContractParam.hash160(addressScriptHash)],
+    });
+  });
+
+  test("transfer", () => {
+    const result = contract.transfer(address, addressTwo, 100000000);
+
+    expect(result).toEqual({
+      scriptHash,
+      operation: "transfer",
+      args: [
+        ContractParam.hash160(addressScriptHash),
+        ContractParam.hash160(addressTwoScriptHash),
+        ContractParam.integer(100000000),
+      ],
+    });
+  });
+});

--- a/packages/neon-core/__tests__/testWallet.json
+++ b/packages/neon-core/__tests__/testWallet.json
@@ -25,7 +25,8 @@
             },
             "extra": {
                 "WIF": "L1QqQJnpBwbsPGAuutuzPTac8piqvbR1HRjrY5qHup48TBCBFe4g",
-                "publicKey": "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef"
+                "publicKey": "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+                "scriptHash": "36a6e6a7c4658acf096f5d288cc81129c815681c"
             }
         },
         {
@@ -46,7 +47,8 @@
             },
             "extra": {
                 "WIF": "L2QTooFoDFyRFTxmtiVHt5CfsXfVnexdbENGDkkrrgTTryiLsPMG",
-                "publicKey": "031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c9"
+                "publicKey": "031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c9",
+                "scriptHash": "5461c33e9bbc7de7076754540ba9e62b255ea9fc"
             }
         },
         {
@@ -67,7 +69,8 @@
             },
             "extra": {
                 "WIF": "KyKvWLZsNwBJx5j9nurHYRwhYfdQUu9tTEDsLCUHDbYBL8cHxMiG",
-                "publicKey": "02232ce8d2e2063dce0451131851d47421bfc4fc1da4db116fca5302c0756462fa"
+                "publicKey": "02232ce8d2e2063dce0451131851d47421bfc4fc1da4db116fca5302c0756462fa",
+                "scriptHash":"a38db239bb36ace1a69eb727a5b0157baa094653"
             }
         },
         {

--- a/packages/neon-core/src/consts.ts
+++ b/packages/neon-core/src/consts.ts
@@ -7,9 +7,9 @@ export const MAGIC_NUMBER = {
 };
 
 export const NATIVE_CONTRACTS: { [key: string]: string } = {
-  NEO: "NEO",
+  NEO: "de5f57d430d3dece511cf975a8d37848cb9e0525",
   de5f57d430d3dece511cf975a8d37848cb9e0525: "NEO",
-  GAS: "GAS",
+  GAS: "668e0c1f9d7b70a99dd9e06eadd4c784d641afbc",
   "668e0c1f9d7b70a99dd9e06eadd4c784d641afbc": "GAS",
   POLICY: "ce06595079cd69583126dbfd1d2e25cca74cffe9",
 };

--- a/packages/neon-core/src/sc/contracts/BaseContract.ts
+++ b/packages/neon-core/src/sc/contracts/BaseContract.ts
@@ -1,0 +1,100 @@
+import ContractParam, {
+  ContractParamJson,
+  ContractParamType,
+} from "../ContractParam";
+import { ContractMethodDefinition } from "../manifest";
+import { ContractCall } from "../types";
+
+export class BaseContract {
+  #scriptHash: string;
+  #abi: Record<string, ContractMethodDefinition> = {};
+
+  public get scriptHash(): string {
+    return this.#scriptHash;
+  }
+  /**
+   * Getter for retrieving the ABI for this contract.
+   * This is made readonly with Typescript. This has no effect in Javascript.
+   */
+  public get methods(): Readonly<Record<string, ContractMethodDefinition>> {
+    return this.#abi;
+  }
+
+  constructor(scriptHash: string, methods: ContractMethodDefinition[] = []) {
+    this.#scriptHash = scriptHash;
+    this.#abi = methods.reduce((map, method) => {
+      map[method.name] = method;
+      return map;
+    }, {} as Record<string, ContractMethodDefinition>);
+  }
+
+  public call(
+    method: ContractMethodDefinition | string,
+    ...inputArgs: (
+      | string
+      | boolean
+      | number
+      | ContractParam
+      | ContractParamJson
+    )[]
+  ): ContractCall {
+    const methodDefinition =
+      typeof method === "string" ? this.#abi[method] : method;
+
+    if (methodDefinition === undefined) {
+      throw new Error(`The method ${method} is not defined on this contract.`);
+    }
+
+    if (methodDefinition.parameters.length !== inputArgs.length) {
+      throw new Error(
+        `Invalid number of parameters provided. Method requires ${methodDefinition.parameters.length} parameters but got ${inputArgs.length}.`
+      );
+    }
+
+    const args = inputArgs.map((arg, index) =>
+      convertParameter(arg, methodDefinition.parameters[index].type)
+    );
+    return {
+      scriptHash: this.scriptHash,
+      operation: methodDefinition.name,
+      args,
+    };
+  }
+}
+
+function convertParameter(
+  arg: string | boolean | number | ContractParam | ContractParamJson,
+  type: ContractParamType
+): ContractParam {
+  if (typeof arg === "object") {
+    const contractParamInstance =
+      arg instanceof ContractParam ? arg : ContractParam.fromJson(arg);
+
+    if (isCompatibleType(contractParamInstance.type, type)) {
+      return contractParamInstance;
+    } else {
+      throw new Error(
+        `Provided ${contractParamInstance.type} when trying to get ${type}`
+      );
+    }
+  }
+
+  return ContractParam.fromJson({
+    type: ContractParamType[type],
+    value: arg,
+  });
+}
+
+function isCompatibleType(
+  givenType: ContractParamType,
+  requiredType: ContractParamType
+): boolean {
+  return (
+    // same type
+    requiredType === givenType ||
+    // Hash160 & Hash256 are subsets of ByteArray
+    (requiredType === ContractParamType.ByteArray &&
+      (givenType === ContractParamType.Hash160 ||
+        givenType === ContractParamType.Hash256))
+  );
+}

--- a/packages/neon-core/src/sc/contracts/Nep5Contract.ts
+++ b/packages/neon-core/src/sc/contracts/Nep5Contract.ts
@@ -43,7 +43,7 @@ export class Nep5Contract extends BaseContract {
    * @example
    * const contract = new Nep5Contract(contractHash);
    * const balanceOfCall = contract.balanceOf(address);
-   * const result = 
+   * const result =
    */
   public balanceOf(address: string): ContractCall {
     return this.call("balanceOf", ContractParam.hash160(address));

--- a/packages/neon-core/src/sc/contracts/Nep5Contract.ts
+++ b/packages/neon-core/src/sc/contracts/Nep5Contract.ts
@@ -1,0 +1,75 @@
+import { ContractParam } from "../ContractParam";
+import { ContractMethodDefinition } from "../manifest";
+import { ContractCall } from "../types";
+import { BaseContract } from "./BaseContract";
+import defaultAbi from "./Nep5TemplateMethods.json";
+
+/**
+ * A standard NEP-5 contract according to specification.
+ */
+export class Nep5Contract extends BaseContract {
+  /**
+   * The list of methods found on the NEP-5 specification.
+   */
+  public static getMethods(): ContractMethodDefinition[] {
+    return defaultAbi.methods.map((m) => ContractMethodDefinition.fromJson(m));
+  }
+
+  constructor(
+    scriptHash: string,
+    additionalMethods: ContractMethodDefinition[] = []
+  ) {
+    super(scriptHash, Nep5Contract.getMethods().concat(additionalMethods));
+  }
+
+  public name(): ContractCall {
+    return this.call("name");
+  }
+
+  public symbol(): ContractCall {
+    return this.call("symbol");
+  }
+
+  public decimals(): ContractCall {
+    return this.call("decimals");
+  }
+
+  /**
+   * Retrieves the balance of the address.
+   * The balance returned will be an integer which needs to be processed according to the number of decimals for this token.
+   *
+   * @param address - The address to enquire.
+   *
+   * @example
+   * const contract = new Nep5Contract(contractHash);
+   * const balanceOfCall = contract.balanceOf(address);
+   * const result = 
+   */
+  public balanceOf(address: string): ContractCall {
+    return this.call("balanceOf", ContractParam.hash160(address));
+  }
+
+  public totalSupply(): ContractCall {
+    return this.call("totalSupply");
+  }
+
+  /**
+   * Transfers some token between addresses.
+   * The amount of tokens needs to be
+   * @param from - The address from where the funds originate.
+   * @param to - The address where the funds will arrive at.
+   * @param amount - The amount of tokens to transfer.
+   */
+  public transfer(
+    from: string,
+    to: string,
+    amount: string | number
+  ): ContractCall {
+    return this.call(
+      "transfer",
+      ContractParam.hash160(from),
+      ContractParam.hash160(to),
+      ContractParam.integer(amount)
+    );
+  }
+}

--- a/packages/neon-core/src/sc/contracts/Nep5TemplateMethods.json
+++ b/packages/neon-core/src/sc/contracts/Nep5TemplateMethods.json
@@ -1,0 +1,78 @@
+{
+  "hash": "",
+  "methods": [
+    {
+      "name": "totalSupply",
+      "parameters": [],
+      "offset": 0,
+      "returntype": "Integer"
+    },
+    {
+      "name": "balanceOf",
+      "parameters": [
+        {
+          "name": "account",
+          "type": "ByteArray"
+        }
+      ],
+      "offset": 0,
+      "returntype": "Integer"
+    },
+    {
+      "name": "transfer",
+      "parameters": [
+        {
+          "name": "from",
+          "type": "ByteArray"
+        },
+        {
+          "name": "to",
+          "type": "ByteArray"
+        },
+        {
+          "name": "amount",
+          "type": "Integer"
+        }
+      ],
+      "offset": 0,
+      "returntype": "Boolean"
+    },
+    {
+      "name": "name",
+      "parameters": [],
+      "offset": 0,
+      "returntype": "String"
+    },
+    {
+      "name": "symbol",
+      "parameters": [],
+      "offset": 0,
+      "returntype": "String"
+    },
+    {
+      "name": "decimals",
+      "parameters": [],
+      "offset": 0,
+      "returntype": "Integer"
+    }
+  ],
+  "events": [
+    {
+      "name": "Transfer",
+      "parameters": [
+        {
+          "name": "from",
+          "type": "Hash160"
+        },
+        {
+          "name": "to",
+          "type": "Hash160"
+        },
+        {
+          "name": "amount",
+          "type": "Integer"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/neon-core/src/sc/contracts/index.ts
+++ b/packages/neon-core/src/sc/contracts/index.ts
@@ -1,0 +1,2 @@
+export * from "./BaseContract";
+export * from "./Nep5Contract";

--- a/packages/neon-core/src/sc/index.ts
+++ b/packages/neon-core/src/sc/index.ts
@@ -9,3 +9,4 @@ export * from "./InteropServicePrices";
 export * from "./StackItem";
 export * from "./manifest";
 export * from "./OpToken";
+export * from "./contracts";

--- a/packages/neon-core/src/sc/types.ts
+++ b/packages/neon-core/src/sc/types.ts
@@ -1,0 +1,9 @@
+import ContractParam from "./ContractParam";
+
+export interface ContractCall {
+  /** Hexstring of 40 characters in BE */
+  scriptHash: string;
+  /** ASCII string */
+  operation: string;
+  args?: ContractParam[];
+}

--- a/packages/neon-core/tsconfig.json
+++ b/packages/neon-core/tsconfig.json
@@ -4,5 +4,6 @@
     "rootDir": "src",
     "outDir": "lib"
   },
-  "include": ["src/**/*", "./typings/*"]
+  // default include without extensions only inclues typescript stuff
+  "include": ["src/**/*", "src/**/*.json","./typings/*"]
 }


### PR DESCRIPTION
A SmartContract framework for simple contract script construction. 

Before, the old framework revolves around the interface `ScriptIntent` (which is very similar to the new `ContractCall` interface). This was designed to be a simple object that SDK users can create to denote a smart contract method call. However, it was not really fully supported by the old `neon-nep5` package, which was coupled tightly with the ScriptBuilder. The `args` field was also `unknown`, leading to multiple parsing issues as there was insufficient information to verify and serialize the data.

This PR reworks `ScriptIntent` and the `neon-nep5` package for better support:

`ScriptIntent` is now superceded by `ContractCall`. With NEO3 standardizing the entry point, we can now support the (scriptHash, operation, args) inputs as a first class citizen for all contracts. Args is now typed as ContractParams which provided stable typing for us to reliably execute serialization.

The `BaseContract` class provides a base layer for constructing a simple SmartContract representation that can be used to safely construct `ContractCall` objects with their parameters parsed correctly.

The `Nep5Contract` class is an example of how the `BaseContract` class is extended and provides a clean API interface. I will further extend it to implement the NEO and GAS contracts.

Translation of a `ContractCall` into a hexstring is trivial with ScriptBuilder as all the parameters are now well defined. The `ContractCall` object can also be easily used with `invokeFunction` RPC call.

I intend to deprecate:

- ContractParam.byteArray(value, format,...args) -> ContractParam.byteArray(value). I think moving the parameter translation upwards would reduce the burden on this class. For address conversions, there is `ContractParam.hash160`. For Fixed8 conversion, we should rely on BigInteger class. I plan to remove the 2 extra arguments.

- ScriptBuilder.emitAppCall. This can be superceded by a new method to accept `ContractCall`. For now, I plan to only mark it as deprecated and visit this again after more implementation.