### PR TITLE
fix(sc): Import TextEncoder correctly

### DIFF
--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -14,7 +14,6 @@ import {
 } from "./ContractParam";
 import { OpCode } from "./OpCode";
 import { InteropServiceCode } from "./InteropServiceCode";
-import { TextEncoder } from "util";
 import { ContractCall, ContractCallJson } from "./types";
 
 /**

--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -15,7 +15,7 @@ import {
 import { OpCode } from "./OpCode";
 import { InteropServiceCode } from "./InteropServiceCode";
 import { ContractCall, ContractCallJson } from "./types";
-
+import { TextEncoder as textEncoderNode10 } from "util";
 /**
  * Builds a VM script in hexstring. Used for constructing smart contract method calls.
  */
@@ -130,7 +130,10 @@ export class ScriptBuilder extends StringStream {
    * Appends a UTF-8 string.
    */
   public emitString(str: string): this {
-    const encoder = new TextEncoder();
+    const encoder =
+      typeof TextEncoder !== "undefined"
+        ? new TextEncoder()
+        : new textEncoderNode10();
     const bytes = encoder.encode(str);
     return this.emitBytes(bytes);
   }

--- a/packages/neon-core/typings/node.d.ts
+++ b/packages/neon-core/typings/node.d.ts
@@ -1,0 +1,9 @@
+import { EncodeIntoResult } from "util";
+
+declare global {
+  class TextEncoder {
+    readonly encoding: string;
+    encode(input?: string): Uint8Array;
+    encodeInto(input: string, output: Uint8Array): EncodeIntoResult;
+  }
+}


### PR DESCRIPTION
Original import was using nodejs util. Fix by adding a typing reference to global so that it will reference window.TextEncoder in browser & global.TextEncoder in node.

Simple test case:
```
var sb = new Neon.sc.ScriptBuilder();
sb.emitString("sasas");
```