### PR TITLE
Fix(rc2): Remove duplicate DesignationContract

### DIFF
--- a/packages/neon-core/src/consts.ts
+++ b/packages/neon-core/src/consts.ts
@@ -12,7 +12,6 @@ export enum NATIVE_CONTRACT_HASH {
   PolicyContract = "cc5e4edd9f5f8dba8bb65734541df7a1c081c67b",
   ManagementContract = "fffdc93764dbaddd97c48f252a53ea4643faa3fd",
   OracleContract = "fe924b7cfe89ddd271abaf7210a80a7e11178758",
-  DesignationContract = "49cf4e5378ffcd4dec034fd98a174c5491e395e2", // renamed to RoleManagement
   LedgerContract = "da65b600f7124ce6c79950c1772a36403104f2be",
   RoleManagement = "49cf4e5378ffcd4dec034fd98a174c5491e395e2",
   NameService = "7a8fcf0392cd625647907afa8e45cc66872b596b",


### PR DESCRIPTION
Close item `2` of  https://github.com/CityOfZion/neon-js/issues/691

`DesignationContract` was renamed to `RoleManagement` but I just realised that the latter already existed, so just removing the former.