### PR TITLE
fix(rpc): Fix getContractState RPC call converting manifest wrongly

### DIFF
--- a/packages/neon-core/__tests__/rpc/RPCClient.ts
+++ b/packages/neon-core/__tests__/rpc/RPCClient.ts
@@ -287,13 +287,28 @@ describe("RPC Methods", () => {
       const successfulResult = {
         script: "1234",
         hash: "5678",
-        manifest: { safeMethods: ["a", "b"] },
+        manifest: {
+          groups: [],
+          abi: {
+            hash: "1234",
+            methods: [],
+            events: [],
+          },
+          permissions: [],
+          trusts: "*" as const,
+          safemethods: ["a", "b"],
+          supportedstandards: [],
+          features: {
+            storage: true,
+            payable: false,
+          },
+        },
       };
       Axios.post.mockImplementationOnce(async (url, data) => {
         expect(url).toEqual("http://testUrl.com");
         expect(data).toMatchObject({
           method: "getcontractstate",
-          params: ["hash"],
+          params: ["5678"],
         });
         return {
           data: {
@@ -303,9 +318,11 @@ describe("RPC Methods", () => {
           },
         };
       });
-      const result = await client.getContractState("hash");
+      const result = await client.getContractState("5678");
 
-      expect(result).toEqual(new ContractManifest(successfulResult.manifest));
+      expect(result).toEqual(
+        ContractManifest.fromJson(successfulResult.manifest)
+      );
     });
   });
 

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_REQ } from "../consts";
 import { Transaction, TransactionJson, Signer, SignerJson } from "../tx";
-import { ContractManifestLike, ContractParam, StackItemJson } from "../sc";
+import { ContractManifestJson, ContractParam, StackItemJson } from "../sc";
 import { BlockJson, Validator, BlockHeaderJson } from "../types";
 
 export type BooleanLikeParam = 0 | 1 | boolean;
@@ -59,7 +59,7 @@ export interface GetContractStateResult {
   /** 0x prefixed hexstring */
   hash: string;
   script: string;
-  manifest: ContractManifestLike;
+  manifest: ContractManifestJson;
 }
 
 export interface GetNep5TransfersResult {

--- a/packages/neon-core/src/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/src/rpc/clients/NeoServerRpcClient.ts
@@ -104,7 +104,7 @@ export function NeoServerRpcMixin<TBase extends RpcDispatcherMixin>(
       scriptHash: string
     ): Promise<ContractManifest> {
       const response = await this.execute(Query.getContractState(scriptHash));
-      return new ContractManifest(response.manifest);
+      return ContractManifest.fromJson(response.manifest);
     }
 
     /**


### PR DESCRIPTION
Use fromJson method instead of constructor. The constructor was expecting `safeMethods` but fromJson takes `safemethods`. 

Closes #618