### PR TITLE
fix(sc): Fix ContractParam.string emission

### DIFF
--- a/packages/neon-core/__tests__/sc/ScriptBuilder.ts
+++ b/packages/neon-core/__tests__/sc/ScriptBuilder.ts
@@ -209,6 +209,11 @@ describe("emitContractParam", () => {
       ContractParam.hash160("5461c33e9bbc7de7076754540ba9e62b255ea9fc"),
       "0c14fca95e252be6a90b54546707e77dbc9b3ec36154",
     ],
+    [
+      "ContractParam(string)",
+      ContractParam.string("hello world"),
+      "0c0b68656c6c6f20776f726c64",
+    ],
   ])("%s", (_msg: string, data: ContractParam, expected: string) => {
     const result = new ScriptBuilder().emitContractParam(data).build();
     expect(result).toBe(expected);

--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -281,7 +281,7 @@ export class ScriptBuilder extends StringStream {
           (param.value as string | HexString | null) ?? ""
         );
       case ContractParamType.String:
-        return this.emitString(str2hexstring(param.value as string));
+        return this.emitString(param.value as string);
       case ContractParamType.Boolean:
         return this.emitBoolean(param.value as boolean);
       case ContractParamType.Integer:

--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -4,7 +4,6 @@ import {
   HexString,
   int2hex,
   num2hexstring,
-  str2hexstring,
   StringStream,
 } from "../u";
 import {

--- a/packages/neon-js/src/experimental/helpers.ts
+++ b/packages/neon-js/src/experimental/helpers.ts
@@ -256,9 +256,7 @@ export async function deployContract(
     callFlags: sc.CallFlags.All,
     args: [
       sc.ContractParam.byteArray(u.HexString.fromHex(nef.serialize(), true)),
-      sc.ContractParam.byteArray(
-        u.HexString.fromAscii(JSON.stringify(manifest.toJson())).reversed()
-      ),
+      sc.ContractParam.string(JSON.stringify(manifest.toJson())),
     ],
   });
 


### PR DESCRIPTION
Fix emission of string type ContractParam. There was double encoding instead of single.