### PR TITLE
feat(sc): OpToken.toScript

### DIFF
--- a/packages/neon-core/__tests__/sc/OpToken.ts
+++ b/packages/neon-core/__tests__/sc/OpToken.ts
@@ -122,6 +122,18 @@ describe("toScript", () => {
       expect(result).toEqual(script);
     }
   );
+
+  test("throws on incorrectly sized OpToken (operandSize)", () => {
+    const token = new OpToken(OpCode.PUSHINT8, "000000");
+
+    expect(() => token.toScript()).toThrow();
+  });
+
+  test("throws on incorrectly sized OpToken (operandSizePrefix)", () => {
+    const token = new OpToken(OpCode.PUSHDATA1, "00".repeat(500));
+
+    expect(() => token.toScript()).toThrow();
+  });
 });
 
 describe("parseInt", () => {

--- a/packages/neon-core/__tests__/sc/OpToken.ts
+++ b/packages/neon-core/__tests__/sc/OpToken.ts
@@ -44,68 +44,84 @@ describe("prettyPrint", () => {
   });
 });
 
+const scriptAndOpCodes = [
+  ["empty", "", []],
+  ["single opcode", "0b", [new OpToken(OpCode.PUSHNULL)]],
+  [
+    "single opcode with params",
+    "4101020304",
+    [new OpToken(OpCode.SYSCALL, "01020304")],
+  ],
+  [
+    "PUSHINT256",
+    "05faffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    [
+      new OpToken(
+        OpCode.PUSHINT256,
+        "faffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      ),
+    ],
+  ],
+  [
+    "simple jump",
+    "212203371140",
+    [
+      new OpToken(OpCode.NOP),
+      new OpToken(OpCode.JMP, "03"),
+      new OpToken(OpCode.ABORT),
+      new OpToken(OpCode.PUSH1),
+      new OpToken(OpCode.RET),
+    ],
+  ],
+  [
+    "new array with type",
+    "12c421",
+    [new OpToken(OpCode.PUSH2), new OpToken(OpCode.NEWARRAY_T, "21")],
+  ],
+  [
+    "multisig script",
+    "120c2102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef0c21031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c90c2102232ce8d2e2063dce0451131851d47421bfc4fc1da4db116fca5302c0756462fa130b41138defaf",
+    [
+      new OpToken(OpCode.PUSH2),
+      new OpToken(
+        OpCode.PUSHDATA1,
+        "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef"
+      ),
+      new OpToken(
+        OpCode.PUSHDATA1,
+        "031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c9"
+      ),
+      new OpToken(
+        OpCode.PUSHDATA1,
+        "02232ce8d2e2063dce0451131851d47421bfc4fc1da4db116fca5302c0756462fa"
+      ),
+      new OpToken(OpCode.PUSH3),
+      new OpToken(OpCode.PUSHNULL),
+      new OpToken(OpCode.SYSCALL, "138defaf"),
+    ],
+  ],
+  ["PUSHDATA4", "0e020000001234", [new OpToken(OpCode.PUSHDATA4, "1234")]],
+];
 describe("fromScript", () => {
-  test.each([
-    ["empty", "", []],
-    ["single opcode", "0b", [new OpToken(OpCode.PUSHNULL)]],
-    [
-      "single opcode with params",
-      "4101020304",
-      [new OpToken(OpCode.SYSCALL, "01020304")],
-    ],
-    [
-      "PUSHINT256",
-      "05faffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      [
-        new OpToken(
-          OpCode.PUSHINT256,
-          "faffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-        ),
-      ],
-    ],
-    [
-      "simple jump",
-      "212203371140",
-      [
-        new OpToken(OpCode.NOP),
-        new OpToken(OpCode.JMP, "03"),
-        new OpToken(OpCode.ABORT),
-        new OpToken(OpCode.PUSH1),
-        new OpToken(OpCode.RET),
-      ],
-    ],
-    [
-      "new array with type",
-      "12c421",
-      [new OpToken(OpCode.PUSH2), new OpToken(OpCode.NEWARRAY_T, "21")],
-    ],
-    [
-      "multisig script",
-      "120c2102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef0c21031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c90c2102232ce8d2e2063dce0451131851d47421bfc4fc1da4db116fca5302c0756462fa130b41138defaf",
-      [
-        new OpToken(OpCode.PUSH2),
-        new OpToken(
-          OpCode.PUSHDATA1,
-          "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef"
-        ),
-        new OpToken(
-          OpCode.PUSHDATA1,
-          "031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c9"
-        ),
-        new OpToken(
-          OpCode.PUSHDATA1,
-          "02232ce8d2e2063dce0451131851d47421bfc4fc1da4db116fca5302c0756462fa"
-        ),
-        new OpToken(OpCode.PUSH3),
-        new OpToken(OpCode.PUSHNULL),
-        new OpToken(OpCode.SYSCALL, "138defaf"),
-      ],
-    ],
-  ])("%s", (_: string, script: string, tokens: OpToken[]) => {
-    const result = OpToken.fromScript(script);
+  test.each(scriptAndOpCodes)(
+    "%s",
+    (_: string, script: string, tokens: OpToken[]) => {
+      const result = OpToken.fromScript(script);
 
-    expect(result).toEqual(expect.arrayContaining(tokens));
-  });
+      expect(result).toEqual(expect.arrayContaining(tokens));
+    }
+  );
+});
+
+describe("toScript", () => {
+  test.each(scriptAndOpCodes)(
+    "%s",
+    (_: string, script: string, tokens: OpToken[]) => {
+      const result = tokens.reduce((r, t) => r + t.toScript(), "");
+
+      expect(result).toEqual(script);
+    }
+  );
 });
 
 describe("parseInt", () => {

--- a/packages/neon-core/__tests__/u/HexString.ts
+++ b/packages/neon-core/__tests__/u/HexString.ts
@@ -29,11 +29,6 @@ describe("Initiator", () => {
       expect(hex.toBigEndian()).toBe("270f");
     });
 
-    test("param littleEndian is true", () => {
-      const hex = HexString.fromNumber(9999, true);
-      expect(hex.toBigEndian()).toBe("0f27");
-    });
-
     test("0 as param", () => {
       const hex = HexString.fromNumber(0);
       expect(hex.toBigEndian()).toBe("00");

--- a/packages/neon-core/src/sc/OpToken.ts
+++ b/packages/neon-core/src/sc/OpToken.ts
@@ -104,14 +104,25 @@ export class OpToken {
     }`;
   }
 
+  /**
+   * Converts an OpToken back to hexstring.
+   */
   public toScript(): string {
     const opCodeHex = HexString.fromNumber(this.code).toLittleEndian();
     const params = this.params ?? "";
     const annotation = OpCodeAnnotations[this.code];
+
+    // operandSizePrefix indicates how many variable bytes after the OpCode to read.
     if (annotation.operandSizePrefix) {
       const sizeByte = HexString.fromNumber(params.length / 2).toLittleEndian();
+
       if (sizeByte.length / 2 > annotation.operandSizePrefix) {
-        throw new Error("params is larger than allowed by OpCode.");
+        const maxExpectedSize = Math.pow(2, annotation.operandSizePrefix * 8);
+        throw new Error(
+          `Expected params to be less than ${maxExpectedSize} but got ${
+            params.length / 2
+          }`
+        );
       }
 
       return (
@@ -120,6 +131,18 @@ export class OpToken {
         params
       );
     }
+
+    // operandSize indicates how many bytes after the OpCode to read.
+    if (annotation.operandSize) {
+      if (params.length / 2 !== annotation.operandSize) {
+        throw new Error(
+          `Expected params to be ${annotation.operandSize} bytes long but got ${
+            params.length / 2
+          } instead.`
+        );
+      }
+    }
+
     return opCodeHex + params;
   }
 }

--- a/packages/neon-core/src/sc/OpToken.ts
+++ b/packages/neon-core/src/sc/OpToken.ts
@@ -103,6 +103,25 @@ export class OpToken {
         : OpCode[this.code]
     }`;
   }
+
+  public toScript(): string {
+    const opCodeHex = HexString.fromNumber(this.code).toLittleEndian();
+    const params = this.params ?? "";
+    const annotation = OpCodeAnnotations[this.code];
+    if (annotation.operandSizePrefix) {
+      const sizeByte = HexString.fromNumber(params.length / 2).toLittleEndian();
+      if (sizeByte.length / 2 > annotation.operandSizePrefix) {
+        throw new Error("params is larger than allowed by OpCode.");
+      }
+
+      return (
+        opCodeHex +
+        sizeByte.padEnd(annotation.operandSizePrefix * 2, "0") +
+        params
+      );
+    }
+    return opCodeHex + params;
+  }
 }
 
 type ParamsExtracter = (script: StringStream) => string;

--- a/packages/neon-core/src/u/HexString.ts
+++ b/packages/neon-core/src/u/HexString.ts
@@ -1,7 +1,6 @@
 import { ensureHex, reverseHex, hexXor } from "./misc";
 import {
   str2hexstring,
-  num2hexstring,
   hexstring2ab,
   ab2hexstring,
   hexstring2str,
@@ -141,8 +140,12 @@ export class HexString {
    * Get HexString instance from a number
    * @param littleEndian - whether `num` is little endian
    */
-  public static fromNumber(num: number, littleEndian = false): HexString {
-    return new HexString(num2hexstring(num), littleEndian);
+  public static fromNumber(num: number): HexString {
+    const rawHex = num.toString(16);
+    if (rawHex.length % 2 !== 0) {
+      return new HexString("0" + rawHex);
+    }
+    return new HexString(rawHex);
   }
 
   /**


### PR DESCRIPTION
Converts an OpToken back to hexstring format.

Also adjusts HexString.fromNumber as the little endian option did not make sense. num2hexstring needs a size so just use toString to get the hex directly.