### PR TITLE
chore(ci): Refactor workflows to be branchbased

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,27 @@
 version: 2.1
 
 executors:
-  env-node12:
+  env_node:
+    parameters:
+      version: &parameter-version
+        description: "Node version"
+        type: enum
+        enum: ["12-stretch", "14-stretch"]
+        default: "12-stretch"
     working_directory: ~/repo
     docker:
-      - image: circleci/node:12-stretch
+      - image: circleci/node:<< parameters.version >>
 
-  env-node14:
+  env_node_integration:
+    parameters:
+      version:
+        description: "Node version"
+        type: enum
+        enum: ["12-stretch", "14-stretch"]
+        default: "12-stretch"
     working_directory: ~/repo
     docker:
-      - image: circleci/node:14-stretch
-
-  env-integration12:
-    working_directory: ~/repo
-    docker:
-      - image: circleci/node:12-stretch
-      - image: snowypowers/neo-privatenet:v3.0.0-rc2
-
-  env-integration14:
-    working_directory: ~/repo
-    docker:
-      - image: circleci/node:14-stretch
-      - image: snowypowers/neo-privatenet:v3.0.0-rc2
+      - image: circleci/node:<< parameters.version >>
 
 commands:
   run-unittest:
@@ -69,7 +69,7 @@ commands:
 
 jobs:
   setup:
-    executor: env-node12
+    executor: env_node
     steps:
       - run:
           name: "Versions"
@@ -106,7 +106,7 @@ jobs:
             - packages
 
   lint:
-    executor: env-node12
+    executor: env_node
     steps:
       - checkout
       - attach_workspace:
@@ -135,22 +135,24 @@ jobs:
 
   unittest:
     parameters:
-      env:
-        type: executor
-    executor: << parameters.env >>
+      version: *parameter-version
+    executor:
+      name: env_node
+      version: << parameters.version >>
     steps:
       - run-unittest
 
   integrationtest:
     parameters:
-      env:
-        type: executor
-    executor: << parameters.env >>
+      version: *parameter-version
+    executor:
+      name: env_node_integration
+      version: << parameters.version >>
     steps:
       - run-integrationtest
 
   publish-latest:
-    executor: env-node12
+    executor: env_node
     steps:
       - checkout
       - attach_workspace:
@@ -163,7 +165,7 @@ jobs:
           command: yarn release:latest --yes
 
   publish-next:
-    executor: env-node12
+    executor: env_node
     steps:
       - checkout
       - attach_workspace:
@@ -176,7 +178,7 @@ jobs:
           command: yarn release:next --yes
 
   publish-docs:
-    executor: env-node12
+    executor: env_node
     steps:
       - checkout
       - run:
@@ -207,20 +209,20 @@ workflows:
           requires:
             - setup
       - unittest:
-          name: unittest-<< matrix.env >>
+          name: unittest-<< matrix.version >>
           matrix:
             parameters:
-              env: ["env-node12", "env-node14"]
+              version: ["12-stretch", "14-stretch"]
           requires:
             - setup
       - integrationtest:
-          name: integrationtest-<< matrix.env >>
+          name: integrationtest-<< matrix.version >>
           matrix:
             parameters:
-              env: ["env-node12", "env-node14"]
+              version: ["12-stretch", "14-stretch"]
           requires:
             - lint
-            - unittest-<< matrix.env >>
+            - unittest-<< matrix.version >>
 
   # Workflow that runs on the stable branches
   main_flow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,8 @@ workflows:
           matrix:
             parameters:
               env: ["env-node12", "env-node14"]
+          requires:
+            - setup
       - integrationtest:
           name: integrationtest-<< matrix.env >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ executors:
     working_directory: ~/repo
     docker:
       - image: circleci/node:<< parameters.version >>
+      - image: snowypowers/neo-privatenet:v3.0.0-rc2
 
 commands:
   run-unittest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
           name: Lint
           command: |
             CURRENT_BRANCH=$(git symbolic-ref -q --short HEAD)
-            BASE_BRANCH=$(node helpers/getBaseBranch.js $CIRCLE_PULL_REQUEST)
+            BASE_BRANCH=$(curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.ref')
             git checkout --track origin/$BASE_BRANCH
             git checkout $CURRENT_BRANCH
             echo "Finding files to lint"
@@ -133,23 +133,19 @@ jobs:
       - store_artifacts:
           path: reports
 
-  unittest-node12:
-    executor: env-node12
+  unittest:
+    parameters:
+      env:
+        type: executor
+    executor: << parameters.env >>
     steps:
       - run-unittest
 
-  unittest-node14:
-    executor: env-node14
-    steps:
-      - run-unittest
-
-  integrationtest-node12:
-    executor: env-integration12
-    steps:
-      - run-integrationtest
-
-  integrationtest-node14:
-    executor: env-integration14
+  integrationtest:
+    parameters:
+      env:
+        type: executor
+    executor: << parameters.env >>
     steps:
       - run-integrationtest
 
@@ -196,43 +192,51 @@ jobs:
             yarn install
             yarn run release
 
+# Branch based workflows
 workflows:
   version: 2
-  build_and_test:
+
+  # Workflow that runs on all pull requests.
+  pull_request:
     jobs:
       - setup:
-          filters:
+          filters: &filters-pull-request
             branches:
-              ignore: gh-pages
               only: /pull\/.*/
-            tags:
-              ignore: /.*/
       - lint:
           requires:
             - setup
-      - unittest-node12:
-          requires:
-            - setup
-      - unittest-node14:
-          requires:
-            - setup
-      - integrationtest-node12:
+      - unittest:
+          name: unittest-<< matrix.env >>
+          matrix:
+            parameters:
+              env: ["env-node12", "env-node14"]
+      - integrationtest:
+          name: integrationtest-<< matrix.env >>
+          matrix:
+            parameters:
+              env: ["env-node12", "env-node14"]
           requires:
             - lint
-            - unittest-node12
-      - integrationtest-node14:
-          requires:
-            - lint
-            - unittest-node14
+            - unittest-<< matrix.env >>
 
-  publish:
+  # Workflow that runs on the stable branches
+  main_flow:
     jobs:
       - setup:
           filters:
             branches:
-              ignore: /.*/
+              only:
+                - master
+                - next
+      - publish-latest:
+          requires:
+            - setup
+          filters:
+            branches:
+              only: master
             tags:
-              only: /v[0-9]+\.[0-9]+\.[0-9]+-next.*/
+              only: /v[0-9]+\.[0-9]+\.[0-9]+/
       - publish-next:
           requires:
             - setup


### PR DESCRIPTION
Refactor workflows to be branch based. This makes it easier to visualise what is happening.

- Renamed workflow build_and_test to pull_request. This will now run on every pull branch.
- Renamed workflow publish to main_flow. This will run on every commit on master/next branch. The publish steps are triggered only when a version tag accompanies the commit.
- Refactor executors to be parameterized to make it easier to transit between node versions.