### PR TITLE
fix(typings): Remove skipLibCheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.34",
+    "@types/tapable": "0.2.5",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "clean-webpack-plugin": "3.0.0",

--- a/packages/neon-core/package.json
+++ b/packages/neon-core/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "abort-controller": "3.0.0",
+    "bignumber.js": "7.2.1",
     "bn.js": "5.2.0",
     "bs58": "4.0.1",
     "buffer": "6.0.3",

--- a/packages/neon-core/typings/node.d.ts
+++ b/packages/neon-core/typings/node.d.ts
@@ -1,9 +1,0 @@
-import { EncodeIntoResult } from "util";
-
-declare global {
-  class TextEncoder {
-    readonly encoding: string;
-    encode(input?: string): Uint8Array;
-    encodeInto(input: string, output: Uint8Array): EncodeIntoResult;
-  }
-}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -10,7 +10,6 @@
     "esModuleInterop": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,6 +1763,11 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
 
+"@types/tapable@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-0.2.5.tgz#2443fc12da514c81346b1a665675559cee21fa75"
+  integrity sha512-dEoVvo/I9QFomyhY+4Q6Qk+I+dhG59TYceZgC6Q0mCifVPErx6Y83PNTKGDS5e9h9Eti6q0S2mm16BU6iQK+3w==
+
 "@types/uglify-js@*":
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.11.1.tgz#97ff30e61a0aa6876c270b5f538737e2d6ab8ceb"


### PR DESCRIPTION
Remove skipLibCheck from base tsconfig. This enforces lib checks for all files.

- Re-add bignumber.js as dependency (deprecated but not removed at the moment)
- Add @tapable workaround for webpack typings
- Remove old @types/nodes workaround for TextEncoder