### PR TITLE
fix(rpc): update getversion for Neo3.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     working_directory: ~/repo
     docker:
       - image: circleci/node:<< parameters.version >>
-      - image: snowypowers/n3-csharp-solonet:3.0.1
+      - image: snowypowers/n3-csharp-solonet:3.0.3
 
 commands:
   run-unittest:

--- a/packages/neon-api/src/NetworkFacade.ts
+++ b/packages/neon-api/src/NetworkFacade.ts
@@ -46,7 +46,7 @@ export class NetworkFacade {
 
   async initialize(): Promise<void> {
     const response = await this.client.getVersion();
-    this.magicNumber = response.network;
+    this.magicNumber = response.protocol.network;
   }
 
   public getRpcNode(): rpc.NeoServerRpcClient {

--- a/packages/neon-core/__integration__/rpc/RPCClient.ts
+++ b/packages/neon-core/__integration__/rpc/RPCClient.ts
@@ -9,11 +9,11 @@ import testWallet from "../../__tests__/testWallet.json";
 const wallet = new Wallet(testWallet);
 
 const TESTNET_URLS = [
-  "http://seed1t.neo.org:20332",
-  "http://seed2t.neo.org:20332",
-  "http://seed3t.neo.org:20332",
-  "http://seed4t.neo.org:20332",
-  "http://seed5t.neo.org:20332",
+  "http://seed1t4.neo.org:20332",
+  "http://seed2t4.neo.org:20332",
+  "http://seed3t4.neo.org:20332",
+  "http://seed4t4.neo.org:20332",
+  "http://seed5t4.neo.org:20332",
 ];
 
 const LOCALNET_URLS = ["http://localhost:20332"];
@@ -237,7 +237,17 @@ describe("RPC Methods", () => {
       wsport: expect.any(Number),
       nonce: expect.any(Number),
       useragent: expect.any(String),
-      network: expect.any(Number),
+      protocol: expect.arrayContaining([
+        "addressversion",
+        "network",
+        "validatorscount",
+        "msperblock",
+        "maxtraceableblocks",
+        "maxvaliduntilblockincrement",
+        "maxtransactionsperblock",
+        "memorypoolmaxtransactions",
+        "initialgasdistribution",
+      ]),
     });
   });
 

--- a/packages/neon-core/__integration__/rpc/RPCClient.ts
+++ b/packages/neon-core/__integration__/rpc/RPCClient.ts
@@ -237,17 +237,17 @@ describe("RPC Methods", () => {
       wsport: expect.any(Number),
       nonce: expect.any(Number),
       useragent: expect.any(String),
-      protocol: expect.arrayContaining([
-        "addressversion",
-        "network",
-        "validatorscount",
-        "msperblock",
-        "maxtraceableblocks",
-        "maxvaliduntilblockincrement",
-        "maxtransactionsperblock",
-        "memorypoolmaxtransactions",
-        "initialgasdistribution",
-      ]),
+      protocol: expect.objectContaining({
+        addressversion: expect.any(Number),
+        network: expect.any(Number),
+        validatorscount: expect.any(Number),
+        msperblock: expect.any(Number),
+        maxtraceableblocks: expect.any(Number),
+        maxvaliduntilblockincrement: expect.any(Number),
+        maxtransactionsperblock: expect.any(Number),
+        memorypoolmaxtransactions: expect.any(Number),
+        initialgasdistribution: expect.any(Number),
+      }),
     });
   });
 

--- a/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/NeoServerRpcClient.ts
@@ -212,7 +212,17 @@ describe("NeoServerRpcClient", () => {
       wsport: expect.any(Number),
       nonce: expect.any(Number),
       useragent: expect.any(String),
-      network: expect.any(Number),
+      protocol: expect.objectContaining({
+        addressversion: expect.any(Number),
+        network: expect.any(Number),
+        validatorscount: expect.any(Number),
+        msperblock: expect.any(Number),
+        maxtraceableblocks: expect.any(Number),
+        maxvaliduntilblockincrement: expect.any(Number),
+        maxtransactionsperblock: expect.any(Number),
+        memorypoolmaxtransactions: expect.any(Number),
+        initialgasdistribution: expect.any(Number),
+      }),
     });
   });
 

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -130,15 +130,15 @@ export interface GetVersionResult {
   nonce: number;
   useragent: string;
   protocol: {
-   addressversion: number;
-   network: number;
-   validatorscount: number;
-   msperblock: number;
-   maxtraceableblocks: number;
-   maxvaliduntilblockincrement: number;
-   maxtransactionsperblock: number;
-   memorypoolmaxtransactions: number;
-   initialgasdistribution: number;
+    addressversion: number;
+    network: number;
+    validatorscount: number;
+    msperblock: number;
+    maxtraceableblocks: number;
+    maxvaliduntilblockincrement: number;
+    maxtransactionsperblock: number;
+    memorypoolmaxtransactions: number;
+    initialgasdistribution: number;
   }
 }
 

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -139,7 +139,7 @@ export interface GetVersionResult {
     maxtransactionsperblock: number;
     memorypoolmaxtransactions: number;
     initialgasdistribution: number;
-  }
+  };
 }
 
 export interface NodePeer {

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -129,7 +129,17 @@ export interface GetVersionResult {
   wsport: number;
   nonce: number;
   useragent: string;
-  network: number;
+  protocol: {
+   addressversion: number;
+   network: number;
+   validatorscount: number;
+   msperblock: number;
+   maxtraceableblocks: number;
+   maxvaliduntilblockincrement: number;
+   maxtransactionsperblock: number;
+   memorypoolmaxtransactions: number;
+   initialgasdistribution: number;
+  }
 }
 
 export interface NodePeer {

--- a/testHelpers.ts
+++ b/testHelpers.ts
@@ -1,11 +1,11 @@
 import { rpc } from "./packages/neon-core/src";
 
 export const TESTNET_URLS = [
-  "http://seed1t.neo.org:20332",
-  "http://seed2t.neo.org:20332",
-  "http://seed3t.neo.org:20332",
-  "http://seed4t.neo.org:20332",
-  "http://seed5t.neo.org:20332",
+  "http://seed1t4.neo.org:20332",
+  "http://seed2t4.neo.org:20332",
+  "http://seed3t4.neo.org:20332",
+  "http://seed4t4.neo.org:20332",
+  "http://seed5t4.neo.org:20332",
 ];
 
 export const LOCALNET_URLS = ["http://localhost:20332"];
@@ -13,7 +13,7 @@ export const LOCALNET_URLS = ["http://localhost:20332"];
 export async function getIntegrationEnvUrl(): Promise<string> {
   const urls = isTestNet() ? TESTNET_URLS : LOCALNET_URLS;
   return await getBestUrl(urls);
-}
+e
 
 export function isTestNet(): boolean {
   return (global["__TARGETNET__"] as string).toLowerCase() === "testnet";

--- a/testHelpers.ts
+++ b/testHelpers.ts
@@ -13,7 +13,7 @@ export const LOCALNET_URLS = ["http://localhost:20332"];
 export async function getIntegrationEnvUrl(): Promise<string> {
   const urls = isTestNet() ? TESTNET_URLS : LOCALNET_URLS;
   return await getBestUrl(urls);
-e
+}
 
 export function isTestNet(): boolean {
   return (global["__TARGETNET__"] as string).toLowerCase() === "testnet";


### PR DESCRIPTION
Neo 3.0.3 introduced a breaking change to the getversion RPC method. The network value was moved one level down under protocol, which broke the Facade api in neon-js.