### PR TITLE
fix(typings): Fix neon-js typings

### DIFF
--- a/packages/neon-api/package.json
+++ b/packages/neon-api/package.json
@@ -39,7 +39,7 @@
     "ws": "7.4.4"
   },
   "peerDependencies": {
-    "@cityofzion/neon-core": "^4.0.0"
+    "@cityofzion/neon-core": "~5.0.0-next.7"
   },
   "files": [
     "dist/",

--- a/packages/neon-js/package.json
+++ b/packages/neon-js/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "browser": "dist/browser.js",
-  "types": "dist/index.d.ts",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf ./lib ./dist tsconfig.tsbuildinfo",

--- a/packages/neon-js/src/index.ts
+++ b/packages/neon-js/src/index.ts
@@ -4,9 +4,8 @@ import * as neonCore from "@cityofzion/neon-core";
 import defaultNetworks from "./networks";
 const neonJs = apiPlugin(neonCore);
 import * as experimental from "./experimental";
-export { experimental };
-export const { api, settings, sc, rpc, wallet, CONST, u, tx, logging } = neonJs;
 
+const { api, settings, sc, rpc, wallet, CONST, u, tx, logging } = neonJs;
 const bootstrap: {
   [net: string]: Partial<neonCore.rpc.NetworkJSON>;
 } = defaultNetworks;
@@ -124,3 +123,5 @@ export default {
   CONST,
   experimental,
 };
+
+export { experimental, api, settings, sc, rpc, wallet, CONST, u, tx, logging };

--- a/packages/neon-js/test.html
+++ b/packages/neon-js/test.html
@@ -15,11 +15,6 @@
     </div>
   </section>
   <script src="./../neon-js/dist/browser.js"></script>
-  <script src="./lib/index.js"></script>
-  <script>
-  var NeonJs =
-
-  </script>
 </body>
 
 </html>

--- a/packages/neon-ledger/package.json
+++ b/packages/neon-ledger/package.json
@@ -39,7 +39,7 @@
     "@types/ledgerhq__hw-transport": "4.21.3"
   },
   "peerDependencies": {
-    "@cityofzion/neon-core": "^4.0.0"
+    "@cityofzion/neon-core": "~5.0.0-next.7"
   },
   "files": [
     "lib/",

--- a/packages/neon-nep9/package.json
+++ b/packages/neon-nep9/package.json
@@ -32,11 +32,8 @@
     "test": "jest",
     "test:unit": "jest /packages/.*/__tests__/.*"
   },
-  "dependencies": {
-    "@cityofzion/neon-core": "^5.0.0-next.7"
-  },
   "peerDependencies": {
-    "@cityofzion/neon-core": "^4.0.0"
+    "@cityofzion/neon-core": "~5.0.0-next.7"
   },
   "files": [
     "dist/",

--- a/packages/neon-test/package.json
+++ b/packages/neon-test/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "neon-test",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "test": "node lib/index.js"
+  },
+  "dependencies": {
+    "@cityofzion/neon-js": "^5.0.0-next.7"
+  }
+}

--- a/packages/neon-test/src/index.ts
+++ b/packages/neon-test/src/index.ts
@@ -1,0 +1,16 @@
+import { api, rpc } from "@cityofzion/neon-js";
+
+const RPC_URL = "http://seed1t.neo.org:20332";
+
+const rpcClient = new rpc.RPCClient(RPC_URL);
+console.log("Neo Weather Report");
+
+rpcClient
+  .getBlockCount()
+  .then((currentHeight) => console.log(`Blockchain height: ${currentHeight}`))
+  .then(() => api.getFeeInformation(rpcClient))
+  .then((feeInfo) =>
+    console.log(
+      `Current fees: ${feeInfo.feePerByte} per byte, ${feeInfo.executionFeeFactor} multipler`
+    )
+  );

--- a/packages/neon-test/tsconfig.json
+++ b/packages/neon-test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "module": "es6"
+  },
+  "references": [{ "path": "../neon-core" }],
+  "include": ["src/**/*"]
+}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "commonjs",
     "lib": ["es2018"],
     "moduleResolution": "node",
     "composite": true,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const webpack = require("webpack");
 
 let env = process.env.NODE_ENV || "development";
 
@@ -26,7 +25,6 @@ module.exports = function (rootDir) {
           options: {
             projectReferences: true,
             compilerOptions: {
-              declarationDir: path.resolve(rootDir, "dist"),
               sourceMap: env === "development",
               module: "commonjs",
             },


### PR DESCRIPTION
Fix neon-js typings being incorrect. Webpack was producing incorrect typings.

- Disable type emission from webpack. Use tsc typings directly instead.
- Emit es6 modules in lib/ and allow webpack to do the conversion to commonjs.
- Add neon-test package as a playground for manual testing.
- Also fix peer dependencies being incorrect.