### PR TITLE
docs: Use baseUrl to contruct relative link

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,7 +1,10 @@
 import Layout from "@theme/Layout";
 import React from "react";
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 export default () => {
+  const {siteConfig} = useDocusaurusContext();
+  const {baseUrl} = siteConfig;
   return (
     <Layout title="NeonJS">
       <div class="hero hero--primary">
@@ -11,7 +14,7 @@ export default () => {
           <div>
             <a
               class="button button--secondary button--outline button--lg"
-              href="./docs"
+              href={baseUrl + "docs/"}
             >
               Get Started
             </a>


### PR DESCRIPTION
COZ redirects the frontpage to `dojo.coz.io/neo3/neon-js`. Docusaurus expects the page to be `/neo3/neon-js/`. As such, the relative link `./docs` produces the url `dojo.coz.io/neo3/docs` (Expected link is `dojo.coz.io/neo3/neon-js/docs/`.

Instead of using raw relative links, I have updated the code to import the baseUrl from config and produce a relative link from the domain.

Fix #737