### PR TITLE
fix(rpc): Update invokeFunction and invokeScript

### DIFF
--- a/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
@@ -188,22 +188,32 @@ describe("NeoServerRpcClient", () => {
     });
   });
 
-  //TODO: Add new field: exception
-  // TODO: Update script to receive base64 string
   describe("Invocation methods", () => {
-    test("invokeFunction", async () => {
+    test("invokeFunction with HALT", async () => {
       const result = await client.invokeFunction(contractHash, "name");
 
-      expect(Object.keys(result)).toEqual(
-        expect.arrayContaining([
-          "script",
-          "state",
-          "gasconsumed",
-          "stack",
-          "tx",
-        ])
-      );
-      expect(result.state).toContain("HALT");
+      expect(Object.keys(result)).toHaveLength(6);
+      expect(result).toMatchObject({
+        script: expect.any(String),
+        state: "HALT",
+        gasconsumed: expect.any(String),
+        exception: null,
+        stack: expect.any(Array),
+        tx: null,
+      });
+    });
+
+    test("invokeFunction with FAULT", async () => {
+      const result = await client.invokeFunction(contractHash, "fail");
+
+      expect(Object.keys(result)).toHaveLength(5);
+      expect(result).toMatchObject({
+        script: expect.any(String),
+        state: "FAULT",
+        gasconsumed: expect.any(String),
+        exception: expect.any(String),
+        stack: expect.any(Array),
+      });
     });
 
     test("invokeFunction with signers", async () => {
@@ -225,16 +235,15 @@ describe("NeoServerRpcClient", () => {
         ]
       );
 
-      expect(Object.keys(result)).toEqual(
-        expect.arrayContaining([
-          "script",
-          "state",
-          "gasconsumed",
-          "stack",
-          "tx",
-        ])
-      );
-      expect(result.state).toContain("HALT");
+      expect(Object.keys(result)).toHaveLength(6);
+      expect(result).toMatchObject({
+        script: expect.any(String),
+        state: "HALT",
+        gasconsumed: expect.any(String),
+        exception: null,
+        stack: expect.any(Array),
+        tx: null,
+      });
     });
 
     test("invokeScript", async () => {
@@ -244,15 +253,17 @@ describe("NeoServerRpcClient", () => {
           .emitAppCall(contractHash, "symbol")
           .build()
       );
-      expect(Object.keys(result)).toEqual(
-        expect.arrayContaining([
-          "script",
-          "state",
-          "gasconsumed",
-          "stack",
-          "tx",
-        ])
-      );
+
+      expect(Object.keys(result)).toHaveLength(6);
+      expect(result).toMatchObject({
+        script: expect.any(String),
+        state: "HALT",
+        gasconsumed: expect.any(String),
+        exception: null,
+        stack: expect.any(Array),
+        tx: null,
+      });
+
       expect(result.state).toContain("HALT");
       expect(result.stack.length).toEqual(2);
       expect(result.stack[0].value).toEqual(
@@ -283,16 +294,15 @@ describe("NeoServerRpcClient", () => {
         }),
       ]);
 
-      expect(Object.keys(result)).toEqual(
-        expect.arrayContaining([
-          "script",
-          "state",
-          "gasconsumed",
-          "stack",
-          "tx",
-        ])
-      );
-      expect(result.state).toContain("HALT");
+      expect(Object.keys(result)).toHaveLength(6);
+      expect(result).toMatchObject({
+        script: expect.any(String),
+        state: "HALT",
+        gasconsumed: expect.any(String),
+        exception: null,
+        stack: expect.any(Array),
+        tx: null,
+      });
     });
   });
 

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -42,13 +42,16 @@ export type GetApplicationLogsResult = ApplicationLog[];
  * Result from calling invokescript or invokefunction.
  */
 export interface InvokeResult {
-  /** The script that is sent for execution on the blockchain. This is a hexstring. */
+  /** The script that is sent for execution on the blockchain as a base64 string. */
   script: string;
   /** State of VM on exit. HALT means a successful exit while FAULT means exit with error. */
   state: "HALT" | "FAULT";
   /** Amount of gas consumed up to the point of stopping in the VM. If state is FAULT, this value is not representative of the amount of gas it will consume if it somehow succeeds on the blockchain. */
   gasconsumed: string;
+  /** A human-readable string clarifying the exception that occurred. Only available when state is "FAULT". */
+  exception: string | null;
   stack: StackItemJson[];
+  /** A ready to send transaction that wraps the script. Only available when signers are provided and the sender's private key is open in the RPC node.*/
   tx?: unknown;
 }
 


### PR DESCRIPTION
invokeFunction and invokeScript now returns the script as a base64 string and returns a new `exception` field. We do not post process the fields at the moment so this is a simple type update.