### PR TITLE
feat(api): Use RPC call calculateNetworkFee

### DIFF
--- a/common/api/neon-api.api.json
+++ b/common/api/neon-api.api.json
@@ -172,7 +172,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@cityofzion/neon-api!calculateNetworkFee:function(1)",
-          "docComment": "/**\n * Calculates the network fee required to process the transaction. The fields signers, attributes and script needs to be fully populated for this to work.\n *\n * @param txn - A partially filled out transaction.\n *\n * @param feePerByte - The current feePerByte in Policy contract.\n *\n * @param signingAccts - The accounts that will be signing this.\n */\n",
+          "docComment": "/**\n * Calculates the network fee required to process the transaction. The fields signers, attributes and script needs to be fully populated for this to work.\n *\n * @deprecated\n *\n * use the RPC call calculateNetworkFee instead.\n *\n * @param txn - A partially filled out transaction.\n *\n * @param feePerByte - The current feePerByte in Policy contract.\n *\n * @param signingAccts - The accounts that will be signing this.\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/common/api/neon-api.api.md
+++ b/common/api/neon-api.api.md
@@ -10,7 +10,7 @@ import { tx } from '@cityofzion/neon-core';
 import { u } from '@cityofzion/neon-core';
 import { wallet } from '@cityofzion/neon-core';
 
-// @public
+// @public @deprecated
 export function calculateNetworkFee(txn: tx.Transaction, feePerByte: number | u.BigInteger, executionFeeFactor: number | u.BigInteger): u.BigInteger;
 
 // @public

--- a/common/api/neon-core.api.json
+++ b/common/api/neon-core.api.json
@@ -2571,6 +2571,154 @@
               "extendsTokenRanges": []
             },
             {
+              "kind": "Interface",
+              "canonicalReference": "@cityofzion/neon-core!rpc.NativeContractState:interface",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "export interface NativeContractState "
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NativeContractState",
+              "members": [
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.NativeContractState#hash:member",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "hash: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "string"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "releaseTag": "Public",
+                  "name": "hash",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                },
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.NativeContractState#id:member",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "id: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "number"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "releaseTag": "Public",
+                  "name": "id",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                },
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.NativeContractState#manifest:member",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "manifest: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "ContractManifestJson",
+                      "canonicalReference": "@cityofzion/neon-core!ContractManifestJson:interface"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "releaseTag": "Public",
+                  "name": "manifest",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                },
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.NativeContractState#nef:member",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "nef: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "NEFJson",
+                      "canonicalReference": "@cityofzion/neon-core!NEFJson:interface"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "releaseTag": "Public",
+                  "name": "nef",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                },
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.NativeContractState#updatehistory:member",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "updatehistory: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "number[]"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "releaseTag": "Public",
+                  "name": "updatehistory",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                }
+              ],
+              "extendsTokenRanges": []
+            },
+            {
               "kind": "Class",
               "canonicalReference": "@cityofzion/neon-core!rpc.NeoServerRpcClient:class",
               "docComment": "/**\n * RPC Client model to query a NEO node. Contains built-in methods to query using RPC calls.\n */\n",
@@ -2771,7 +2919,25 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ">;\n        getRawMemPool(shouldGetUnverified?: false | 0 | undefined): "
+                  "text": ">;\n        getNativeContracts(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "NativeContractState",
+                  "canonicalReference": "@cityofzion/neon-core!NativeContractState:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]>;\n        getRawMemPool(shouldGetUnverified?: false | 0 | undefined): "
                 },
                 {
                   "kind": "Reference",
@@ -3068,7 +3234,34 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ">;\n        listPlugins(): "
+                  "text": ">;\n        calculateNetworkFee(tx: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Transaction",
+                  "canonicalReference": "@cityofzion/neon-core!Transaction:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "HexString",
+                  "canonicalReference": "@cityofzion/neon-core!HexString:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | string): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string>;\n        listPlugins(): "
                 },
                 {
                   "kind": "Reference",
@@ -3131,7 +3324,7 @@
               ],
               "returnTypeTokenRange": {
                 "startIndex": 5,
-                "endIndex": 108
+                "endIndex": 118
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
@@ -5014,6 +5207,70 @@
                 },
                 {
                   "kind": "Method",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.Query.calculateNetworkFee:member(1)",
+                  "docComment": "/**\n * Query returning the network fee required for a given transaction.\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "static calculateNetworkFee(tx: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Transaction",
+                      "canonicalReference": "@cityofzion/neon-core!Transaction:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": " | "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "HexString",
+                      "canonicalReference": "@cityofzion/neon-core!HexString:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": " | string"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "): "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Query",
+                      "canonicalReference": "@cityofzion/neon-core!Query:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<[string], {\n        networkfee: string;\n    }>"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "isStatic": true,
+                  "returnTypeTokenRange": {
+                    "startIndex": 6,
+                    "endIndex": 8
+                  },
+                  "releaseTag": "Public",
+                  "overloadIndex": 1,
+                  "parameters": [
+                    {
+                      "parameterName": "tx",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 1,
+                        "endIndex": 5
+                      }
+                    }
+                  ],
+                  "name": "calculateNetworkFee"
+                },
+                {
+                  "kind": "Method",
                   "canonicalReference": "@cityofzion/neon-core!rpc.Query#equals:member(1)",
                   "docComment": "",
                   "excerptTokens": [
@@ -5686,6 +5943,49 @@
                     }
                   ],
                   "name": "getContractState"
