### PR TITLE
fix(rpc): Rename getValidators to getNextBlockValidators

### DIFF
--- a/packages/neon-core/__integration__/rpc/RPCClient.ts
+++ b/packages/neon-core/__integration__/rpc/RPCClient.ts
@@ -201,8 +201,8 @@ describe("RPC Methods", () => {
     expect(result).toBe(0);
   });
 
-  test.skip("getValidators", async () => {
-    const result = await client.getValidators();
+  test("getNextBlockValidators", async () => {
+    const result = await client.getNextBlockValidators();
     result.map((v) =>
       expect(v).toMatchObject({
         publickey: expect.any(String),

--- a/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
@@ -158,16 +158,16 @@ describe("NeoServerRpcClient", () => {
     expect(result).toBe(0);
   });
 
-  //TODO: Update to getNextBlockValidators
-  test.skip("getValidators", async () => {
-    const result = await client.getValidators();
-    result.map((v) =>
+  test("getNextBlockValidators", async () => {
+    const result = await client.getNextBlockValidators();
+    result.map((v) => {
+      expect(Object.keys(v)).toHaveLength(3);
       expect(v).toMatchObject({
         publickey: expect.any(String),
         active: expect.any(Boolean),
         votes: expect.any(String),
-      })
-    );
+      });
+    });
   });
 
   // TODO: Add new field magic

--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -140,9 +140,9 @@ describe("static", () => {
     expect(result.params).toEqual(["hash"]);
   });
 
-  test("getValidators", () => {
-    const result = Query.getValidators();
-    expect(result.method).toEqual("getvalidators");
+  test("getNextBlockValidators", () => {
+    const result = Query.getNextBlockValidators();
+    expect(result.method).toEqual("getnextblockvalidators");
     expect(result.params).toEqual([]);
   });
 

--- a/packages/neon-core/__tests__/rpc/RPCClient.ts
+++ b/packages/neon-core/__tests__/rpc/RPCClient.ts
@@ -9,6 +9,10 @@ import { Signer, WitnessScope } from "../../src/tx";
 jest.mock("axios");
 const Axios = mocked(_Axios, true);
 
+beforeEach(() => {
+  Axios.mockReset();
+});
+
 describe("constructor", () => {
   test("net", () => {
     const result = new RPCClient("MainNet");
@@ -470,7 +474,7 @@ describe("RPC Methods", () => {
     });
   });
 
-  describe("getValidators", () => {
+  describe("getNextBlockValidators", () => {
     test("success", async () => {
       const expected = [
         {
@@ -482,7 +486,7 @@ describe("RPC Methods", () => {
       Axios.post.mockImplementationOnce(async (url, data) => {
         expect(url).toEqual("http://testUrl.com");
         expect(data).toMatchObject({
-          method: "getvalidators",
+          method: "getnextblockvalidators",
           params: [],
         });
         return {
@@ -494,7 +498,7 @@ describe("RPC Methods", () => {
         };
       });
 
-      const result = await client.getValidators();
+      const result = await client.getNextBlockValidators();
       expect(result).toEqual(expected);
     });
   });

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -374,9 +374,9 @@ export class Query<TParams extends unknown[], TResponse> {
    * Gets the list of candidates available for voting.
    * @returns list of validators
    */
-  public static getValidators(): Query<[], Validator[]> {
+  public static getNextBlockValidators(): Query<[], Validator[]> {
     return new Query({
-      method: "getvalidators",
+      method: "getnextblockvalidators",
     });
   }
 

--- a/packages/neon-core/src/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/src/rpc/clients/NeoServerRpcClient.ts
@@ -177,8 +177,8 @@ export function NeoServerRpcMixin<TBase extends RpcDispatcherMixin>(
     /**
      * Gets the list of validators available for voting.
      */
-    public async getValidators(): Promise<Validator[]> {
-      const response = await this.execute(Query.getValidators());
+    public async getNextBlockValidators(): Promise<Validator[]> {
+      const response = await this.execute(Query.getNextBlockValidators());
       return response;
     }
     /**


### PR DESCRIPTION
Rename getValidators to getNextBlockValidators on RpcClient. Data has not changed.