### PR TITLE
feat(tx): Update MAX_TRANSACTION_LIFESPAN for preview4

### DIFF
--- a/packages/neon-api/__tests__/transaction/validator.ts
+++ b/packages/neon-api/__tests__/transaction/validator.ts
@@ -85,7 +85,7 @@ describe("validate", () => {
           valid: true,
           fixed: true,
           prev: 1,
-          suggestion: 10 + tx.Transaction.MAX_TRANSACTION_LIFESPAN - 1,
+          suggestion: 10 + TransactionValidator.TX_LIFESPAN_SUGGESTION - 1,
         },
         systemFee: { valid: true, fixed: false },
         script: { valid: true, fixed: false },
@@ -126,7 +126,7 @@ describe("validateValidUntilBlock", () => {
       valid: false,
       fixed: false,
       prev: 1,
-      suggestion: 10 + tx.Transaction.MAX_TRANSACTION_LIFESPAN - 1,
+      suggestion: 10 + TransactionValidator.TX_LIFESPAN_SUGGESTION - 1,
     });
     expect(txn.validUntilBlock).toBe(1);
   });
@@ -144,7 +144,7 @@ describe("validateValidUntilBlock", () => {
       valid: false,
       fixed: false,
       prev: 100000000,
-      suggestion: 10 + tx.Transaction.MAX_TRANSACTION_LIFESPAN - 1,
+      suggestion: 10 + TransactionValidator.TX_LIFESPAN_SUGGESTION - 1,
     });
     expect(txn.validUntilBlock).toBe(100000000);
   });
@@ -163,7 +163,7 @@ describe("validateValidUntilBlock", () => {
       valid: true,
       fixed: false,
       prev: 250,
-      suggestion: 10 + tx.Transaction.MAX_TRANSACTION_LIFESPAN - 1,
+      suggestion: 10 + TransactionValidator.TX_LIFESPAN_SUGGESTION - 1,
     });
     expect(txn.validUntilBlock).toBe(250);
   });
@@ -182,10 +182,10 @@ describe("validateValidUntilBlock", () => {
       valid: true,
       fixed: true,
       prev: 1,
-      suggestion: 10 + tx.Transaction.MAX_TRANSACTION_LIFESPAN - 1,
+      suggestion: 10 + TransactionValidator.TX_LIFESPAN_SUGGESTION - 1,
     });
     expect(txn.validUntilBlock).toBe(
-      10 + tx.Transaction.MAX_TRANSACTION_LIFESPAN - 1
+      10 + TransactionValidator.TX_LIFESPAN_SUGGESTION - 1
     );
   });
 });

--- a/packages/neon-api/__tests__/transaction/validator.ts
+++ b/packages/neon-api/__tests__/transaction/validator.ts
@@ -165,7 +165,7 @@ describe("validateValidUntilBlock", () => {
       prev: 30,
       suggestion: 10 + TransactionValidator.TX_LIFESPAN_SUGGESTION - 1,
     });
