### PR TITLE
feat(core): Breakout address version

### DIFF
--- a/common/api/neon-core.api.json
+++ b/common/api/neon-core.api.json
@@ -180,7 +180,7 @@
             {
               "kind": "Variable",
               "canonicalReference": "@cityofzion/neon-core!CONST.ADDR_VERSION:var",
-              "docComment": "",
+              "docComment": "/**\n * @deprecated\n *\n * If you are looking for the default MainNet address version for N3, please use DEFAULT_ADDRESS_VERSION.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -234,6 +234,23 @@
               "variableTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
+              }
+            },
+            {
+              "kind": "Variable",
+              "canonicalReference": "@cityofzion/neon-core!CONST.DEFAULT_ADDRESS_VERSION:var",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DEFAULT_ADDRESS_VERSION = 53"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DEFAULT_ADDRESS_VERSION",
+              "variableTypeTokenRange": {
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
@@ -32771,6 +32788,14 @@
                     },
                     {
                       "kind": "Content",
+                      "text": ", config?: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "{\n        addressVersion: number;\n    }"
+                    },
+                    {
+                      "kind": "Content",
                       "text": ");"
                     }
                   ],
@@ -32782,6 +32807,13 @@
                       "parameterTypeTokenRange": {
                         "startIndex": 1,
                         "endIndex": 6
+                      }
+                    },
+                    {
+                      "parameterName": "config",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 7,
+                        "endIndex": 8
                       }
                     }
                   ]
@@ -32807,6 +32839,33 @@
                   "isOptional": false,
                   "releaseTag": "Public",
                   "name": "address",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isStatic": false
+                },
+                {
+                  "kind": "Property",
+                  "canonicalReference": "@cityofzion/neon-core!wallet.Account#addressVersion:member",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "addressVersion: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "number"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "releaseTag": "Public",
+                  "name": "addressVersion",
                   "propertyTypeTokenRange": {
                     "startIndex": 1,
                     "endIndex": 2
@@ -33738,6 +33797,14 @@
                 },
                 {
                   "kind": "Content",
+                  "text": ", addressVersion?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
                   "text": "): "
                 },
                 {
@@ -33755,8 +33822,8 @@
                 }
               ],
               "returnTypeTokenRange": {
-                "startIndex": 7,
-                "endIndex": 9
+                "startIndex": 9,
+                "endIndex": 11
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
@@ -33780,6 +33847,13 @@
                   "parameterTypeTokenRange": {
                     "startIndex": 5,
                     "endIndex": 6
+                  }
+                },
+                {
+                  "parameterName": "addressVersion",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 8
                   }
                 }
               ],
@@ -33896,6 +33970,14 @@
                 },
                 {
                   "kind": "Content",
+                  "text": ", addressVersion?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
                   "text": "): "
                 },
                 {
@@ -33913,8 +33995,8 @@
                 }
               ],
               "returnTypeTokenRange": {
-                "startIndex": 7,
-                "endIndex": 9
+                "startIndex": 9,
+                "endIndex": 11
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
@@ -33938,6 +34020,13 @@
                   "parameterTypeTokenRange": {
                     "startIndex": 5,
                     "endIndex": 6
+                  }
+                },
+                {
+                  "parameterName": "addressVersion",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 8
                   }
                 }
               ],
