### PR TITLE
test: Update integration container to rc3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     working_directory: ~/repo
     docker:
       - image: circleci/node:<< parameters.version >>
-      - image: snowypowers/neo-privatenet:v3.0.0-rc2
+      - image: snowypowers/neo-privatenet:v3.0.0-rc3
 
 commands:
   run-unittest:

--- a/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
@@ -229,7 +229,6 @@ describe("NeoServerRpcClient", () => {
     test.skip("invokeContractVerify", async () => {
       const result = await client.invokeContractVerify(contractHash, []);
 
-      expect(Object.keys(result)).toHaveLength(5);
       expect(result).toMatchObject({
         script: expect.any(String),
         state: "HALT",
@@ -241,7 +240,6 @@ describe("NeoServerRpcClient", () => {
     test("invokeFunction with HALT", async () => {
       const result = await client.invokeFunction(contractHash, "symbol");
 
-      expect(Object.keys(result)).toHaveLength(5);
       expect(result).toMatchObject({
         script: expect.any(String),
         state: "HALT",
@@ -254,7 +252,6 @@ describe("NeoServerRpcClient", () => {
     test("invokeFunction with FAULT", async () => {
       const result = await client.invokeFunction(contractHash, "fail");
 
-      expect(Object.keys(result)).toHaveLength(5);
       expect(result).toMatchObject({
         script: expect.any(String),
         state: "FAULT",
@@ -284,7 +281,6 @@ describe("NeoServerRpcClient", () => {
         ]
       );
 
-      expect(Object.keys(result)).toHaveLength(5);
       expect(result).toMatchObject({
         script: expect.any(String),
         state: "HALT",
@@ -301,7 +297,6 @@ describe("NeoServerRpcClient", () => {
         )
       );
 
-      expect(Object.keys(result)).toHaveLength(5);
       expect(result).toMatchObject({
         script: expect.any(String),
         state: "HALT",
@@ -338,7 +333,6 @@ describe("NeoServerRpcClient", () => {
         }),
       ]);
 
-      expect(Object.keys(result)).toHaveLength(5);
       expect(result).toMatchObject({
         script: expect.any(String),
         state: "HALT",


### PR DESCRIPTION
Updates integration test container to use rc3 container. Also removes assertion of object sizes as invokes can return up to 6 fields (tx field is populated when wallet is open on the node).