-    expect(txn.validUntilBlock).toBe(250);
+    expect(txn.validUntilBlock).toBe(30);
   });
 
   test("autofix", async () => {

--- a/packages/neon-api/__tests__/transaction/validator.ts
+++ b/packages/neon-api/__tests__/transaction/validator.ts
@@ -40,7 +40,7 @@ describe("validate", () => {
         .mockImplementation(async () => ({ state: "HALT", gasconsumed: 100 })),
     } as unknown) as rpc.RPCClient;
     const txn = new tx.Transaction({
-      validUntilBlock: 1000000,
+      validUntilBlock: 5000,
       script: "abcd",
       systemFee: 100,
     });
@@ -100,7 +100,7 @@ describe("validateValidUntilBlock", () => {
       getBlockCount: jest.fn().mockImplementation(async () => 10),
     } as unknown) as rpc.RPCClient;
     const txn = new tx.Transaction({
-      validUntilBlock: 1000000,
+      validUntilBlock: 5000,
     });
     const validator = new TransactionValidator(rpcClient, txn);
     const result = await validator.validateValidUntilBlock(false);
@@ -109,7 +109,7 @@ describe("validateValidUntilBlock", () => {
       valid: true,
       fixed: false,
     });
-    expect(txn.validUntilBlock).toBe(1000000);
+    expect(txn.validUntilBlock).toBe(5000);
   });
 
   test("invalid (validUntilBlock too small)", async () => {
@@ -149,12 +149,12 @@ describe("validateValidUntilBlock", () => {
     expect(txn.validUntilBlock).toBe(100000000);
   });
 
-  test("valid but suggest when lifespan too short (240)", async () => {
+  test("valid but suggest when lifespan too short (20)", async () => {
     const rpcClient: rpc.RPCClient = ({
       getBlockCount: jest.fn().mockImplementation(async () => 10),
     } as unknown) as rpc.RPCClient;
     const txn = new tx.Transaction({
-      validUntilBlock: 250,
+      validUntilBlock: 30,
     });
     const validator = new TransactionValidator(rpcClient, txn);
     const result = await validator.validateValidUntilBlock(false);

--- a/packages/neon-api/__tests__/transaction/validator.ts
+++ b/packages/neon-api/__tests__/transaction/validator.ts
@@ -162,7 +162,7 @@ describe("validateValidUntilBlock", () => {
     expect(result).toMatchObject({
       valid: true,
       fixed: false,
-      prev: 250,
+      prev: 30,
       suggestion: 10 + TransactionValidator.TX_LIFESPAN_SUGGESTION - 1,
     });
     expect(txn.validUntilBlock).toBe(250);

--- a/packages/neon-api/src/transaction/validator.ts
+++ b/packages/neon-api/src/transaction/validator.ts
@@ -38,6 +38,7 @@ export interface ValidationResult {
  * A class with functions to validate transaction
  */
 export class TransactionValidator {
+  public static TX_LIFESPAN_SUGGESTION = 240;
   /**
    * Transaction will be validated on this rpc node
    */
@@ -62,7 +63,8 @@ export class TransactionValidator {
   ): Promise<ValidationSuggestion<number>> {
     const { validUntilBlock: prev } = this.transaction;
     const height = await this.rpcClient.getBlockCount();
-    const suggestion = tx.Transaction.MAX_TRANSACTION_LIFESPAN + height - 1;
+    // Suggest a lifespan of approx. 1hr based on 15s blocks
+    const suggestion = TransactionValidator.TX_LIFESPAN_SUGGESTION + height - 1;
     if (
       prev <= height ||
       prev >= height + tx.Transaction.MAX_TRANSACTION_LIFESPAN
@@ -77,7 +79,7 @@ export class TransactionValidator {
         "Your transaction lifespan was out of range."
       );
     }
-    if (prev - height <= 240) {
+    if (prev - height <= 20) {
       return suggest(
         prev,
         suggestion,

--- a/packages/neon-core/src/tx/transaction/Transaction.ts
+++ b/packages/neon-core/src/tx/transaction/Transaction.ts
@@ -119,9 +119,10 @@ export class Transaction implements NeonObject<TransactionLike> {
   public script: HexString;
 
   /**
-   * Maximum duration in blocks that a transaction can stay valid in the mempol
+   * Maximum duration in blocks that a transaction can stay valid in the mempool.
+   * This is 24 hours based on 15s blocktime.
    */
-  public static MAX_TRANSACTION_LIFESPAN = 2102400;
+  public static MAX_TRANSACTION_LIFESPAN = 5760;
 
   public static fromJson(input: TransactionJson): Transaction {
     return new Transaction({


### PR DESCRIPTION
- Update the max lifespan to 24 hrs with 15s blocks.
- Update validator recommendation to 1hr with 15s blocks.
- Update validator warning to appear only when the transaction has lifespan less than 5 mins.