### PR TITLE
fix(u): rely on crypto-js for random bytes

### DIFF
--- a/packages/neon-core/__tests__/u/random.ts
+++ b/packages/neon-core/__tests__/u/random.ts
@@ -1,0 +1,21 @@
+import { generateRandomArray } from "../../src/u/basic/random";
+
+it("returns empty array when 0", () => {
+  const result = generateRandomArray(0);
+  expect(result.length).toBe(0);
+});
+
+it("returns correct length of bytes", () => {
+  const result = generateRandomArray(10);
+
+  expect(result.length).toBe(10);
+});
+
+it("returns numbers within 0-255", () => {
+  const randomNumbers = generateRandomArray(100);
+
+  randomNumbers.forEach((n) => {
+    expect(n).toBeLessThanOrEqual(255);
+    expect(n).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/neon-core/package.json
+++ b/packages/neon-core/package.json
@@ -48,8 +48,7 @@
     "elliptic": "6.5.4",
     "loglevel": "1.7.1",
     "loglevel-plugin-prefix": "0.8.4",
-    "scrypt-js": "3.0.1",
-    "secure-random": "1.1.2"
+    "scrypt-js": "3.0.1"
   },
   "devDependencies": {
     "@types/bn.js": "5.1.0",

--- a/packages/neon-core/src/u/basic/random.ts
+++ b/packages/neon-core/src/u/basic/random.ts
@@ -1,9 +1,16 @@
-import secureRandom from "secure-random";
-
+import { lib } from "crypto-js";
 /**
- * Generates a arrayBuffer filled with random bits.
+ * Generates a arrayBuffer filled with random bytes.
  * @param length - length of buffer.
  */
 export const generateRandomArray = (length: number): number[] => {
-  return secureRandom(length) as number[];
+  // Round up to nearest multiple of 4 so that the words generated is more than what we need.
+  const numberOfWords = length % 4 === 0 ? length : length + (length % 4);
+
+  // This converts the generated words into a hexstring.
+  const wordArray = lib.WordArray.random(numberOfWords).toString();
+
+  // Chunk the hexstring into chunks of 2 which represents 1 byte each
+  const hexStrings = wordArray.substr(0, length * 2).match(/.{1,2}/g) || [];
+  return hexStrings.map((hexstr) => parseInt(hexstr, 16));
 };

--- a/packages/neon-core/typings/secure-random.d.ts
+++ b/packages/neon-core/typings/secure-random.d.ts
@@ -1,6 +1,0 @@
-declare module "secure-random" {
-  export default function (
-    byteCount: number,
-    options?: { type: "Array" | "Uint8Array" | "Buffer" }
-  ): number[] | Uint8Array | Buffer;
-}


### PR DESCRIPTION
Instead of `secure-random` package, rely on purely `crypto-js` to generate random bytes. Underneath the hood, both attempts to use the native crypto package in browser/node so it should work the same, the only difference being the code that checks the environment to retrieve the correct dependency. 

Possibly fix #752 