### PR TITLE
fix(rpc): Tweak Query to conform to jsonrpc params

### DIFF
--- a/packages/neon-core/__tests__/rpc/Query.ts
+++ b/packages/neon-core/__tests__/rpc/Query.ts
@@ -44,6 +44,28 @@ describe("equals", () => {
   );
 });
 
+describe("JSONRPC spec", () => {
+  test("allows structured values in params", () => {
+    const objectquery = {
+      method: "objectquery",
+      params: {
+        key: "value",
+        anotherfield: 1,
+        thirdfield: [1, 2, 3],
+        fourthfield: {
+          nested: "string",
+        },
+      },
+    };
+    const result = new Query(objectquery);
+
+    const exportedQuery = result.export();
+
+    expect(exportedQuery.jsonrpc).toBe("2.0");
+    expect(exportedQuery.method).toBe(objectquery.method);
+    expect(exportedQuery.params).toBe(objectquery.params);
+  });
+});
 describe("static", () => {
   test("calculateNetworkFee", () => {
     const result = Query.calculateNetworkFee("12345");

--- a/packages/neon-core/package.json
+++ b/packages/neon-core/package.json
@@ -47,6 +47,7 @@
     "cross-fetch": "^3.1.4",
     "crypto-js": "4.1.1",
     "elliptic": "6.5.4",
+    "lodash": "4.17.21",
     "loglevel": "1.8.0",
     "loglevel-plugin-prefix": "0.8.4",
     "scrypt-js": "3.0.1"
@@ -55,7 +56,8 @@
     "@types/bn.js": "5.1.0",
     "@types/bs58": "4.0.1",
     "@types/crypto-js": "4.0.2",
-    "@types/elliptic": "6.4.14"
+    "@types/elliptic": "6.4.14",
+    "@types/lodash": "4.14.178"
   },
   "files": [
     "dist/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2010,6 +2010,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@^4.14.178":
+  version "4.14.178"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
+  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
Update the Query type to conform to JSONRPC specs to allow structure values under params. This means either an array or object.

Closes #805.