### PR TITLE
feat(sc): Improve ContractParam with fromJson

### DIFF
--- a/packages/neon-core/__tests__/internal.ts
+++ b/packages/neon-core/__tests__/internal.ts
@@ -1,0 +1,26 @@
+import { parseEnum } from "../src/internal";
+
+enum TestEnum {
+  Any = 0,
+  First = 1,
+  Second = 2,
+}
+describe("parseEnum", () => {
+  test("integer", () => {
+    const result = parseEnum(0, TestEnum);
+
+    expect(result.toString()).toBe("0");
+  });
+
+  test("string", () => {
+    const result = parseEnum("First", TestEnum);
+
+    expect(result.toString()).toBe("1");
+  });
+
+  test("enum", () => {
+    const result = parseEnum(TestEnum.Second, TestEnum);
+
+    expect(result.toString()).toBe("2");
+  });
+});

--- a/packages/neon-core/__tests__/sc/ContractParam.ts
+++ b/packages/neon-core/__tests__/sc/ContractParam.ts
@@ -102,9 +102,40 @@ describe("Static constructors", () => {
       expect(hexStringValue.toBigEndian()).toBe(expected);
     });
 
-    test("Errors on non-address or scripthash", () => {
-      const thrower = (): ContractParam => ContractParam.hash160("1");
-      expect(thrower).toThrow();
+    test("errors when not 20 bytes", () => {
+      expect(() => ContractParam.hash160(HexString.fromHex("12"))).toThrow(
+        "expected 20 bytes"
+      );
+    });
+  });
+
+  describe("hash256", () => {
+    test("hexstring", () => {
+      const expected = "abcd".repeat(16);
+      const result = ContractParam.hash256(expected);
+
+      expect(result instanceof ContractParam).toBeTruthy();
+      expect(result.type).toBe(ContractParamType.Hash256);
+      expect(result.value).toBeInstanceOf(HexString);
+      const hexStringValue = result.value as HexString;
+      expect(hexStringValue.toBigEndian()).toBe(expected);
+    });
+
+    test("HexString class", () => {
+      const expected = HexString.fromHex("1234".repeat(16));
+      const result = ContractParam.hash256(expected);
+
+      expect(result instanceof ContractParam).toBeTruthy();
+      expect(result.type).toBe(ContractParamType.Hash256);
+      expect(result.value).toBeInstanceOf(HexString);
+      const hexStringValue = result.value as HexString;
+      expect(hexStringValue.equals(expected)).toBeTruthy();
+    });
+
+    test("errors when not 32 bytes", () => {
+      expect(() => ContractParam.hash256(HexString.fromHex("12"))).toThrow(
+        "expected 32 bytes"
+      );
     });
   });
 
@@ -133,18 +164,26 @@ describe("Static constructors", () => {
     });
   });
 
-  test("publicKey", () => {
-    const result = ContractParam.publicKey(
-      "026d3ca98c83dd2490a134ba4f874b59292afaac8abc2f9b34b690fcd2b44648ee"
-    );
+  describe("publicKey", () => {
+    test("valid key", () => {
+      const result = ContractParam.publicKey(
+        "026d3ca98c83dd2490a134ba4f874b59292afaac8abc2f9b34b690fcd2b44648ee"
+      );
 
-    expect(result instanceof ContractParam).toBeTruthy();
-    expect(result.type).toBe(ContractParamType.PublicKey);
-    expect(result.value).toBeInstanceOf(HexString);
-    const hexStringValue = result.value as HexString;
-    expect(hexStringValue.toBigEndian()).toBe(
-      "026d3ca98c83dd2490a134ba4f874b59292afaac8abc2f9b34b690fcd2b44648ee"
-    );
+      expect(result instanceof ContractParam).toBeTruthy();
+      expect(result.type).toBe(ContractParamType.PublicKey);
+      expect(result.value).toBeInstanceOf(HexString);
+      const hexStringValue = result.value as HexString;
+      expect(hexStringValue.toBigEndian()).toBe(
+        "026d3ca98c83dd2490a134ba4f874b59292afaac8abc2f9b34b690fcd2b44648ee"
+      );
+    });
+
+    test("invalid key", () => {
+      expect(() => ContractParam.publicKey("")).toThrow(
+        "expected valid public key"
+      );
+    });
   });
 });
 
@@ -223,16 +262,6 @@ describe("toJson", () => {
     });
   });
 
