### PR TITLE
fix for getversion change in Neo 3.0.3

### DIFF
--- a/packages/neon-api/src/NetworkFacade.ts
+++ b/packages/neon-api/src/NetworkFacade.ts
@@ -46,7 +46,7 @@ export class NetworkFacade {
 
   async initialize(): Promise<void> {
     const response = await this.client.getVersion();
-    this.magicNumber = response.network;
+    this.magicNumber = response.protocol.network;
   }
 
   public getRpcNode(): rpc.NeoServerRpcClient {


### PR DESCRIPTION
Neo 3.0.3 introduced a breaking change to the `getversion` RPC method. The `network` value was moved one level down under `protocol`, which broke the `Facade` api in neon-js.