+                },
+                {
+                  "kind": "Method",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.Query.getNativeContracts:member(1)",
+                  "docComment": "/**\n * This Query returns all the native contracts state.\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "static getNativeContracts(): "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Query",
+                      "canonicalReference": "@cityofzion/neon-core!Query:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<[], "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "NativeContractState",
+                      "canonicalReference": "@cityofzion/neon-core!NativeContractState:interface"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "[]>"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "isStatic": true,
+                  "returnTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 5
+                  },
+                  "releaseTag": "Public",
+                  "overloadIndex": 1,
+                  "parameters": [],
+                  "name": "getNativeContracts"
                 },
                 {
                   "kind": "Method",

--- a/common/api/neon-core.api.md
+++ b/common/api/neon-core.api.md
@@ -1240,6 +1240,20 @@ enum NATIVE_CONTRACT_HASH {
 }
 
 // @public (undocumented)
+interface NativeContractState {
+    // (undocumented)
+    hash: string;
+    // (undocumented)
+    id: number;
+    // (undocumented)
+    manifest: ContractManifestJson;
+    // (undocumented)
+    nef: NEFJson;
+    // (undocumented)
+    updatehistory: number[];
+}
+
+// @public (undocumented)
 class NEF {
     constructor(obj: Partial<NEFLike>);
     // (undocumented)
@@ -1326,6 +1340,7 @@ function NeoServerRpcMixin<TBase extends RpcDispatcherMixin>(base: TBase): {
         getBlockHeader(indexOrHash: number | string, verbose: 1): Promise<BlockHeaderJson>;
         getCommittee(): Promise<string[]>;
         getContractState(scriptHash: string): Promise<GetContractStateResult>;
+        getNativeContracts(): Promise<NativeContractState[]>;
         getRawMemPool(shouldGetUnverified?: false | 0 | undefined): Promise<string[]>;
         getRawMemPool(shouldGetUnverified: 1 | true): Promise<GetRawMemPoolResult>;
         getRawTransaction(txid: string, verbose?: false | 0 | undefined): Promise<string>;
@@ -1342,6 +1357,7 @@ function NeoServerRpcMixin<TBase extends RpcDispatcherMixin>(base: TBase): {
         invokeContractVerify(scriptHash: string, args: unknown[], signers?: (Signer | SignerJson)[]): Promise<InvokeResult>;
         invokeFunction(scriptHash: string, operation: string, params?: unknown[], signers?: (Signer | SignerJson)[]): Promise<InvokeResult>;
         invokeScript(script: string | HexString, signers?: (Signer | SignerJson)[]): Promise<InvokeResult>;
+        calculateNetworkFee(tx: Transaction | HexString | string): Promise<string>;
         listPlugins(): Promise<CliPlugin[]>;
         validateAddress(addr: string): Promise<boolean>;
         url: string;
@@ -2125,6 +2141,9 @@ class Query<TParams extends unknown[], TResponse> {
     // (undocumented)
     get [Symbol.toStringTag](): string;
     constructor(req: Partial<QueryLike<TParams>>);
+    static calculateNetworkFee(tx: Transaction | HexString | string): Query<[string], {
+        networkfee: string;
+    }>;
     // (undocumented)
     equals(other: Partial<QueryLike<TParams>>): boolean;
     // (undocumented)
@@ -2142,6 +2161,7 @@ class Query<TParams extends unknown[], TResponse> {
     static getCommittee(): Query<[], string[]>;
     static getConnectionCount(): Query<[], number>;
     static getContractState(scriptHash: string): Query<[string], GetContractStateResult>;
+    static getNativeContracts(): Query<[], NativeContractState[]>;
     // (undocumented)
     static getNep11Balances(accountIdentifier: string): Query<[string], GetNep11BalancesResult>;
     // (undocumented)
@@ -2213,6 +2233,7 @@ declare namespace rpc {
         ApplicationLogJson,
         InvokeResult,
         GetContractStateResult,
+        NativeContractState,
         GetNep11BalancesResult,
         GetNep11TransfersResult,
         Nep11TransferEvent,
@@ -2989,9 +3010,9 @@ enum WitnessScope {
 
 // Warnings were encountered during analysis:
 //
-// src/rpc/clients/NeoServerRpcClient.ts:38:5 - (ae-forgotten-export) The symbol "BlockJson" needs to be exported by the entry point index.d.ts
-// src/rpc/clients/NeoServerRpcClient.ts:77:5 - (ae-forgotten-export) The symbol "BlockHeaderJson" needs to be exported by the entry point index.d.ts
-// src/rpc/clients/NeoServerRpcClient.ts:185:5 - (ae-forgotten-export) The symbol "Validator" needs to be exported by the entry point index.d.ts
+// src/rpc/clients/NeoServerRpcClient.ts:39:5 - (ae-forgotten-export) The symbol "BlockJson" needs to be exported by the entry point index.d.ts
+// src/rpc/clients/NeoServerRpcClient.ts:78:5 - (ae-forgotten-export) The symbol "BlockHeaderJson" needs to be exported by the entry point index.d.ts
+// src/rpc/clients/NeoServerRpcClient.ts:190:5 - (ae-forgotten-export) The symbol "Validator" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/api/neon-js.api.json
+++ b/common/api/neon-js.api.json
@@ -225,7 +225,7 @@
             },
             {
               "kind": "Content",
-              "text": ";\n        contractParam: (type: \"Any\" | \"Boolean\" | \"Integer\" | \"Array\" | \"Map\" | \"InteropInterface\" | \"ByteArray\" | \"String\" | \"Hash160\" | \"Hash256\" | \"PublicKey\" | \"Signature\" | \"Void\", value?: string | number | boolean | neonCore.sc."
+              "text": ";\n        contractParam: (type: \"Any\" | \"Boolean\" | \"Integer\" | \"ByteArray\" | \"String\" | \"Hash160\" | \"Hash256\" | \"PublicKey\" | \"Signature\" | \"Array\" | \"Map\" | \"InteropInterface\" | \"Void\", value?: string | number | boolean | neonCore.sc."
             },
             {
               "kind": "Reference",

--- a/common/api/neon-js.api.md
+++ b/common/api/neon-js.api.md
@@ -24,7 +24,7 @@ const _default: {
         privateKey: typeof neonCore.wallet.generatePrivateKey;
         signature: typeof neonCore.wallet.generateSignature;
         wallet: (k: neonCore.wallet.WalletJSON) => neonCore.wallet.Wallet;
-        contractParam: (type: "Any" | "Boolean" | "Integer" | "Array" | "Map" | "InteropInterface" | "ByteArray" | "String" | "Hash160" | "Hash256" | "PublicKey" | "Signature" | "Void", value?: string | number | boolean | neonCore.sc.ContractParamJson[] | null | undefined) => neonCore.sc.ContractParam;
+        contractParam: (type: "Any" | "Boolean" | "Integer" | "ByteArray" | "String" | "Hash160" | "Hash256" | "PublicKey" | "Signature" | "Array" | "Map" | "InteropInterface" | "Void", value?: string | number | boolean | neonCore.sc.ContractParamJson[] | null | undefined) => neonCore.sc.ContractParam;
         script: typeof neonCore.sc.createScript;
         scriptBuilder: () => neonCore.sc.ScriptBuilder;
         rpcClient: (net: string) => neonCore.rpc.RPCClient;

--- a/packages/neon-api/__integration__/transaction/validator.ts
+++ b/packages/neon-api/__integration__/transaction/validator.ts
@@ -2,7 +2,7 @@ import {
   TransactionValidator,
   ValidationAttributes,
 } from "../../src/transaction";
-import { sc, tx, u, rpc, CONST } from "@cityofzion/neon-core";
+import { sc, tx, u, rpc, wallet, CONST } from "@cityofzion/neon-core";
 import * as TestHelpers from "../../../../testHelpers";
 
 let rpcClient: rpc.NeoServerRpcClient;
@@ -23,6 +23,19 @@ const multiSig = {
   verificationScript:
     "110c2103118a2b7962fa0226fa35acf5d224855b691c7ea978d1afe2c538631d5f7be85e11419ed0dc3a",
 };
+
+const signers: tx.SignerLike[] = [
+  {
+    account: wallet.getScriptHashFromVerificationScript(sig.verificationScript),
+    scopes: 1,
+  },
+  {
+    account: wallet.getScriptHashFromVerificationScript(
+      multiSig.invocationScript
+    ),
+    scopes: 1,
+  },
+];
 
 describe("validateValidUntilBlock", () => {
   test("valid", async () => {
@@ -199,6 +212,8 @@ describe("validateSystemFee", () => {
 describe("validateNetworkFee", () => {
   test("valid", async () => {
     const transaction = new tx.Transaction({
+      script: "1234",
+      signers,
       witnesses: [sig, multiSig],
       networkFee: 2376540,
     });
@@ -209,6 +224,8 @@ describe("validateNetworkFee", () => {
 
   test("invalid", async () => {
     const transaction = new tx.Transaction({
+      script: "1234",
+      signers,
       witnesses: [sig, multiSig],
       networkFee: 1,
     });
@@ -219,6 +236,8 @@ describe("validateNetworkFee", () => {
 
   test("autoFix", async () => {
     const transaction = new tx.Transaction({
+      script: "1234",
+      signers,
       witnesses: [sig, multiSig],
       networkFee: 1,
     });
@@ -244,6 +263,7 @@ describe("validateAll", () => {
     const transaction = new tx.Transaction({
       validUntilBlock:
         tx.Transaction.MAX_TRANSACTION_LIFESPAN + currentBlock - 1,
+      signers,
       witnesses: [sig, multiSig],
       script,
       networkFee: 100000000,
@@ -264,6 +284,7 @@ describe("validateAll", () => {
     const transaction = new tx.Transaction({
       validUntilBlock:
         tx.Transaction.MAX_TRANSACTION_LIFESPAN + currentBlock - 1,
+      signers,
       witnesses: [sig, multiSig],
       script,
       networkFee: 1,
@@ -285,6 +306,7 @@ describe("validateAll", () => {
       const transaction = new tx.Transaction({
         validUntilBlock:
           tx.Transaction.MAX_TRANSACTION_LIFESPAN + currentBlock - 1,
+        signers,
         witnesses: [sig, multiSig],
         script,
         networkFee: 1,
@@ -332,6 +354,7 @@ describe("validateAll", () => {
       const transaction = new tx.Transaction({
         validUntilBlock:
           tx.Transaction.MAX_TRANSACTION_LIFESPAN + currentBlock - 1,
+        signers,
         witnesses: [sig, multiSig],
         script,
         networkFee: 1,

--- a/packages/neon-api/src/api/calculateNetworkFee.ts
+++ b/packages/neon-api/src/api/calculateNetworkFee.ts
@@ -7,6 +7,8 @@ import { tx, sc, u, wallet } from "@cityofzion/neon-core";
  * @param txn - A partially filled out transaction.
  * @param feePerByte - The current feePerByte in Policy contract.
  * @param signingAccts - The accounts that will be signing this.
+ *
+ * @deprecated use the RPC call calculateNetworkFee instead.
  */
 export function calculateNetworkFee(
   txn: tx.Transaction,

--- a/packages/neon-api/src/transaction/validator.ts
+++ b/packages/neon-api/src/transaction/validator.ts
@@ -1,5 +1,4 @@
 import { tx, rpc, u } from "@cityofzion/neon-core";
-import { calculateNetworkFee, getFeeInformation } from "../api";
 
 export enum ValidationAttributes {
   None = 0,
@@ -148,15 +147,11 @@ export class TransactionValidator {
   ): Promise<ValidationSuggestion<u.BigInteger>> {
     const { networkFee: prev } = this.transaction;
 
-    const { feePerByte, executionFeeFactor } = await getFeeInformation(
-      this.rpcClient
+    const calculateResponse = await this.rpcClient.calculateNetworkFee(
+      this.transaction
     );
 
-    const suggestion = calculateNetworkFee(
-      this.transaction,
-      feePerByte,
-      executionFeeFactor
-    );
+    const suggestion = u.BigInteger.fromNumber(calculateResponse);
     const compareResult = suggestion.compare(prev);
     if (compareResult > 0) {
       // Underpaying


### PR DESCRIPTION
- Deprecate api.calculateNetworkFee
- Update TransactionValidator to use RPC call to calculate network fee instead
- Update tests to pass in correctly constructed transactions
- Fix #789