### PR TITLE
fix(api): Remove default notification urls

### DIFF
--- a/docs/api/plugin/api.md
+++ b/docs/api/plugin/api.md
@@ -75,7 +75,7 @@ The available providers are `neoscan`, `neonDB` and `notifications`. The first t
 ```js
 const mainNetNeoscan = new api.neocan.instance("MainNet");
 const mainNetNeonDB = new api.neonDB.instance("MainNet");
-const mainNetNotifications = new api.notifications.instance("MainNet");
+const mainNetNotifications = new api.notifications.instance("wss://YOUR_PUBSUB_SERVER.com");
 
 const neoscanBalance = await mainNetNeoscan.getBalance(addr);
 const neonDBBalance = await mainNetNeonDB.getBalance(addr);

--- a/docs/changelog/latest.md
+++ b/docs/changelog/latest.md
@@ -3,6 +3,13 @@ id: latest
 title: Changelog (v4)
 ---
 
+4.8.2
+=====
+
+- Fixes
+
+  - Fix false not being accepted as a valid value for ContractParam.
+
 4.8.1
 =====
 

--- a/docs/examples/network.md
+++ b/docs/examples/network.md
@@ -34,10 +34,8 @@ const apiCli = new api.neoCli.instance(
 ```javascript
 const { api } = require("@cityofzion/neon-js");
 
-const NETWORK = "MainNet"; // or "TestNet"
 const notificationsProvider = new api.notifications.instance(
-  "wss://pubsub.main.neologin.io/event"
-  //or "wss://pubsub.test.neologin.io/event" for TestNet
+  "wss://main.YOUR_PUBSUB_SERVER.com/event"
 );
 ```
 

--- a/examples/browser/subscribenotifications/demo/demo.js
+++ b/examples/browser/subscribenotifications/demo/demo.js
@@ -4,7 +4,7 @@ const contractHash = "0x314b5aac1cdd01d10661b00886197f2194c3c89b";
 const allContractHashes = null;
 
 // Get an instance of the Notifications server
-const provider = new Neon.api.notifications.instance("MainNet");
+const provider = new Neon.api.notifications.instance("wss://YOUR_PUBSUB_SERVER.com/event");
 
 let subscription;
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.8.1",
+  "version": "4.8.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "workspaces": [

--- a/packages/neon-api/src/notifications/class.ts
+++ b/packages/neon-api/src/notifications/class.ts
@@ -21,6 +21,7 @@ export class Notifications {
 
   /**
    * Create a new notification service that handles contract subscriptions
+   * Source code and instructions on how to run this service are available on https://github.com/corollari/neo-PubSub
    * @param url - URL of a notifications service.
    */
   public constructor(url: string) {

--- a/packages/neon-core/package.json
+++ b/packages/neon-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cityofzion/neon-core",
   "description": "Neon-JS Core functionality",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CityOfZion/neon-js.git"

--- a/packages/neon-js/package.json
+++ b/packages/neon-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cityofzion/neon-js",
   "description": "Neon-JS SDK for interacting with NEO blockchain",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CityOfZion/neon-js.git"
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@cityofzion/neon-api": "^4.8.1",
-    "@cityofzion/neon-core": "^4.8.1",
-    "@cityofzion/neon-nep5": "^4.8.1"
+    "@cityofzion/neon-core": "^4.8.2",
+    "@cityofzion/neon-nep5": "^4.8.2"
   },
   "files": [
     "dist/"

--- a/packages/neon-js/src/networks.ts
+++ b/packages/neon-js/src/networks.ts
@@ -29,8 +29,7 @@ export default {
     },
     ExtraConfiguration: {
       neonDB: "http://api.wallet.cityofzion.io",
-      neoscan: "https://api.neoscan.io/api/main_net",
-      notifications: "wss://pubsub.main.neologin.io/event",
+      neoscan: "https://api.neoscan.io/api/main_net"
     },
   },
   TestNet: {
@@ -63,8 +62,7 @@ export default {
     },
     ExtraConfiguration: {
       neonDB: "http://testnet-api.wallet.cityofzion.io",
-      neoscan: "https://neoscan-testnet.io/api/test_net",
-      notifications: "wss://pubsub.test.neologin.io/event",
+      neoscan: "https://neoscan-testnet.io/api/test_net"
     },
   },
   CozNet: {

--- a/packages/neon-ledger/package.json
+++ b/packages/neon-ledger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cityofzion/neon-ledger",
   "description": "Neon Ledger integration for Node.js",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CityOfZion/neon-js.git"
@@ -45,7 +45,7 @@
     "typings/"
   ],
   "devDependencies": {
-    "@cityofzion/neon-js": "^4.8.1",
+    "@cityofzion/neon-js": "^4.8.2",
     "@ledgerhq/hw-transport-node-hid": "5.15.0",
     "@ledgerhq/hw-transport-u2f": "5.15.0",
     "@types/ledgerhq__hw-transport-node-hid": "4.22.1"

--- a/packages/neon-nep5/package.json
+++ b/packages/neon-nep5/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cityofzion/neon-nep5",
   "description": "Neon-NEP5 Module",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CityOfZion/neon-js.git"
@@ -33,7 +33,7 @@
     "test:unit": "jest /packages/.*/__tests__/.*"
   },
   "dependencies": {
-    "@cityofzion/neon-core": "^4.8.1"
+    "@cityofzion/neon-core": "^4.8.2"
   },
   "peerDependencies": {
     "@cityofzion/neon-core": "^4.0.0"

--- a/packages/neon-nep9/package.json
+++ b/packages/neon-nep9/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cityofzion/neon-nep9",
   "description": "Neon-NEP9 Module",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CityOfZion/neon-js.git"
@@ -32,7 +32,7 @@
     "test:unit": "jest /packages/.*/__tests__/.*"
   },
   "dependencies": {
-    "@cityofzion/neon-core": "^4.8.1"
+    "@cityofzion/neon-core": "^4.8.2"
   },
   "peerDependencies": {
     "@cityofzion/neon-core": "^4.0.0"


### PR DESCRIPTION
Following the discussion on #624, this PR removes the notification server urls that are used by default when the network is set to either "MainNet" or "TestNet", reverting some of the changes applied in #514 and #515.

After this PR is merged I'll make an announcement to the broader community and, after a grace period, shut down the servers.