-  test("string", () => {
-    const testObject = ContractParam.string("utf8 string");
-    const result = testObject.toJson();
-
-    expect(result).toEqual({
-      type: "String",
-      value: "utf8 string",
-    });
-  });
-
   test("hash160", () => {
     const testObject = ContractParam.hash160("abcd".repeat(10));
     const result = testObject.toJson();
@@ -240,6 +269,16 @@ describe("toJson", () => {
     expect(result).toEqual({
       type: "Hash160",
       value: "abcd".repeat(10),
+    });
+  });
+
+  test("hash256", () => {
+    const testObject = ContractParam.hash256("abcd".repeat(16));
+    const result = testObject.toJson();
+
+    expect(result).toEqual({
+      type: "Hash256",
+      value: "abcd".repeat(16),
     });
   });
 

--- a/packages/neon-core/__tests__/sc/ContractParam.ts
+++ b/packages/neon-core/__tests__/sc/ContractParam.ts
@@ -1,8 +1,8 @@
 import {
   ContractParam,
+  ContractParamLike,
   ContractParamType,
   likeContractParam,
-  ContractParamLike,
 } from "../../src/sc/ContractParam";
 import { HexString } from "../../src/u";
 
@@ -71,7 +71,7 @@ describe("Static constructors", () => {
         "179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137215",
         "179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137215",
       ],
-    ])("%s", (_msg: string, data: string | number, expected: unknown) => {
+    ])("%s", (_msg: string, data: string | number, expected: string) => {
       const result = ContractParam.integer(data);
 
       expect(result instanceof ContractParam).toBeTruthy();
@@ -109,35 +109,14 @@ describe("Static constructors", () => {
   });
 
   describe("byteArray", () => {
-    test.each([
-      ["bytearray", ["010203"], "010203"],
-      [
-        "address",
-        ["ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s", "address"],
-        "35b20010db73bf86371075ddfba4e6596f1ff35d",
-      ],
-      ["fixed8", [100.012345678, "fixed8"], "88ba1e5402000000"],
-      ["fixed8 (0 decimals)", [1, "fixed8", 0], "0100000000000000"],
-      ["fixed8(4 decimals)", [222.1234, "fixed8", 4], "b2e4210000000000"],
-    ] as [string, [string | number, string?, ...(string | number)[]], string][])(
-      "%s",
-      (
-        _msg: string,
-        data: [string | number, string?, ...(string | number)[]],
-        expected: string
-      ) => {
-        const result = ContractParam.byteArray(...data);
+    test("%s", () => {
+      const result = ContractParam.byteArray("1234");
 
-        expect(result instanceof ContractParam).toBeTruthy();
-        expect(result.type).toBe(ContractParamType.ByteArray);
-        expect(result.value).toBe(expected);
-      }
-    );
-
-    test("errors when exceeds allowed precision for fixed8", () => {
-      const thrower = (): ContractParam =>
-        ContractParam.byteArray(222.12345, "fixed8", 4);
-      expect(thrower).toThrow("wrong precision");
+      expect(result instanceof ContractParam).toBeTruthy();
+      expect(result.type).toBe(ContractParamType.ByteArray);
+      expect(result.value).toBeInstanceOf(HexString);
+      const hexStringValue = result.value as HexString;
+      expect(hexStringValue.toBigEndian()).toEqual("1234");
     });
   });
 
@@ -200,34 +179,111 @@ describe("likeContractParam", () => {
       },
       true,
     ],
-    ["ContractParam", new ContractParam({ type: "Integer", value: 1 }), true],
+    ["ContractParam", ContractParam.integer(1), true],
     ["empty", {}, false],
     ["wrong type", { type: "", value: 1 }, false],
     ["missing value", { type: "ByteArray" }, false],
   ])(
     "%s",
-    (
-      msg: string,
-      data: Partial<ContractParam | ContractParamLike>,
-      expected: boolean
-    ) => {
+    (msg: string, data: Partial<ContractParamLike>, expected: boolean) => {
       const result = likeContractParam(data);
       expect(result).toBe(expected);
     }
   );
 });
 
-describe("export", () => {
-  test("exports properly", () => {
-    const testObject = new ContractParam({
-      type: ContractParamType.Integer,
-      value: 1,
-    });
-    const result = testObject.export();
+describe("toJson", () => {
+  test("integer", () => {
+    const testObject = ContractParam.integer(1);
+    const result = testObject.toJson();
 
     expect(result).toEqual({
       type: "Integer",
-      value: 1,
+      value: "1",
+    });
+  });
+
+  test("boolean", () => {
+    const testObject = ContractParam.boolean(true);
+    const result = testObject.toJson();
+
+    expect(result).toEqual({
+      type: "Boolean",
+      value: true,
+    });
+  });
+
+  test("string", () => {
+    const testObject = ContractParam.string("utf8 string");
+    const result = testObject.toJson();
+
+    expect(result).toEqual({
+      type: "String",
+      value: "utf8 string",
+    });
+  });
+
+  test("string", () => {
+    const testObject = ContractParam.string("utf8 string");
+    const result = testObject.toJson();
+
+    expect(result).toEqual({
+      type: "String",
+      value: "utf8 string",
+    });
+  });
+
+  test("hash160", () => {
+    const testObject = ContractParam.hash160("abcd".repeat(10));
+    const result = testObject.toJson();
+
+    expect(result).toEqual({
+      type: "Hash160",
+      value: "abcd".repeat(10),
+    });
+  });
+
+  test("publicKey", () => {
+    const testObject = ContractParam.publicKey(
+      "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef"
+    );
+    const result = testObject.toJson();
+
+    expect(result).toEqual({
+      type: "PublicKey",
+      value:
+        "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+    });
+  });
+
+  test("byteArray", () => {
+    const testObject = ContractParam.byteArray("1234abcd");
+    const result = testObject.toJson();
+
+    expect(result).toEqual({
+      type: "ByteArray",
+      value: "1234abcd",
+    });
+  });
+
+  test("array", () => {
+    const testObject = ContractParam.array(
+      ContractParam.integer(999),
+      ContractParam.boolean(false),
+      ContractParam.string("hello world")
+    );
+    const result = testObject.toJson();
+
+    expect(result).toEqual({
+      type: "Array",
+      value: [
+        {
+          type: "Integer",
+          value: "999",
+        },
+        { type: "Boolean", value: false },
+        { type: "String", value: "hello world" },
+      ],
     });
   });
 });
@@ -267,9 +323,9 @@ describe("equals", () => {
     type: "Void",
   };
 
-  const param1 = new ContractParam(obj1);
-  const param2 = new ContractParam(obj2);
-  const param3 = new ContractParam(obj3);
+  const param1 = ContractParam.fromJson(obj1);
+  const param2 = ContractParam.fromJson(obj2);
+  const param3 = ContractParam.fromJson(obj3);
 
   test.each([
     ["Param1 === Param1", param1, param1, true],

--- a/packages/neon-core/__tests__/sc/ContractParam.ts
+++ b/packages/neon-core/__tests__/sc/ContractParam.ts
@@ -140,8 +140,18 @@ describe("Static constructors", () => {
   });
 
   describe("byteArray", () => {
-    test("%s", () => {
-      const result = ContractParam.byteArray("1234");
+    test("base64 encoded string", () => {
+      const result = ContractParam.byteArray("NBI=");
+
+      expect(result instanceof ContractParam).toBeTruthy();
+      expect(result.type).toBe(ContractParamType.ByteArray);
+      expect(result.value).toBeInstanceOf(HexString);
+      const hexStringValue = result.value as HexString;
+      expect(hexStringValue.toBigEndian()).toEqual("1234");
+    });
+
+    test("HexString", () => {
+      const result = ContractParam.byteArray(HexString.fromHex("1234"));
 
       expect(result instanceof ContractParam).toBeTruthy();
       expect(result.type).toBe(ContractParamType.ByteArray);
@@ -296,12 +306,12 @@ describe("toJson", () => {
   });
 
   test("byteArray", () => {
-    const testObject = ContractParam.byteArray("1234abcd");
+    const testObject = ContractParam.byteArray("/KleJSvmqQtUVGcH5328mz7DYVQ=");
     const result = testObject.toJson();
 
     expect(result).toEqual({
       type: "ByteArray",
-      value: "1234abcd",
+      value: "/KleJSvmqQtUVGcH5328mz7DYVQ=",
     });
   });
 

--- a/packages/neon-core/__tests__/sc/ScriptBuilder.ts
+++ b/packages/neon-core/__tests__/sc/ScriptBuilder.ts
@@ -210,6 +210,18 @@ describe("emitContractParam", () => {
       (0x10 + 1).toString(16),
     ],
     ["ContractParam(integer) 256", ContractParam.integer(256), "010001"],
+    [
+      "ContractParam(byteArray)",
+      ContractParam.byteArray(
+        HexString.fromHex("5461c33e9bbc7de7076754540ba9e62b255ea9fc")
+      ),
+      "0c14fca95e252be6a90b54546707e77dbc9b3ec36154",
+    ],
+    [
+      "ContractParam(hash160)",
+      ContractParam.hash160("5461c33e9bbc7de7076754540ba9e62b255ea9fc"),
+      "0c14fca95e252be6a90b54546707e77dbc9b3ec36154",
+    ],
   ])("%s", (_msg: string, data: ContractParam, expected: string) => {
     const sb = new ScriptBuilder();
     sb.emitContractParam(data);

--- a/packages/neon-core/src/sc/ContractParam.ts
+++ b/packages/neon-core/src/sc/ContractParam.ts
@@ -15,7 +15,7 @@ export enum ContractParamType {
   PublicKey = 0x16,
   Signature = 0x17, // TODO: Implement support
 
-  Array = 0x20, // TODO: Implement support
+  Array = 0x20,
   Map = 0x22, // TODO: Implement support
 
   InteropInterface = 0x30, // TODO: Implement support
@@ -291,6 +291,7 @@ export class ContractParam implements NeonObject<ContractParamLike> {
           return ContractParam.array(...arg);
         }
         break;
+
       case ContractParamType.Boolean:
         if (
           typeof arg === "string" ||
@@ -407,6 +408,7 @@ export class ContractParam implements NeonObject<ContractParamLike> {
             );
           }
           return false;
+
         case ContractParamType.ByteArray:
         case ContractParamType.Hash160:
         case ContractParamType.Hash256:
@@ -418,6 +420,7 @@ export class ContractParam implements NeonObject<ContractParamLike> {
             return (this.value as HexString).equals(other.value);
           }
           return false;
+
         case ContractParamType.Integer:
           if (typeof other.value === "number") {
             return this.value === other.value.toString();
@@ -426,8 +429,12 @@ export class ContractParam implements NeonObject<ContractParamLike> {
             return this.value === other.value;
           }
           return false;
+
         case ContractParamType.Void:
           return true;
+
+        case ContractParamType.Boolean:
+        case ContractParamType.String:
         default:
           return this.value === other.value;
       }

--- a/packages/neon-core/src/sc/ContractParam.ts
+++ b/packages/neon-core/src/sc/ContractParam.ts
@@ -99,8 +99,9 @@ export class ContractParam implements NeonObject<ContractParamLike> {
   }
 
   /**
-   * Creates an Integer ContractParam. This is converted into an BigInteger in NeoVM. Value field will be a string.
-   * @param value - A value that can be parsed to an BigInteger. Numbers or numeric strings are accepted.
+   * Creates an Integer ContractParam. This is converted into a BigInteger in NeoVM. Value field will be a string.
+   * @param value - A value that can be parsed to a BigInteger. Numbers or numeric strings are accepted.
+
    * @example
    * ContractParam.integer(128);
    * ContractParam.integer("128");

--- a/packages/neon-core/src/sc/ContractParam.ts
+++ b/packages/neon-core/src/sc/ContractParam.ts
@@ -1,6 +1,7 @@
-import { Fixed8, reverseHex, HexString } from "../u";
+import { BigInteger, HexString } from "../u";
 import { getScriptHashFromAddress, isAddress } from "../wallet";
 import { NeonObject } from "../model";
+import { parseEnum } from "../internal";
 
 export enum ContractParamType {
   Any = 0x00,
@@ -22,30 +23,33 @@ export enum ContractParamType {
   Void = 0xff,
 }
 
-export interface ContractParamLike {
+export interface ContractParamJson {
   type: string;
-  value: string | boolean | number | ContractParamLike[] | null;
+  value?: string | boolean | number | ContractParamJson[] | null;
 }
 
-function toContractParamType(
-  type: ContractParamType | string | number
-): ContractParamType {
-  if (typeof type === "string") {
-    if (type in ContractParamType) {
-      return ContractParamType[type as keyof typeof ContractParamType];
-    }
-    throw new Error(`${type} not found in ContractParamType!`);
-  }
-  return type;
-}
+export type ContractParamLike = Pick<
+  ContractParamJson | ContractParam,
+  keyof ContractParamJson
+>;
 
 /**
- * Contract input parameters.
- * These are mainly used as parameters to pass in for RPC test invokes.
+ * These are the parameters used for interacting with smart contracts.
+ * Depending on the type, the data is stored differently.
+ * The constructor only validates the input types. It does not do transformation.
+ * The static methods provide safe parsing from various data types into their intended final storage form.
+ *
+ * @example
+ *
+ * ContractParam.integer(1);
+ * ContractParam.boolean(true);
+ * ContractParam.string("12ab");
  */
 export class ContractParam implements NeonObject<ContractParamLike> {
   /**
    * Creates a String ContractParam.
+   *
+   * @param value - UTF8 string.
    */
   public static string(value: string): ContractParam {
     return new ContractParam({
@@ -55,7 +59,7 @@ export class ContractParam implements NeonObject<ContractParamLike> {
   }
 
   /**
-   * Creates a Boolean ContractParam. Does basic checks to convert value into a boolean.
+   * Creates a Boolean ContractParam. Does basic checks to convert value into a boolean. Value field will be a boolean.
    */
   public static boolean(value: boolean | string | number): ContractParam {
     return new ContractParam({
@@ -64,15 +68,23 @@ export class ContractParam implements NeonObject<ContractParamLike> {
     });
   }
 
-  public static publicKey(value: string): ContractParam {
-    return new ContractParam({ type: ContractParamType.PublicKey, value });
+  public static publicKey(value: string | HexString): ContractParam {
+    return new ContractParam({
+      type: ContractParamType.PublicKey,
+      value: value instanceof HexString ? value : HexString.fromHex(value),
+    });
   }
 
   /**
-   * Creates a Hash160 ContractParam. This is used for containing a scriptHash. Do not reverse the input if using this format.
+   * Creates a Hash160 ContractParam. This is used for containing a scriptHash. Value field will be a HexString.
+   * Do not reverse the input if using this format.
    * @param value - A 40 character long hexstring. Automatically converts an address to scripthash if provided.
    */
-  public static hash160(value: string): ContractParam {
+  public static hash160(value: string | HexString): ContractParam {
+    if (value instanceof HexString) {
+      return new ContractParam({ type: ContractParamType.Hash160, value });
+    }
+
     if (isAddress(value)) {
       value = getScriptHashFromAddress(value);
     }
@@ -81,133 +93,152 @@ export class ContractParam implements NeonObject<ContractParamLike> {
         `hash160 expected a 40 character string but got ${value.length} chars instead.`
       );
     }
-    return new ContractParam({ type: ContractParamType.Hash160, value });
-  }
-
-  /**
-   * Creates an Integer ContractParam. This is converted into an BigInteger in NeoVM.
-   * @param value - A value that can be parsed to an BigInteger. Numbers or numeric strings are accepted.
-   * @example
-   * ContractParam.integer(128)
-   * ContractParam.integer("128")
-   */
-  public static integer(value: string | number): ContractParam {
-    const num =
-      typeof value === "string"
-        ? value.split(".")[0]
-        : Math.round(value).toString();
     return new ContractParam({
-      type: ContractParamType.Integer,
-      value: num,
+      type: ContractParamType.Hash160,
+      value: HexString.fromHex(value),
     });
   }
 
   /**
-   * Creates a ByteArray ContractParam.
-   * @param value - the raw data as a string or number
-   * @param format - the format that this value represents. Different formats are parsed differently.
-   * @param args - additional arguments such as decimal precision
+   * Creates an Integer ContractParam. This is converted into an BigInteger in NeoVM. Value field will be a string.
+   * @param value - A value that can be parsed to an BigInteger. Numbers or numeric strings are accepted.
+   * @example
+   * ContractParam.integer(128);
+   * ContractParam.integer("128");
+   * ContractParam.integer(BigInteger.fromNumber(128));
    */
-  public static byteArray(
-    value: string | number,
-    format?: string,
-    ...args: unknown[]
-  ): ContractParam {
-    if (format) {
-      format = format.toLowerCase();
-    }
-    if (format === "address") {
-      if (typeof value !== "string") {
-        throw new Error("Expected string when format is address");
-      }
+  public static integer(value: string | number | BigInteger): ContractParam {
+    if (typeof value === "string") {
       return new ContractParam({
-        type: ContractParamType.ByteArray,
-        value: reverseHex(getScriptHashFromAddress(value)),
+        type: ContractParamType.Integer,
+        value: value.split(".")[0],
       });
-    } else if (format === "fixed8") {
-      let decimals = 8;
-      if (args.length === 1) {
-        if (typeof args[0] !== "number") {
-          throw new Error("Expected number when format is fixed8");
-        }
-        decimals = args[0];
-      }
-      if (typeof value !== "number" || !isFinite(value)) {
-        throw new Error(`Input should be number!`);
-      }
-      const divisor = new Fixed8(Math.pow(10, 8 - decimals));
-      const fixed8Value = new Fixed8(value);
-      const adjustedValue = fixed8Value.times(Math.pow(10, decimals));
-      const modValue = adjustedValue.mod(1);
-      if (!modValue.isZero()) {
-        throw new Error(`wrong precision: expected ${decimals}`);
-      }
-      const finalValue = fixed8Value.div(divisor);
-      return new ContractParam({
-        type: ContractParamType.ByteArray,
-        value: finalValue.toReverseHex().slice(0, 16),
-      });
-    } else {
-      return new ContractParam({ type: ContractParamType.ByteArray, value });
     }
+
+    if (typeof value === "number") {
+      return new ContractParam({
+        type: ContractParamType.Integer,
+        value: Math.round(value).toString(),
+      });
+    }
+    if (value instanceof BigInteger) {
+      return new ContractParam({
+        type: ContractParamType.Integer,
+        value: value.toString(),
+      });
+    }
+
+    throw new Error(`Unknown input provided: ${value}`);
   }
 
   /**
-   * Creates an Array ContractParam.
+   * Creates a ByteArray ContractParam. Value field will be a HexString.
+   * @param value - a string or HexString.
+   */
+  public static byteArray(value: string | HexString): ContractParam {
+    if (typeof value === "string") {
+      return new ContractParam({
+        type: ContractParamType.ByteArray,
+        value: HexString.fromHex(value),
+      });
+    }
+
+    if (value instanceof HexString) {
+      return new ContractParam({ type: ContractParamType.ByteArray, value });
+    }
+
+    throw new Error(`Unknown input provided: ${value}`);
+  }
+
+  /**
+   * Creates a Void ContractParam. Value field will be set to null.
+   */
+  public static void(): ContractParam {
+    return new ContractParam({ type: ContractParamType.Void });
+  }
+
+  /**
+   * Creates an Array ContractParam. Value field will be a ContractParam array.
    * @param params - params to be encapsulated in an array.
    */
-  public static array(...params: ContractParam[]): ContractParam {
-    return new ContractParam({ type: ContractParamType.Array, value: params });
+  public static array(...params: ContractParamLike[]): ContractParam {
+    const value = params.map((i) => ContractParam.fromJson(i));
+    return new ContractParam({ type: ContractParamType.Array, value });
   }
 
   public type: ContractParamType;
-  public value: string | boolean | number | HexString | ContractParam[] | null;
+  public value: string | boolean | HexString | ContractParam[] | null;
 
-  public constructor(input: Partial<ContractParamLike | ContractParam>) {
-    if (typeof input === "object") {
-      if (input.type === undefined) {
-        throw new Error("type must be defined!");
-      }
-      this.type = toContractParamType(input.type);
-      if (this.type !== ContractParamType.Void && input.value === undefined) {
-        throw new Error("value must be defined!");
-      }
-      switch (this.type) {
-        case ContractParamType.Array:
-          this.value = (input.value as (
-            | ContractParamLike
+  public constructor(input: ContractParamLike) {
+    if (typeof input !== "object") {
+      throw new Error(
+        "Please provide an object for constructing ContractParam."
+      );
+    }
+
+    if (input instanceof ContractParam) {
+      this.type = input.type;
+      this.value = input.value;
+      return;
+    }
+
+    if (input.type === undefined) {
+      throw new Error("Please provide a type for ContractParam.");
+    }
+
+    this.type = parseEnum(input.type, ContractParamType);
+    const arg = input.value;
+    switch (this.type) {
+      case ContractParamType.Boolean:
+        if (typeof arg === "boolean") {
+          this.value = arg;
+          return;
+        } else {
+          throw new Error("Please provide a boolean for value!");
+        }
+
+      case ContractParamType.ByteArray:
+      case ContractParamType.Hash160:
+      case ContractParamType.PublicKey:
+        if (arg instanceof HexString) {
+          this.value = arg;
+          return;
+        } else {
+          throw new Error("Please provide a HexString for value!");
+        }
+
+      case ContractParamType.Integer:
+      case ContractParamType.String:
+        if (typeof arg === "string") {
+          this.value = arg;
+          return;
+        } else {
+          throw new Error("Please provide a string for value!");
+        }
+
+      case ContractParamType.Array:
+        if (Array.isArray(arg)) {
+          this.value = (arg as (
             | ContractParam
-          )[]).map((cp) => new ContractParam(cp));
+            | ContractParamLike
+          )[]).map((i: ContractParam | ContractParamLike) =>
+            ContractParam.fromJson(i)
+          );
           return;
-        case ContractParamType.Boolean:
-          this.value = !!input.value;
+        } else {
+          throw new Error("Please provide an array for value!");
+        }
+
+      case ContractParamType.Void:
+        if (arg === null || arg === undefined) {
+          this.value = null;
           return;
-        case ContractParamType.Hash160:
-        case ContractParamType.Hash256:
-        case ContractParamType.PublicKey:
-          this.value = HexString.fromHex(input.value as string);
-          return;
-        case ContractParamType.Integer:
-        case ContractParamType.String:
-          this.value = input.value as number | string;
-          return;
-        case ContractParamType.Any:
-          this.value =
-            typeof input.value === "object"
-              ? (input.value as (ContractParamLike | ContractParam)[]).map(
-                  (cp) => new ContractParam(cp)
-                )
-              : input.value ?? null;
-          return;
-      }
-      this.value =
-        typeof input.value === "object"
-          ? (input.value as (ContractParamLike | ContractParam)[]).map(
-              (cp) => new ContractParam(cp)
-            )
-          : input.value ?? null;
-    } else {
-      throw new Error("No constructor arguments provided!");
+        } else {
+          throw new Error("Void should not have any value provided.");
+        }
+
+      default:
+        throw new Error(`${this.type} not supported!`);
     }
   }
 
@@ -215,10 +246,82 @@ export class ContractParam implements NeonObject<ContractParamLike> {
     return "ContractParam:" + ContractParamType[this.type];
   }
 
-  public export(): ContractParamLike {
+  /**
+   * Creates a ContractParam from a JSON representation. Use this as the main entry point for conversion from external systems.
+   * @param json - JSON format
+   */
+  public static fromJson(json: ContractParamLike): ContractParam {
+    if (json instanceof ContractParam) {
+      return new ContractParam(json);
+    }
+    const type = parseEnum(json.type, ContractParamType);
+    const arg = json.value;
+    switch (type) {
+      case ContractParamType.Array:
+        if (Array.isArray(arg)) {
+          return ContractParam.array(...arg);
+        }
+        break;
+      case ContractParamType.Boolean:
+        if (
+          typeof arg === "string" ||
+          typeof arg === "number" ||
+          typeof arg === "boolean"
+        ) {
+          return ContractParam.boolean(arg);
+        }
+        break;
+
+      case ContractParamType.ByteArray:
+        if (typeof arg === "string" || arg instanceof HexString) {
+          return ContractParam.byteArray(arg);
+        }
+        break;
+
+      case ContractParamType.Hash160:
+        if (typeof arg === "string" || arg instanceof HexString) {
+          return ContractParam.hash160(arg);
+        }
+        break;
+
+      case ContractParamType.Integer:
+        if (typeof arg === "string" || typeof arg === "number") {
+          return ContractParam.integer(arg);
+        }
+        break;
+
+      case ContractParamType.PublicKey:
+        if (typeof arg === "string") {
+          return ContractParam.publicKey(arg);
+        }
+        break;
+
+      case ContractParamType.String:
+        if (typeof arg === "string") {
+          return ContractParam.string(arg);
+        }
+        break;
+
+      case ContractParamType.Void:
+        return ContractParam.void();
+      default:
+        throw new Error(`${ContractParamType[type]} not supported!`);
+    }
+    throw new Error(`got ${typeof arg} which is not convertable to ${type}`);
+  }
+
+  public export(): ContractParamJson {
+    return this.toJson();
+  }
+
+  /**
+   * Converts the object to JSON format.
+   */
+  public toJson(): ContractParamJson {
     switch (this.type) {
       case ContractParamType.Void:
         return { type: ContractParamType[this.type], value: null };
+      case ContractParamType.ByteArray:
       case ContractParamType.Hash160:
       case ContractParamType.Hash256:
       case ContractParamType.PublicKey:
@@ -230,7 +333,7 @@ export class ContractParam implements NeonObject<ContractParamLike> {
       case ContractParamType.Array:
         return {
           type: ContractParamType[this.type],
-          value: (this.value as ContractParam[]).map((cp) => cp.export()),
+          value: (this.value as ContractParam[]).map((cp) => cp.toJson()),
         };
       case ContractParamType.Boolean:
         return {
@@ -238,10 +341,6 @@ export class ContractParam implements NeonObject<ContractParamLike> {
           value: this.value as boolean,
         };
       case ContractParamType.Integer:
-        return {
-          type: ContractParamType[this.type],
-          value: this.value as number,
-        };
       case ContractParamType.String:
       case ContractParamType.Signature:
       case ContractParamType.Any:
@@ -249,14 +348,19 @@ export class ContractParam implements NeonObject<ContractParamLike> {
           type: ContractParamType[this.type],
           value: this.value as string,
         };
+
       default:
         //TODO: Support Map and Interop
         throw new Error("Unsupported!");
     }
   }
 
+  /**
+   * Compares whether the other object is equal in value.
+   * @param other - ContractParam or the JSON format.
+   */
   public equals(other: ContractParamLike): boolean {
-    if (this.type === toContractParamType(other.type)) {
+    if (this.type === parseEnum(other.type, ContractParamType)) {
       switch (this.type) {
         case ContractParamType.Array:
         case ContractParamType.Map:
@@ -270,8 +374,7 @@ export class ContractParam implements NeonObject<ContractParamLike> {
             );
           }
           return false;
-        case ContractParamType.Void:
-          return true;
+        case ContractParamType.ByteArray:
         case ContractParamType.Hash160:
         case ContractParamType.Hash256:
         case ContractParamType.PublicKey:
@@ -282,6 +385,16 @@ export class ContractParam implements NeonObject<ContractParamLike> {
             return (this.value as HexString).equals(other.value);
           }
           return false;
+        case ContractParamType.Integer:
+          if (typeof other.value === "number") {
+            return this.value === other.value.toString();
+          }
+          if (typeof other.value === "string") {
+            return this.value === other.value;
+          }
+          return false;
+        case ContractParamType.Void:
+          return true;
         default:
           return this.value === other.value;
       }
@@ -293,7 +406,7 @@ export class ContractParam implements NeonObject<ContractParamLike> {
 export default ContractParam;
 
 export function likeContractParam(
-  cp: Partial<ContractParamLike | ContractParam>
+  cp: Partial<ContractParamLike>
 ): cp is ContractParamLike {
   if (cp === null || cp === undefined) {
     return false;

--- a/packages/neon-core/src/sc/ContractParam.ts
+++ b/packages/neon-core/src/sc/ContractParam.ts
@@ -161,13 +161,13 @@ export class ContractParam implements NeonObject<ContractParamLike> {
 
   /**
    * Creates a ByteArray ContractParam. Value field will be a HexString.
-   * @param value - a string or HexString.
+   * @param value - a base64 encoded string (LE) or HexString.
    */
   public static byteArray(value: string | HexString): ContractParam {
     if (typeof value === "string") {
       return new ContractParam({
         type: ContractParamType.ByteArray,
-        value: HexString.fromHex(value),
+        value: HexString.fromBase64(value, true),
       });
     }
 
@@ -359,6 +359,10 @@ export class ContractParam implements NeonObject<ContractParamLike> {
         return { type: ContractParamType[this.type], value: null };
 
       case ContractParamType.ByteArray:
+        return {
+          type: ContractParamType[this.type],
+          value: (this.value as HexString).toBase64(true),
+        };
       case ContractParamType.Hash160:
       case ContractParamType.Hash256:
       case ContractParamType.PublicKey:

--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -97,7 +97,7 @@ export class ScriptBuilder extends StringStream {
         } else if (data === null) {
           return this.emitPush(false);
         } else if (likeContractParam(data)) {
-          return this.emitContractParam(new ContractParam(data));
+          return this.emitContractParam(ContractParam.fromJson(data));
         }
         throw new Error(`Unidentified object: ${data}`);
       default:

--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -283,7 +283,7 @@ export class ScriptBuilder extends StringStream {
       case ContractParamType.Hash256:
         return this.emitHexString(param.value as HexString);
       case ContractParamType.PublicKey:
-        return this.emitPublicKey(param.value as string);
+        return this.emitPublicKey(param.value as HexString);
       default:
         throw new Error(`Unaccounted ContractParamType!: ${param.type}`);
     }

--- a/packages/neon-domain/src/provider/NeoNS/core.ts
+++ b/packages/neon-domain/src/provider/NeoNS/core.ts
@@ -33,7 +33,7 @@ export async function resolveDomain(
   const hashDomain = u.sha256(u.str2hexstring(tld));
 
   const hashName = u.sha256(hashSubdomain.concat(hashDomain));
-  const parsedName = sc.ContractParam.byteArray(hashName, "name");
+  const parsedName = sc.ContractParam.byteArray(hashName);
 
   const args = [protocol, parsedName, empty];
 

--- a/packages/neon-js/src/index.ts
+++ b/packages/neon-js/src/index.ts
@@ -39,14 +39,14 @@ const create = {
     new wallet.Wallet(k),
   contractParam: (
     type: keyof typeof sc.ContractParamType,
-    value:
+    value?:
       | string
       | number
       | boolean
-      | neonCore.sc.ContractParamLike[]
+      | neonCore.sc.ContractParamJson[]
       | null
       | undefined
-  ): neonCore.sc.ContractParam => new sc.ContractParam({ type, value }),
+  ): neonCore.sc.ContractParam => sc.ContractParam.fromJson({ type, value }),
   script: sc.createScript,
   scriptBuilder: (): neonCore.sc.ScriptBuilder => new sc.ScriptBuilder(),
   deployScript: (args: neonCore.sc.DeployParams): neonCore.sc.ScriptBuilder =>


### PR DESCRIPTION
Rework how ContractParam construction works. Introduce fromJson and restructure the methods to have clear separation of logic. Static methods are now the preferred entry points with fromJson being the common entrypoint.

- Introduce ContractParamJson which is the direct json output coming from c#.
- Reduce constructor to type validation.
- Move parsing and transformation logic into static methods.
- Add fromJson method as a main entrypoint from external systems.
- Rework ContractParamLike to be a union of the class and json format.
- Add tests for parseEnum.
