### PR TITLE
fix(wallet): Rename account.isdefault to isDefault

### DIFF
--- a/packages/neon-core/__tests__/testWallet1.json
+++ b/packages/neon-core/__tests__/testWallet1.json
@@ -6,7 +6,7 @@
     {
       "address": "NMPAXGtMfZ8s8rcfP9JhrYrNeZHG4xSVmd",
       "label": null,
-      "isdefault": false,
+      "isDefault": false,
       "lock": false,
       "key": "6PYWdzMKGbfxHbfb2JqZJ5Yr1y6jjjuSPLjvgS4byvDkgz2NdiBgeJwBFc",
       "contract": {

--- a/packages/neon-core/__tests__/testWallet2.json
+++ b/packages/neon-core/__tests__/testWallet2.json
@@ -6,7 +6,7 @@
     {
       "address": "NRC6oteucWYXq7aASD6YWe5rNeXAw1ehye",
       "label": null,
-      "isdefault": false,
+      "isDefault": false,
       "lock": false,
       "key": "6PYLxXgqDZS1q1GJLQfmGchFndAoxuEtKJTxpYkZtcoty5PDtBvaTAS8qa",
       "contract": {

--- a/packages/neon-core/__tests__/testWallet3.json
+++ b/packages/neon-core/__tests__/testWallet3.json
@@ -6,7 +6,7 @@
     {
       "address": "NTFAwXLGoiWwSMP5vJyZp8K4cBFwrzUs8m",
       "label": null,
-      "isdefault": false,
+      "isDefault": false,
       "lock": false,
       "key": "6PYRoabFnWARA3ZWwfJ4efQ4uuuB9WdVrA1LFbMkZLtXZ2DJg3bzjiK59s",
       "contract": {

--- a/packages/neon-core/__tests__/wallet/Account.ts
+++ b/packages/neon-core/__tests__/wallet/Account.ts
@@ -38,7 +38,7 @@ describe("constructor", () => {
     const testObject = {
       address: "NMBfzaEq2c5zodiNbLPoohVENARMbJim1r",
       label: "addressB",
-      isdefault: false,
+      isDefault: false,
       lock: false,
       key: "6PYKWKaq5Wd6vEH3f56ELyqWVPNsSaF6wftEqV2z53iuLGJUfyXnmWv3uf",
       contract: {
@@ -60,7 +60,7 @@ describe("export", () => {
     const testObject = {
       address: "NiwvMyWYeNghLG8tDyKkWwuZV3wS8CPrrV",
       label: "addressB",
-      isdefault: false,
+      isDefault: false,
       lock: false,
       key: "6PYKWKaq5Wd6vEH3f56ELyqWVPNsSaF6wftEqV2z53iuLGJUfyXnmWv3uf",
       contract: {

--- a/packages/neon-core/src/wallet/Account.ts
+++ b/packages/neon-core/src/wallet/Account.ts
@@ -21,7 +21,7 @@ export interface AccountJSON {
   /** Base58 encoded string */
   address: string;
   label: string;
-  isdefault: boolean;
+  isDefault: boolean;
   lock: boolean;
   /** NEP2 encoded string */
   key: string;
@@ -113,7 +113,7 @@ export class Account implements NeonObject<AccountJSON> {
       this._encrypted = str.key;
       this._address = str.address;
       this.label = str.label ?? "";
-      this.isDefault = str.isdefault ?? false;
+      this.isDefault = str.isDefault ?? false;
       this.lock = str.lock ?? false;
       this.contract =
         str.contract ?? Object.assign({}, DEFAULT_ACCOUNT_CONTRACT);
@@ -337,7 +337,7 @@ export class Account implements NeonObject<AccountJSON> {
     return {
       address: this.address,
       label: this.label,
-      isdefault: this.isDefault,
+      isDefault: this.isDefault,
       lock: this.lock,
       key,
       contract: this.contract,

--- a/packages/neon-core/src/wallet/Wallet.ts
+++ b/packages/neon-core/src/wallet/Wallet.ts
@@ -41,7 +41,7 @@ export class Wallet {
 
   /**
    * Returns the default Account according to the following rules:
-   * 1. First Account where isdefault is true.
+   * 1. First Account where isDefault is true.
    * 2. First Account with a decrypted private key.
    * 3. First Account with an encrypted private key.
    * 4. First Account in the array.


### PR DESCRIPTION
Close https://github.com/CityOfZion/neon-js/issues/736
The property was initially renamed to `isdefault` by https://github.com/neo-project/neo/pull/1736 now renamed back to `isDefault` by https://github.com/neo-project/neo/pull/2451