### PR TITLE
feat(rpc): Update getVersion to return full version json

### DIFF
--- a/packages/neon-core/__integration__/rpc/RPCClient.ts
+++ b/packages/neon-core/__integration__/rpc/RPCClient.ts
@@ -214,7 +214,15 @@ describe("RPC Methods", () => {
 
   test("getVersion", async () => {
     const result = await client.getVersion();
-    expect(result).toMatch(/\d+\.\d+\.\d+-?.*/);
+
+    expect(Object.keys(result)).toHaveLength(5);
+    expect(result).toMatchObject({
+      tcpport: expect.any(Number),
+      wsport: expect.any(Number),
+      nonce: expect.any(Number),
+      useragent: expect.any(String),
+      magic: expect.any(Number),
+    });
   });
 
   test("listPlugins", async () => {

--- a/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
@@ -170,10 +170,17 @@ describe("NeoServerRpcClient", () => {
     );
   });
 
-  // TODO: Add new field magic
   test("getVersion", async () => {
     const result = await client.getVersion();
-    expect(result).toMatch(/\d+\.\d+\.\d+-?.*/);
+
+    expect(Object.keys(result)).toHaveLength(5);
+    expect(result).toMatchObject({
+      tcpport: expect.any(Number),
+      wsport: expect.any(Number),
+      nonce: expect.any(Number),
+      useragent: expect.any(String),
+      magic: expect.any(Number),
+    });
   });
 
   test("listPlugins", async () => {

--- a/packages/neon-core/__tests__/rpc/RPCClient.ts
+++ b/packages/neon-core/__tests__/rpc/RPCClient.ts
@@ -501,7 +501,13 @@ describe("RPC Methods", () => {
 
   describe("getVersion", () => {
     test("success", async () => {
-      const expected = "3.0.0-preview3";
+      const expected = {
+        tcpport: 20333,
+        wsport: 20334,
+        nonce: 288566725,
+        useragent: "/Neo:3.0.0-preview3/",
+        magic: 1234567890,
+      };
       Axios.post.mockImplementationOnce(async (url, data) => {
         expect(url).toEqual("http://testUrl.com");
         expect(data).toMatchObject({
@@ -512,12 +518,7 @@ describe("RPC Methods", () => {
           data: {
             jsonrpc: "2.0",
             id: data.id,
-            result: {
-              tcpport: 20333,
-              wsport: 20334,
-              nonce: 288566725,
-              useragent: "/Neo:3.0.0-preview3/",
-            },
+            result: expected,
           },
         };
       });

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -111,6 +111,7 @@ export interface GetVersionResult {
   wsport: number;
   nonce: number;
   useragent: string;
+  magic: number;
 }
 
 export interface NodePeer {

--- a/packages/neon-core/src/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/src/rpc/clients/NeoServerRpcClient.ts
@@ -7,6 +7,7 @@ import {
   GetRawTransactionResult,
   InvokeResult,
   BooleanLikeParam,
+  GetVersionResult,
 } from "../Query";
 import { ContractManifest } from "../../sc";
 import { BlockJson, BlockHeaderJson, Validator } from "../../types";
@@ -182,20 +183,11 @@ export function NeoServerRpcMixin<TBase extends RpcDispatcherMixin>(
       return response;
     }
     /**
-     * Gets the version of the NEO node. This method will never be blocked by version. This method will also update the current Client's version to the one received.
+     * Gets the version of the NEO node along with various other metadata.
      */
-    public async getVersion(): Promise<string> {
+    public async getVersion(): Promise<GetVersionResult> {
       const response = await this.execute(Query.getVersion());
-      if (response?.useragent) {
-        const useragent = response.useragent;
-        const responseLength = useragent.length;
-        const strippedResponse = useragent.substring(1, responseLength - 1);
-        return strippedResponse.split(":")[1];
-      } else {
-        throw new Error(
-          `Empty or unexpected version pattern. Got ${JSON.stringify(response)}`
-        );
-      }
+      return response;
     }
 
     /**


### PR DESCRIPTION
getVersion now returns the magic which is important to sign transactions. Instead of parsing and returning the useragent, this changes the method to return the full json response without any edits.