### PR TITLE
chore: Skip node builtins during debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
       "program": "${workspaceRoot}/node_modules/jest/bin/jest",
       "args": ["--verbose", "-i", "--no-cache"],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": ["<node_internals>/**/*.js"]
     },
     {
       "type": "node",
@@ -20,7 +21,8 @@
       "program": "${workspaceRoot}/node_modules/jest/bin/jest",
       "args": ["${fileBasename}", "--verbose", "-i", "--watchAll"],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": ["<node_internals>/**/*.js"]
     }
   ]
 }


### PR DESCRIPTION
Makes vscode debugging easier by not jumping into promise implementations.