@@ -34043,11 +34132,69 @@
                 },
                 {
                   "kind": "Content",
+                  "text": ", addressVersion?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
                   "text": "): "
                 },
                 {
                   "kind": "Content",
                   "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "scriptHash",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                },
+                {
+                  "parameterName": "addressVersion",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  }
+                }
+              ],
+              "name": "getAddressFromScriptHash"
+            },
+            {
+              "kind": "Function",
+              "canonicalReference": "@cityofzion/neon-core!wallet.getAddressVersion:function(1)",
+              "docComment": "/**\n * Extracts the address version from a given correct NEO address.\n *\n * @param address - A NEO address string.\n *\n * @returns Address version\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "export declare function getAddressVersion(address: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
                 },
                 {
                   "kind": "Content",
@@ -34062,14 +34209,14 @@
               "overloadIndex": 1,
               "parameters": [
                 {
-                  "parameterName": "scriptHash",
+                  "parameterName": "address",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
                     "endIndex": 2
                   }
                 }
               ],
-              "name": "getAddressFromScriptHash"
+              "name": "getAddressVersion"
             },
             {
               "kind": "Function",

--- a/common/api/neon-core.api.md
+++ b/common/api/neon-core.api.md
@@ -22,8 +22,12 @@ function ab2str(buf: ArrayBuffer | ArrayLike<number>): string;
 class Account implements NeonObject<AccountJSON> {
     // (undocumented)
     get [Symbol.toStringTag](): string;
-    constructor(str?: string | Partial<AccountJSON>);
+    constructor(str?: string | Partial<AccountJSON>, config?: {
+        addressVersion: number;
+    });
     get address(): string;
+    // (undocumented)
+    addressVersion: number;
     // (undocumented)
     contract: {
         script: string;
@@ -79,7 +83,7 @@ interface AccountJSON {
     lock: boolean;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 const ADDR_VERSION = "35";
 
 // @public (undocumented)
@@ -206,6 +210,7 @@ interface CliPlugin {
 declare namespace CONST {
     export {
         ADDR_VERSION,
+        DEFAULT_ADDRESS_VERSION,
         MAGIC_NUMBER,
         NATIVE_CONTRACT_HASH,
         ASSET_ID,
@@ -578,7 +583,7 @@ interface ContractPermissionLike {
 function createScript(...scripts: (ContractCall | ContractCallJson | string)[]): string;
 
 // @public
-function decrypt(encryptedKey: string, keyphrase: string, scryptParams?: ScryptParams): Promise<string>;
+function decrypt(encryptedKey: string, keyphrase: string, scryptParams?: ScryptParams, addressVersion?: number): Promise<string>;
 
 // @public (undocumented)
 function decryptNeo2(encryptedKey: string, keyphrase: string, scryptParams?: ScryptParams): Promise<string>;
@@ -595,6 +600,9 @@ const DEFAULT_ACCOUNT_CONTRACT: {
     }[];
     deployed: boolean;
 };
+
+// @public (undocumented)
+const DEFAULT_ADDRESS_VERSION = 53;
 
 // @public (undocumented)
 const DEFAULT_REQ: {
@@ -662,7 +670,7 @@ enum EllipticCurvePreset {
 }
 
 // @public
-function encrypt(wifKey: string, keyphrase: string, scryptParams?: ScryptParams): Promise<string>;
+function encrypt(wifKey: string, keyphrase: string, scryptParams?: ScryptParams, addressVersion?: number): Promise<string>;
 
 // @public
 function ensureHex(str: string): void;
@@ -744,7 +752,10 @@ const generateRandomArray: (length: number) => number[];
 function generateSignature(tx: string, privateKey: string): string;
 
 // @public
-function getAddressFromScriptHash(scriptHash: string): string;
+function getAddressFromScriptHash(scriptHash: string, addressVersion?: number): string;
+
+// @public
+function getAddressVersion(address: string): number;
 
 // @public (undocumented)
 interface GetContractStateResult {
@@ -2817,6 +2828,7 @@ declare namespace wallet {
         getAddressFromScriptHash,
         getScriptHashFromAddress,
         generatePrivateKey,
+        getAddressVersion,
         encrypt,
         decrypt,
         decryptNeo2,

--- a/packages/neon-api/src/transaction/signing.ts
+++ b/packages/neon-api/src/transaction/signing.ts
@@ -11,9 +11,10 @@ export function signWithAccount(acct: wallet.Account): SigningFunction {
       wallet.getScriptHashFromVerificationScript(verificationScript);
     if (scriptHash !== acct.scriptHash) {
       throw new Error(
-        `Request for ${wallet.getAddressFromScriptHash(
-          scriptHash
-        )} signature but only have ${acct.address}.`
+        `Requested signature from ${wallet.getAddressFromScriptHash(
+          scriptHash,
+          acct.addressVersion
+        )} but only have key of ${acct.address}.`
       );
     }
     return wallet.sign(txData, acct.privateKey);

--- a/packages/neon-core/__tests__/tx/transaction/Transaction.ts
+++ b/packages/neon-core/__tests__/tx/transaction/Transaction.ts
@@ -277,7 +277,7 @@ describe.each(dataSet)(
 
     test("toJson", () => {
       const result = deserialized.toJson();
-      expect(result).toEqual(json);
+      expect(result).toEqual(Object.assign({}, json, { sender: "" }));
     });
 
     test("serialize", () => {

--- a/packages/neon-core/__tests__/wallet/Account.ts
+++ b/packages/neon-core/__tests__/wallet/Account.ts
@@ -26,6 +26,14 @@ describe("constructor", () => {
     expect(result.address).toBe("NMBfzaEq2c5zodiNbLPoohVENARMbJim1r");
   });
 
+  test("custom address version", () => {
+    const result = new Account(
+      "L2QTooFoDFyRFTxmtiVHt5CfsXfVnexdbENGDkkrrgTTryiLsPMG",
+      { addressVersion: 77 }
+    );
+
+    expect(result.address).toBe("Y1J9dBPk4wD2S34TBQPTSi27UGbzezrfdf");
+  });
   test("empty", () => {
     const result = new Account();
 

--- a/packages/neon-core/__tests__/wallet/core.ts
+++ b/packages/neon-core/__tests__/wallet/core.ts
@@ -104,3 +104,27 @@ describe("Public key", () => {
     );
   });
 });
+
+describe("getAddressFromScriptHash", () => {
+  test("custom address version", () => {
+    const result = C.getAddressFromScriptHash(
+      "118ba6f59931a56ec469770f7fc790ece96df00d",
+      77
+    );
+
+    expect(result).toBe("Y1J9dBPk4wD2S34TBQPTSi27UGbzezrfdf");
+  });
+});
+describe("getAddressVersion", () => {
+  test("Neo3", () => {
+    const result = C.getAddressVersion("NPTmAHDxo6Pkyic8Nvu3kwyXoYJCvcCB6i");
+
+    expect(result).toBe(0x35);
+  });
+
+  test("Neo2", () => {
+    const result = C.getAddressVersion("ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW");
+
+    expect(result).toBe(0x17);
+  });
+});

--- a/packages/neon-core/src/consts.ts
+++ b/packages/neon-core/src/consts.ts
@@ -1,4 +1,9 @@
+/**
+ * @deprecated If you are looking for the default MainNet address version for N3, please use DEFAULT_ADDRESS_VERSION.
+ */
 export const ADDR_VERSION = "35";
+
+export const DEFAULT_ADDRESS_VERSION = 0x35;
 
 export enum MAGIC_NUMBER {
   MainNet = 5195086,

--- a/packages/neon-core/src/wallet/core.ts
+++ b/packages/neon-core/src/wallet/core.ts
@@ -13,7 +13,7 @@
  */
 import base58 from "bs58";
 import { Buffer } from "buffer";
-import { ADDR_VERSION } from "../consts";
+import { DEFAULT_ADDRESS_VERSION } from "../consts";
 import {
   ab2hexstring,
   hash160,
@@ -142,11 +142,15 @@ export function getScriptHashFromPublicKey(publicKey: string): string {
 /**
  * Converts a scripthash to address.
  */
-export function getAddressFromScriptHash(scriptHash: string): string {
+export function getAddressFromScriptHash(
+  scriptHash: string,
+  addressVersion = DEFAULT_ADDRESS_VERSION
+): string {
   scriptHash = reverseHex(scriptHash);
-  const shaChecksum = hash256(ADDR_VERSION + scriptHash).substr(0, 8);
+  const addressVersionHex = addressVersion.toString(16);
+  const shaChecksum = hash256(addressVersionHex + scriptHash).substr(0, 8);
   return base58.encode(
-    Buffer.from(ADDR_VERSION + scriptHash + shaChecksum, "hex")
+    Buffer.from(addressVersionHex + scriptHash + shaChecksum, "hex")
   );
 }
 
@@ -163,4 +167,13 @@ export function getScriptHashFromAddress(address: string): string {
  */
 export function generatePrivateKey(): string {
   return ab2hexstring(generateRandomArray(32));
+}
+
+/**
+ * Extracts the address version from a given correct NEO address.
+ * @param address - A NEO address string.
+ * @returns Address version
+ */
+export function getAddressVersion(address: string): number {
+  return base58.decode(address).readUInt8();
 }

--- a/packages/neon-core/src/wallet/verify.ts
+++ b/packages/neon-core/src/wallet/verify.ts
@@ -116,6 +116,7 @@ export function isScriptHash(scriptHash: string): boolean {
 export function isAddress(address: string): boolean {
   try {
     const programHash = ab2hexstring(base58.decode(address));
+    const addressVersion = parseInt(programHash.slice(0, 2), 16);
     const shaChecksum = hash256(programHash.slice(0, 42)).substr(0, 8);
     // We use the checksum to verify the address
     if (shaChecksum !== programHash.substr(42, 8)) {
@@ -123,7 +124,7 @@ export function isAddress(address: string): boolean {
     }
     // As other chains use similar checksum methods, we need to attempt to transform the programHash back into the address
     const scriptHash = reverseHex(programHash.slice(2, 42));
-    if (getAddressFromScriptHash(scriptHash) !== address) {
+    if (getAddressFromScriptHash(scriptHash, addressVersion) !== address) {
       // address is not valid Neo address, could be btc, ltc etc.
       return false;
     }


### PR DESCRIPTION
Breakout address version as a configurable parameter.

For now, the classes will default to N3 MainNet's number but classes responsible for address construction are now able to take a parameter indicating the custom version.

- Add new export DEFAULT_ADDRESS_VERSION as the library's default. Old const ADDR_VERSION is now marked deprecated.
- Add additional parameter to Account's constructor and getAddressFromScriptHash method.
- Due to this change, TransactionJson cannot do a serialization roundtrip due to the lack of information. 

Fix #765