### PR TITLE
feat(rpc): Update RPC methods to match preview4

### DIFF
--- a/helpers/generateContractHash.js
+++ b/helpers/generateContractHash.js
@@ -4,9 +4,9 @@ const nativeContractNames = [
   "NeoToken",
   "GasToken",
   "PolicyContract",
-  "ContractManagement",
+  "ManagementContract",
   "OracleContract",
-  "RoleManagement",
+  "DesignationContract",
 ];
 
 console.log(

--- a/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
@@ -108,6 +108,14 @@ describe("NeoServerRpcClient", () => {
     });
   });
 
+  test("getCommittee", async () => {
+    const result = await client.getCommittee();
+
+    // expect at least 1 public key
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result[0].length).toBe(66);
+  });
+
   test("getConnectionCount", async () => {
     const result = await client.getConnectionCount();
     expect(typeof result).toBe("number");
@@ -154,12 +162,12 @@ describe("NeoServerRpcClient", () => {
       expect(resultTx).toBeDefined();
     });
 
-    //TODO: Update to receive base64 string
-    test.skip("non-verbose", async () => {
+    test("non-verbose", async () => {
       const result = await client.getRawTransaction(txid);
       expect(typeof result).toBe("string");
 
-      const deserializedTx = tx.Transaction.deserialize(result);
+      const hexstring = HexString.fromBase64(result).toBigEndian();
+      const deserializedTx = tx.Transaction.deserialize(hexstring);
       expect(deserializedTx).toBeDefined();
     });
   });
@@ -214,6 +222,19 @@ describe("NeoServerRpcClient", () => {
   });
 
   describe("Invocation methods", () => {
+    // Currently there are no contracts with verify that we can make use of.
+    test.skip("invokeContractVerify", async () => {
+      const result = await client.invokeContractVerify(contractHash, []);
+
+      expect(Object.keys(result)).toHaveLength(5);
+      expect(result).toMatchObject({
+        script: expect.any(String),
+        state: "HALT",
+        gasconsumed: expect.any(String),
+        exception: null,
+        stack: expect.any(Array),
+      });
+    });
     test("invokeFunction with HALT", async () => {
       const result = await client.invokeFunction(contractHash, "symbol");
 

--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -91,6 +91,12 @@ describe("static", () => {
     });
   });
 
+  test("getCommittee", () => {
+    const result = Query.getCommittee();
+    expect(result.method).toEqual("getcommittee");
+    expect(result.params).toEqual([]);
+  });
+
   test("getConnectionCount", () => {
     const result = Query.getConnectionCount();
     expect(result.method).toEqual("getconnectioncount");
@@ -151,6 +157,29 @@ describe("static", () => {
     const result = Query.getVersion();
     expect(result.method).toEqual("getversion");
     expect(result.params).toEqual([]);
+  });
+
+  describe("invokeContractVerify", () => {
+    test("no params", () => {
+      const result = Query.invokeContractVerify("hash");
+      expect(result.method).toEqual("invokecontractverify");
+      expect(result.params).toEqual(["hash", [], []]);
+    });
+
+    test("multiple params", () => {
+      const result = Query.invokeContractVerify(
+        "hash",
+        [ContractParam.integer(1)],
+        [new Signer({ account: "ab".repeat(20), scopes: "CalledByEntry" })]
+      );
+
+      expect(result.method).toEqual("invokecontractverify");
+      expect(result.params).toEqual([
+        "hash",
+        [{ type: "Integer", value: "1" }],
+        [{ account: "0x" + "ab".repeat(20), scopes: "CalledByEntry" }],
+      ]);
+    });
   });
 
   describe("invokeFunction", () => {

--- a/packages/neon-core/src/consts.ts
+++ b/packages/neon-core/src/consts.ts
@@ -10,9 +10,9 @@ export enum NATIVE_CONTRACT_HASH {
   NeoToken = "0a46e2e37c9987f570b4af253fb77e7eef0f72b6",
   GasToken = "a6a6c15dcdc9b997dac448b6926522d22efeedfb",
   PolicyContract = "dde31084c0fdbebc7f5ed5f53a38905305ccee14",
-  ContractManagement = "081514120c7894779309255b7fb18b376cec731a",
+  ManagementContract = "cd97b70d82d69adfcd9165374109419fade8d6ab",
   OracleContract = "b1c37d5847c2ae36bdde31d0cc833a7ad9667f8f",
-  RoleManagement = "136ec44854ad9a714901eb7d714714f1791203f2",
+  DesignationContract = "c0073f4c7069bf38995780c9da065f9b3949ea7a",
 }
 
 /**


### PR DESCRIPTION
- Add getcommittee and invokecontractverify methods
- Update native contract hashes to match the ones in preview4
- Rearrange NeoServerRpcClient methods for better lookup
- Add tx field back to InvokeResult. This only appears when a wallet is open on the RPC server side.