### PR TITLE
feat(sc): OpToken.forInteger

### DIFF
--- a/packages/neon-core/__tests__/sc/OpToken.ts
+++ b/packages/neon-core/__tests__/sc/OpToken.ts
@@ -160,3 +160,19 @@ describe("parseInt", () => {
     expect(result).toBe(expected);
   });
 });
+
+describe("forInteger", () => {
+  test.each([
+    [16, new OpToken(OpCode.PUSH16)],
+    [0, new OpToken(OpCode.PUSH0)],
+    [-1, new OpToken(OpCode.PUSHM1)],
+    [127, new OpToken(OpCode.PUSHINT8, "7f")],
+    [255, new OpToken(OpCode.PUSHINT16, "ff00")],
+    [32512, new OpToken(OpCode.PUSHINT16, "007f")],
+    ["2130706432", new OpToken(OpCode.PUSHINT32, "0000007f")],
+  ])("%d", (n: number | string, token: OpToken) => {
+    const result = OpToken.forInteger(n);
+
+    expect(result).toEqual(token);
+  });
+});

--- a/packages/neon-core/src/sc/OpToken.ts
+++ b/packages/neon-core/src/sc/OpToken.ts
@@ -72,6 +72,31 @@ export class OpToken {
     }
   }
 
+  /**Creates the OpToken for pushing a variable number onto the stack. */
+  public static forInteger(n: number | string | BigInteger): OpToken {
+    const i = n instanceof BigInteger ? n : BigInteger.fromNumber(n);
+    if (n === -1) {
+      return new OpToken(OpCode.PUSHM1);
+    }
+    if (i.compare(0) >= 0 && i.compare(16) <= 0) {
+      return new OpToken(OpCode.PUSH0 + parseInt(i.toString()));
+    }
+    const twos = i.toReverseTwos();
+    if (twos.length <= 2) {
+      return new OpToken(OpCode.PUSHINT8, twos.padEnd(2, "0"));
+    } else if (twos.length <= 4) {
+      return new OpToken(OpCode.PUSHINT16, twos.padEnd(4, "0"));
+    } else if (twos.length <= 8) {
+      return new OpToken(OpCode.PUSHINT32, twos.padEnd(8, "0"));
+    } else if (twos.length <= 16) {
+      return new OpToken(OpCode.PUSHINT64, twos.padEnd(16, "0"));
+    } else if (twos.length <= 32) {
+      return new OpToken(OpCode.PUSHINT128, twos.padEnd(32, "0"));
+    } else {
+      throw new Error("Number out of range");
+    }
+  }
+
   constructor(public code: OpCode, public params?: string) {}
 
   /**


### PR DESCRIPTION
Converts an integer into an OpToken to push a number onto the stack. Pushing a number is harder than usual due to the required logic to read and understand the cheapest OpCode to use.