### PR TITLE
feat(rpc): Update Nep17Tracker to TokenTracker

### DIFF
--- a/packages/neon-core/__integration__/rpc/clients/TokenTrackerRpcClient.ts
+++ b/packages/neon-core/__integration__/rpc/clients/TokenTrackerRpcClient.ts
@@ -1,15 +1,30 @@
 import { rpc } from "../../../src";
 import * as TestHelpers from "../../../../../testHelpers";
 
-let client: rpc.Nep17TrackerRpcClient;
+let client: rpc.TokenTrackerRpcClient;
 const address = "NR4SHeS9kfgN5EXVcAuFwfu6Y56xaSPxg9";
 
 beforeAll(async () => {
   const url = await TestHelpers.getIntegrationEnvUrl();
-  client = new rpc.Nep17TrackerRpcClient(url);
+  client = new rpc.TokenTrackerRpcClient(url);
 }, 20000);
 
-describe("Nep17TrackerRpcClient", () => {
+describe("TokenTrackerRpcClient", () => {
+  describe("getNep11Transfers", () => {
+    test("empty address", async () => {
+      const result = await client.getNep11Transfers("0".repeat(40));
+      expect(result.received.length).toBe(0);
+      expect(result.sent.length).toBe(0);
+    });
+  });
+
+  describe("getNep11Balances", () => {
+    test("empty address", async () => {
+      const result = await client.getNep11Balances("0".repeat(40));
+      expect(result.balance.length).toBe(0);
+    });
+  });
+
   describe("getNep17Transfers", () => {
     test("empty address", async () => {
       const result = await client.getNep17Transfers("0".repeat(40));

--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -77,6 +77,33 @@ export interface GetContractStateResult {
   manifest: ContractManifestJson;
 }
 
+export interface GetNep11BalancesResult {
+  /* Base58-encoded string */
+  address: string;
+  balance: {
+    /* 0x-prefixed scripthash of the contract. */
+    assethash: string;
+    tokens: { tokenid: string; amount: string; lastupdatedblock: number }[];
+  }[];
+}
+
+export interface GetNep11TransfersResult {
+  address: string;
+  sent: Nep11TransferEvent[];
+  received: Nep11TransferEvent[];
+}
+
+export interface Nep11TransferEvent {
+  timestamp: number;
+  assethash: string;
+  transferaddress: string;
+  amount: string;
+  blockindex: number;
+  transfernotifyindex: number;
+  txhash: string;
+  tokenid: string;
+}
+
 export interface GetNep17TransfersResult {
   sent: Nep17TransferEvent[];
   received: Nep17TransferEvent[];
@@ -291,6 +318,39 @@ export class Query<TParams extends unknown[], TResponse> {
     return new Query({
       method: "getcontractstate",
       params: [scriptHash],
+    });
+  }
+
+  public static getNep11Balances(
+    accountIdentifier: string
+  ): Query<[string], GetNep11BalancesResult> {
+    return new Query({
+      method: "getnep11balances",
+      params: [accountIdentifier],
+    });
+  }
+
+  public static getNep11Properties(
+    contractHash: string,
+    tokenId: string
+  ): Query<[string, string], Record<string, unknown>> {
+    return new Query({
+      method: "getnep11properties",
+      params: [contractHash, tokenId],
+    });
+  }
+
+  public static getNep11Transfers(
+    accountIdentifer: string,
+    startTime?: string,
+    endTime?: string
+  ): Query<[string, string?, string?], GetNep11TransfersResult> {
+    const params: [string, string?, string?] = [accountIdentifer];
+    if (startTime) params.push(startTime);
+    if (endTime) params.push(endTime);
+    return new Query({
+      method: "getnep17transfers",
+      params,
     });
   }
 

--- a/packages/neon-core/src/rpc/RPCClient.ts
+++ b/packages/neon-core/src/rpc/RPCClient.ts
@@ -2,12 +2,12 @@ import { NeoServerRpcMixin } from "./clients/NeoServerRpcClient";
 import {
   RpcDispatcher,
   ApplicationLogsRpcMixin,
-  Nep17TrackerRpcMixin,
+  TokenTrackerRpcMixin,
 } from "./clients";
 import { Query } from "./Query";
 
 const PING_TIMEOUT = 2000;
-class FullRpcClient extends Nep17TrackerRpcMixin(
+class FullRpcClient extends TokenTrackerRpcMixin(
   ApplicationLogsRpcMixin(NeoServerRpcMixin(RpcDispatcher))
 ) {
   public get [Symbol.toStringTag](): string {

--- a/packages/neon-core/src/rpc/clients/TokenTrackerRpcClient.ts
+++ b/packages/neon-core/src/rpc/clients/TokenTrackerRpcClient.ts
@@ -2,14 +2,16 @@ import {
   Query,
   GetNep17BalancesResult,
   GetNep17TransfersResult,
+  GetNep11TransfersResult,
+  GetNep11BalancesResult,
 } from "../Query";
 import { RpcDispatcher, RpcDispatcherMixin } from "./RpcDispatcher";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
-export function Nep17TrackerRpcMixin<TBase extends RpcDispatcherMixin>(
+export function TokenTrackerRpcMixin<TBase extends RpcDispatcherMixin>(
   base: TBase
 ) {
-  return class Nep17TrackerRpcInterface extends base {
+  return class TokenTrackerRpcInterface extends base {
     public async getNep17Transfers(
       accountIdentifier: string,
       startTime?: string,
@@ -24,11 +26,27 @@ export function Nep17TrackerRpcMixin<TBase extends RpcDispatcherMixin>(
     ): Promise<GetNep17BalancesResult> {
       return this.execute(Query.getNep17Balances(accountIdentifier));
     }
+
+    public async getNep11Transfers(
+      accountIdentifier: string,
+      startTime?: string,
+      endTime?: string
+    ): Promise<GetNep11TransfersResult> {
+      return this.execute(
+        Query.getNep11Transfers(accountIdentifier, startTime, endTime)
+      );
+    }
+
+    public async getNep11Balances(
+      accountIdentifier: string
+    ): Promise<GetNep11BalancesResult> {
+      return this.execute(Query.getNep11Balances(accountIdentifier));
+    }
   };
 }
 
-export class Nep17TrackerRpcClient extends Nep17TrackerRpcMixin(RpcDispatcher) {
+export class TokenTrackerRpcClient extends TokenTrackerRpcMixin(RpcDispatcher) {
   public get [Symbol.toStringTag](): string {
-    return `Nep17TrackerRpcClient(${this.url})`;
+    return `TokenTrackerRpcClient(${this.url})`;
   }
 }

--- a/packages/neon-core/src/rpc/clients/index.ts
+++ b/packages/neon-core/src/rpc/clients/index.ts
@@ -1,4 +1,4 @@
 export * from "./RpcDispatcher";
 export * from "./ApplicationLogsRpcClient";
-export * from "./Nep17TrackerRpcClient";
+export * from "./TokenTrackerRpcClient";
 export * from "./NeoServerRpcClient";


### PR DESCRIPTION
- Add getNep11Balances, getNep11Transfers, getNep11Properties.
- Rename Nep17Tracker to TokenTracker in line with the rename in neo-modules.
- No proper tests due to the lack of NEP11 contract in the test container at the moment.