### PR TITLE
fix(sc): Fix ContractPermissions toJson dropping 0x

### DIFF
--- a/packages/neon-core/__tests__/sc/manifest/ContractManifest.ts
+++ b/packages/neon-core/__tests__/sc/manifest/ContractManifest.ts
@@ -1,5 +1,6 @@
 import {
   ContractManifest,
+  ContractManifestJson,
   ContractManifestLike,
   ContractParamType,
   ContractPermissionJson,
@@ -266,5 +267,55 @@ describe("fromJson", () => {
 
     const manifest = ContractManifest.fromJson(neoManifestJson);
     expect(manifest.toJson()).toStrictEqual(neoManifestJson);
+  });
+
+  test("custom permissions", () => {
+    const manifestWithPermissionsJson: ContractManifestJson = {
+      name: "custom_permissions",
+      supportedstandards: [],
+      abi: {
+        events: [],
+        methods: [
+          {
+            name: "method1",
+            offset: 0,
+            parameters: [
+              {
+                name: "param1",
+                type: "ByteArray",
+              },
+              {
+                name: "param2",
+                type: "String",
+              },
+            ],
+            returntype: "Boolean",
+            safe: false,
+          },
+        ],
+      },
+      groups: [],
+      features: {},
+      permissions: [
+        {
+          contract: "0xabcd000000000000000000000000000000000000",
+          methods: ["method1"],
+        },
+        {
+          contract:
+            "021234567890000000000000000000000000000000000000000000000000000000",
+          methods: ["method1"],
+        },
+      ],
+      trusts: [
+        "0x1234000000000000000000000000000000000000",
+        "02abcdef1230000000000000000000000000000000000000000000000000000000",
+      ],
+      extra: undefined,
+    };
+
+    const manifest = ContractManifest.fromJson(manifestWithPermissionsJson);
+
+    expect(manifest.toJson()).toStrictEqual(manifestWithPermissionsJson);
   });
 });

--- a/packages/neon-core/src/sc/manifest/ContractManifest.ts
+++ b/packages/neon-core/src/sc/manifest/ContractManifest.ts
@@ -78,7 +78,9 @@ export class ContractManifest {
     this.permissions = permissions.map(
       (permission) => new ContractPermission(permission)
     );
-    this.trusts = trusts;
+    this.trusts = Array.isArray(trusts)
+      ? trusts.map((t) => ContractPermission.parseJsonDescriptor(t))
+      : trusts;
     this.extra = extra;
   }
 
@@ -90,7 +92,9 @@ export class ContractManifest {
       supportedstandards: this.supportedStandards,
       abi: this.abi.toJson(),
       permissions: this.permissions.map((p) => p.toJson()),
-      trusts: this.trusts,
+      trusts: Array.isArray(this.trusts)
+        ? this.trusts.map((t) => ContractPermission.toJsonDescriptor(t))
+        : this.trusts,
       extra: this.extra,
     };
   }

--- a/packages/neon-core/src/sc/manifest/ContractPermission.ts
+++ b/packages/neon-core/src/sc/manifest/ContractPermission.ts
@@ -4,21 +4,56 @@ export interface ContractPermissionLike {
 }
 
 export interface ContractPermissionJson {
+  /**
+   * 0x-prefixed contract hash (42 characters), public key (66 characters) or '*'.
+   */
   contract: string;
   methods: "*" | string[];
 }
 
 export class ContractPermission {
+  /**
+   * Contract hash (40 characters), public key (66 characters) or '*'
+   */
   public contract: string;
   public methods: "*" | string[];
 
+  /**
+   *  Parses a ContractPermissionDescriptor.
+   * @param jsonDescriptor - descriptor found in JSON format.
+   * @returns a sanitized string
+   */
+  public static parseJsonDescriptor(jsonDescriptor: string): string {
+    switch (true) {
+      case jsonDescriptor.length === 66: // public key of contract manifest group
+      case jsonDescriptor.length === 40: // contract scripthash
+      case jsonDescriptor === "*": // wildcard, means it accept any contract
+        return jsonDescriptor;
+      case jsonDescriptor.length === 42 && jsonDescriptor.indexOf("0x") === 0: // contract with "0x" prefix
+        return jsonDescriptor.slice(2);
+      default:
+        throw new Error(
+          `This is not a ContractPermissionDescriptor: ${jsonDescriptor}`
+        );
+    }
+  }
+
+  /**
+   * Converts an internal ContractPermissionDescriptor to JSON format.
+   * @param descriptor - internal ContractPermissionDescriptor string
+   * @returns JSON formatted string
+   */
+  public static toJsonDescriptor(descriptor: string): string {
+    if (descriptor.length === 40) return `0x${descriptor}`;
+    return descriptor;
+  }
   public fromJson(json: ContractPermissionJson): ContractPermission {
     return new ContractPermission(json);
   }
 
   public constructor(obj: Partial<ContractPermissionLike> = {}) {
     const { contract = "*", methods = "*" } = obj;
-    this.contract = this._formatContract(contract);
+    this.contract = ContractPermission.parseJsonDescriptor(contract);
     this.methods = methods;
   }
 
@@ -34,24 +69,9 @@ export class ContractPermission {
     return this.contract === "*";
   }
 
-  private _formatContract(contract: string): string {
-    switch (true) {
-      case contract.length === 66: // public key of contract manifest group
-      case contract.length === 40: // contract scripthash
-      case contract === "*": // wildcard, means it accept any contract
-        return contract;
-      case contract.length === 42 && contract.indexOf("0x") === 0: // contract with "0x" prefix
-        return contract.slice(2);
-      default:
-        throw new Error(
-          `This is not a ContractPermissionDescriptor: ${contract}`
-        );
-    }
-  }
-
   public toJson(): ContractPermissionJson {
     return {
-      contract: this.contract,
+      contract: ContractPermission.toJsonDescriptor(this.contract),
       methods: this.methods,
     };
   }


### PR DESCRIPTION
ContractPermissionDescriptor uses the UIint classes which maintains the 0x prefix when exporting to JSON. It is possible for the C# code to perform a safe parse using TryParse but currently, it uses a string length check to determine the data type. Thus, a non-prefixed string  fails the length check and errors out. This fixes the export to JSON to maintain the prefix for contract hashes.

Fix #756