### PR TITLE
feat(rpc): BatchQuery

### DIFF
--- a/common/api/neon-core.api.json
+++ b/common/api/neon-core.api.json
@@ -967,7 +967,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<unknown[], TResponse>, config?: import(\"./RpcDispatcher\")."
+                  "text": "<import(\"../Query\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", TResponse>, config?: import(\"./RpcDispatcher\")."
                 },
                 {
                   "kind": "Reference",
@@ -985,7 +994,79 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<TResponse>;\n    };\n} & TBase"
+                  "text": "<TResponse>;\n        executeAll<TResponses extends unknown[]>(batchQuery: import(\"..\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BatchQuery",
+                  "canonicalReference": "@cityofzion/neon-core!BatchQuery:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<import(\"../Query\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[], TResponses>, config?: import(\"./RpcDispatcher\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "RpcConfig",
+                  "canonicalReference": "@cityofzion/neon-core!RpcConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TResponses>;\n        executeAll<TResponses_1 extends unknown[]>(batchQuery: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Query",
+                  "canonicalReference": "@cityofzion/neon-core!Query:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<import(\"../Query\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", unknown>[], config?: import(\"./RpcDispatcher\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "RpcConfig",
+                  "canonicalReference": "@cityofzion/neon-core!RpcConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TResponses_1>;\n    };\n} & TBase"
                 },
                 {
                   "kind": "Content",
@@ -994,7 +1075,7 @@
               ],
               "returnTypeTokenRange": {
                 "startIndex": 5,
-                "endIndex": 16
+                "endIndex": 34
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
@@ -1021,6 +1102,284 @@
                 }
               ],
               "name": "ApplicationLogsRpcMixin"
+            },
+            {
+              "kind": "Class",
+              "canonicalReference": "@cityofzion/neon-core!rpc.BatchQuery:class",
+              "docComment": "/**\n * Helper class that maintains the types in a list of Queries. This allows the RpcDispatcher to return correctly typed responses.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "export declare class BatchQuery<TParams extends "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", TResponses extends "
+                },
+                {
+                  "kind": "Content",
+                  "text": "unknown[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "> "
+                }
+              ],
+              "releaseTag": "Public",
+              "typeParameters": [
+                {
+                  "typeParameterName": "TParams",
+                  "constraintTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 3
+                  },
+                  "defaultTypeTokenRange": {
+                    "startIndex": 0,
+                    "endIndex": 0
+                  }
+                },
+                {
+                  "typeParameterName": "TResponses",
+                  "constraintTokenRange": {
+                    "startIndex": 4,
+                    "endIndex": 5
+                  },
+                  "defaultTypeTokenRange": {
+                    "startIndex": 0,
+                    "endIndex": 0
+                  }
+                }
+              ],
+              "name": "BatchQuery",
+              "members": [
+                {
+                  "kind": "Method",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.BatchQuery#add:member(1)",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "add<TParam extends "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "JsonRpcParams",
+                      "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ", TResponse>(q: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Query",
+                      "canonicalReference": "@cityofzion/neon-core!Query:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<TParam, TResponse>"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "): "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "BatchQuery",
+                      "canonicalReference": "@cityofzion/neon-core!BatchQuery:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<[...TParams, TParam], [...TResponses, TResponse]>"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "isStatic": false,
+                  "returnTypeTokenRange": {
+                    "startIndex": 6,
+                    "endIndex": 8
+                  },
+                  "releaseTag": "Public",
+                  "overloadIndex": 1,
+                  "parameters": [
+                    {
+                      "parameterName": "q",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 3,
+                        "endIndex": 5
+                      }
+                    }
+                  ],
+                  "typeParameters": [
+                    {
+                      "typeParameterName": "TParam",
+                      "constraintTokenRange": {
+                        "startIndex": 1,
+                        "endIndex": 2
+                      },
+                      "defaultTypeTokenRange": {
+                        "startIndex": 0,
+                        "endIndex": 0
+                      }
+                    },
+                    {
+                      "typeParameterName": "TResponse",
+                      "constraintTokenRange": {
+                        "startIndex": 0,
+                        "endIndex": 0
+                      },
+                      "defaultTypeTokenRange": {
+                        "startIndex": 0,
+                        "endIndex": 0
+                      }
+                    }
+                  ],
+                  "name": "add"
+                },
+                {
+                  "kind": "Method",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.BatchQuery.of:member(1)",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "static of<TParams extends "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "JsonRpcParams",
+                      "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ", TResponse>(q: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Query",
+                      "canonicalReference": "@cityofzion/neon-core!Query:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<TParams, TResponse>"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "): "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "BatchQuery",
+                      "canonicalReference": "@cityofzion/neon-core!BatchQuery:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<[TParams], [TResponse]>"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "isStatic": true,
+                  "returnTypeTokenRange": {
+                    "startIndex": 6,
+                    "endIndex": 8
+                  },
+                  "releaseTag": "Public",
+                  "overloadIndex": 1,
+                  "parameters": [
+                    {
+                      "parameterName": "q",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 3,
+                        "endIndex": 5
+                      }
+                    }
+                  ],
+                  "typeParameters": [
+                    {
+                      "typeParameterName": "TParams",
+                      "constraintTokenRange": {
+                        "startIndex": 1,
+                        "endIndex": 2
+                      },
+                      "defaultTypeTokenRange": {
+                        "startIndex": 0,
+                        "endIndex": 0
+                      }
+                    },
+                    {
+                      "typeParameterName": "TResponse",
+                      "constraintTokenRange": {
+                        "startIndex": 0,
+                        "endIndex": 0
+                      },
+                      "defaultTypeTokenRange": {
+                        "startIndex": 0,
+                        "endIndex": 0
+                      }
+                    }
+                  ],
+                  "name": "of"
+                },
+                {
+                  "kind": "Property",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.BatchQuery#queries:member",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "queries: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Query",
+                      "canonicalReference": "@cityofzion/neon-core!Query:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<"
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "JsonRpcParams",
+                      "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ", unknown>[]"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "releaseTag": "Public",
+                  "name": "queries",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 5
+                  },
+                  "isStatic": false
+                }
+              ],
+              "implementsTokenRanges": []
             },
             {
               "kind": "TypeAlias",
@@ -3331,7 +3690,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<unknown[], TResponse>, config?: import(\"./RpcDispatcher\")."
+                  "text": "<import(\"..\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", TResponse>, config?: import(\"./RpcDispatcher\")."
                 },
                 {
                   "kind": "Reference",
@@ -3349,7 +3717,79 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<TResponse>;\n    };\n} & TBase"
+                  "text": "<TResponse>;\n        executeAll<TResponses extends unknown[]>(batchQuery: import(\"..\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BatchQuery",
+                  "canonicalReference": "@cityofzion/neon-core!BatchQuery:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<import(\"..\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[], TResponses>, config?: import(\"./RpcDispatcher\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "RpcConfig",
+                  "canonicalReference": "@cityofzion/neon-core!RpcConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TResponses>;\n        executeAll<TResponses_1 extends unknown[]>(batchQuery: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Query",
+                  "canonicalReference": "@cityofzion/neon-core!Query:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<import(\"..\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", unknown>[], config?: import(\"./RpcDispatcher\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "RpcConfig",
+                  "canonicalReference": "@cityofzion/neon-core!RpcConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TResponses_1>;\n    };\n} & TBase"
                 },
                 {
                   "kind": "Content",
@@ -3358,7 +3798,7 @@
               ],
               "returnTypeTokenRange": {
                 "startIndex": 5,
-                "endIndex": 118
+                "endIndex": 136
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
@@ -8109,7 +8549,16 @@
                     },
                     {
                       "kind": "Content",
-                      "text": "<unknown[], TResponse>"
+                      "text": "<"
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "JsonRpcParams",
+                      "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ", TResponse>"
                     },
                     {
                       "kind": "Content",
@@ -8141,8 +8590,8 @@
                   "isOptional": false,
                   "isStatic": false,
                   "returnTypeTokenRange": {
-                    "startIndex": 6,
-                    "endIndex": 8
+                    "startIndex": 8,
+                    "endIndex": 10
                   },
                   "releaseTag": "Public",
                   "overloadIndex": 1,
@@ -8151,14 +8600,14 @@
                       "parameterName": "query",
                       "parameterTypeTokenRange": {
                         "startIndex": 1,
-                        "endIndex": 3
+                        "endIndex": 5
                       }
                     },
                     {
                       "parameterName": "config",
                       "parameterTypeTokenRange": {
-                        "startIndex": 4,
-                        "endIndex": 5
+                        "startIndex": 6,
+                        "endIndex": 7
                       }
                     }
                   ],
@@ -8176,6 +8625,208 @@
                     }
                   ],
                   "name": "execute"
+                },
+                {
+                  "kind": "Method",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.RpcDispatcher#executeAll:member(1)",
+                  "docComment": "/**\n * Takes an array of Queries and executes them. Throws if any of the queries encounters an error.\n *\n * @param batchQuery - Array of queries or a BatchQuery\n *\n * @param config - Configuration to apply to the RPC call\n *\n * @returns list of unwrapped json-rpc results\n *\n * @example\n * ```ts\n * const dispatcher = new RpcDispatcher(\"http://www.example.com\");\n * const response = dispatcher.executeAll(\n *    BatchQuery.of(new Query({method: \"getversion\"}))\n *      .add(new Query({method: \"getblockcount\"}))\n * );\n * // Correctly typed response when using BatchQuery\n * console.log(response[0].protocol.network);\n *\n * // You will have to manually type the response when using a plain array\n * const response = dispatcher.executeAll<GetVersionResult, number>([\n *    new Query({method: \"getversion\"}),\n *    new Query({method: \"getblockcount\"})\n * ]);\n *\n * console.log(response[0].protocol.network);\n * ```\n *\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "executeAll<TResponses extends "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "unknown[]"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ">(batchQuery: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "BatchQuery",
+                      "canonicalReference": "@cityofzion/neon-core!BatchQuery:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<"
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "JsonRpcParams",
+                      "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "[], TResponses>"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ", config?: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "RpcConfig",
+                      "canonicalReference": "@cityofzion/neon-core!RpcConfig:interface"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "): "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Promise",
+                      "canonicalReference": "!Promise:interface"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<TResponses>"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "isStatic": false,
+                  "returnTypeTokenRange": {
+                    "startIndex": 10,
+                    "endIndex": 12
+                  },
+                  "releaseTag": "Public",
+                  "overloadIndex": 1,
+                  "parameters": [
+                    {
+                      "parameterName": "batchQuery",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 3,
+                        "endIndex": 7
+                      }
+                    },
+                    {
+                      "parameterName": "config",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 8,
+                        "endIndex": 9
+                      }
+                    }
+                  ],
+                  "typeParameters": [
+                    {
+                      "typeParameterName": "TResponses",
+                      "constraintTokenRange": {
+                        "startIndex": 1,
+                        "endIndex": 2
+                      },
+                      "defaultTypeTokenRange": {
+                        "startIndex": 0,
+                        "endIndex": 0
+                      }
+                    }
+                  ],
+                  "name": "executeAll"
+                },
+                {
+                  "kind": "Method",
+                  "canonicalReference": "@cityofzion/neon-core!rpc.RpcDispatcher#executeAll:member(2)",
+                  "docComment": "",
+                  "excerptTokens": [
+                    {
+                      "kind": "Content",
+                      "text": "executeAll<TResponses extends "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "unknown[]"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ">(batchQuery: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Query",
+                      "canonicalReference": "@cityofzion/neon-core!Query:class"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<"
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "JsonRpcParams",
+                      "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ", unknown>[]"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ", config?: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "RpcConfig",
+                      "canonicalReference": "@cityofzion/neon-core!RpcConfig:interface"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "): "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Promise",
+                      "canonicalReference": "!Promise:interface"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<TResponses>"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "isOptional": false,
+                  "isStatic": false,
+                  "returnTypeTokenRange": {
+                    "startIndex": 10,
+                    "endIndex": 12
+                  },
+                  "releaseTag": "Public",
+                  "overloadIndex": 2,
+                  "parameters": [
+                    {
+                      "parameterName": "batchQuery",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 3,
+                        "endIndex": 7
+                      }
+                    },
+                    {
+                      "parameterName": "config",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 8,
+                        "endIndex": 9
+                      }
+                    }
+                  ],
+                  "typeParameters": [
+                    {
+                      "typeParameterName": "TResponses",
+                      "constraintTokenRange": {
+                        "startIndex": 1,
+                        "endIndex": 2
+                      },
+                      "defaultTypeTokenRange": {
+                        "startIndex": 0,
+                        "endIndex": 0
+                      }
+                    }
+                  ],
+                  "name": "executeAll"
                 },
                 {
                   "kind": "Property",
@@ -8538,7 +9189,7 @@
             {
               "kind": "Function",
               "canonicalReference": "@cityofzion/neon-core!rpc.sendQuery:function(1)",
-              "docComment": "",
+              "docComment": "/**\n * Low level method to directly send a json-rpc request.\n *\n * @param url - address to send request to\n *\n * @param query - json-rpc request body\n *\n * @param config - rpc configuration\n *\n * @returns a json-rpc response\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -8559,7 +9210,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<unknown[], TResponse>"
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", TResponse>"
                 },
                 {
                   "kind": "Content",
@@ -8598,8 +9258,8 @@
                 }
               ],
               "returnTypeTokenRange": {
-                "startIndex": 8,
-                "endIndex": 12
+                "startIndex": 10,
+                "endIndex": 14
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
@@ -8615,14 +9275,14 @@
                   "parameterName": "query",
                   "parameterTypeTokenRange": {
                     "startIndex": 3,
-                    "endIndex": 5
+                    "endIndex": 7
                   }
                 },
                 {
                   "parameterName": "config",
                   "parameterTypeTokenRange": {
-                    "startIndex": 6,
-                    "endIndex": 7
+                    "startIndex": 8,
+                    "endIndex": 9
                   }
                 }
               ],
@@ -8640,6 +9300,108 @@
                 }
               ],
               "name": "sendQuery"
+            },
+            {
+              "kind": "Function",
+              "canonicalReference": "@cityofzion/neon-core!rpc.sendQueryList:function(1)",
+              "docComment": "/**\n * Low level method to directly send a list of json-rpc requests. Note that the responses will not be typed.\n *\n * @param url - address to send request to\n *\n * @param batch - array\n *\n * @param config - rpc configuration\n *\n * @returns a list of untyped json-rpc responses\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "export declare function sendQueryList(url: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", batch: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Query",
+                  "canonicalReference": "@cityofzion/neon-core!Query:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", unknown>[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", config?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "RpcConfig",
+                  "canonicalReference": "@cityofzion/neon-core!RpcConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "RPCResponse",
+                  "canonicalReference": "@cityofzion/neon-core!RPCResponse:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<unknown>[]>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "returnTypeTokenRange": {
+                "startIndex": 10,
+                "endIndex": 14
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "url",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                },
+                {
+                  "parameterName": "batch",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 7
+                  }
+                },
+                {
+                  "parameterName": "config",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 8,
+                    "endIndex": 9
+                  }
+                }
+              ],
+              "name": "sendQueryList"
             },
             {
               "kind": "Interface",
@@ -8979,7 +9741,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<unknown[], TResponse>, config?: import(\"./RpcDispatcher\")."
+                  "text": "<import(\"../Query\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", TResponse>, config?: import(\"./RpcDispatcher\")."
                 },
                 {
                   "kind": "Reference",
@@ -8997,7 +9768,79 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<TResponse>;\n    };\n} & TBase"
+                  "text": "<TResponse>;\n        executeAll<TResponses extends unknown[]>(batchQuery: import(\"..\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BatchQuery",
+                  "canonicalReference": "@cityofzion/neon-core!BatchQuery:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<import(\"../Query\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[], TResponses>, config?: import(\"./RpcDispatcher\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "RpcConfig",
+                  "canonicalReference": "@cityofzion/neon-core!RpcConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TResponses>;\n        executeAll<TResponses_1 extends unknown[]>(batchQuery: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Query",
+                  "canonicalReference": "@cityofzion/neon-core!Query:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<import(\"../Query\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonRpcParams",
+                  "canonicalReference": "@cityofzion/neon-core!JsonRpcParams:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", unknown>[], config?: import(\"./RpcDispatcher\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "RpcConfig",
+                  "canonicalReference": "@cityofzion/neon-core!RpcConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TResponses_1>;\n    };\n} & TBase"
                 },
                 {
                   "kind": "Content",
@@ -9006,7 +9849,7 @@
               ],
               "returnTypeTokenRange": {
                 "startIndex": 5,
-                "endIndex": 28
+                "endIndex": 46
               },
               "releaseTag": "Public",
               "overloadIndex": 1,

--- a/common/api/neon-core.api.md
+++ b/common/api/neon-core.api.md
@@ -144,7 +144,9 @@ function ApplicationLogsRpcMixin<TBase extends RpcDispatcherMixin>(base: TBase):
     new (...args: any[]): {
         getApplicationLog(blockOrTxHash: string): Promise<ApplicationLogJson>;
         url: string;
-        execute<TResponse>(query: Query<unknown[], TResponse>, config?: RpcConfig | undefined): Promise<TResponse>;
+        execute<TResponse>(query: Query<JsonRpcParams, TResponse>, config?: RpcConfig | undefined): Promise<TResponse>;
+        executeAll<TResponses extends unknown[]>(batchQuery: BatchQuery<JsonRpcParams[], TResponses>, config?: RpcConfig | undefined): Promise<TResponses>;
+        executeAll<TResponses_1 extends unknown[]>(batchQuery: Query<JsonRpcParams, unknown>[], config?: RpcConfig | undefined): Promise<TResponses_1>;
     };
 } & TBase;
 
@@ -167,6 +169,16 @@ class BaseContract {
     get methods(): Readonly<Record<string, ContractMethodDefinition>>;
     // (undocumented)
     get scriptHash(): string;
+}
+
+// @public
+class BatchQuery<TParams extends JsonRpcParams[], TResponses extends unknown[]> {
+    // (undocumented)
+    add<TParam extends JsonRpcParams, TResponse>(q: Query<TParam, TResponse>): BatchQuery<[...TParams, TParam], [...TResponses, TResponse]>;
+    // (undocumented)
+    static of<TParams extends JsonRpcParams, TResponse>(q: Query<TParams, TResponse>): BatchQuery<[TParams], [TResponse]>;
+    // (undocumented)
+    queries: Query<JsonRpcParams, unknown>[];
 }
 
 // @public
@@ -1488,7 +1500,9 @@ function NeoServerRpcMixin<TBase extends RpcDispatcherMixin>(base: TBase): {
         listPlugins(): Promise<CliPlugin[]>;
         validateAddress(addr: string): Promise<boolean>;
         url: string;
-        execute<TResponse>(query: Query<unknown[], TResponse>, config?: RpcConfig | undefined): Promise<TResponse>;
+        execute<TResponse>(query: Query<JsonRpcParams, TResponse>, config?: RpcConfig | undefined): Promise<TResponse>;
+        executeAll<TResponses extends unknown[]>(batchQuery: BatchQuery<JsonRpcParams[], TResponses>, config?: RpcConfig | undefined): Promise<TResponses>;
+        executeAll<TResponses_1 extends unknown[]>(batchQuery: Query<JsonRpcParams, unknown>[], config?: RpcConfig | undefined): Promise<TResponses_1>;
     };
 } & TBase;
 
@@ -2448,6 +2462,7 @@ declare namespace rpc {
         StackItemParser,
         VMResultParser,
         sendQuery,
+        sendQueryList,
         RpcConfig,
         GConstructor,
         RpcDispatcherMixin,
@@ -2458,7 +2473,8 @@ declare namespace rpc {
         TokenTrackerRpcMixin,
         TokenTrackerRpcClient,
         NeoServerRpcMixin,
-        NeoServerRpcClient
+        NeoServerRpcClient,
+        BatchQuery
     }
 }
 export { rpc }
@@ -2491,7 +2507,10 @@ interface RpcConfig {
 // @public
 class RpcDispatcher {
     constructor(url: string);
-    execute<TResponse>(query: Query<unknown[], TResponse>, config?: RpcConfig): Promise<TResponse>;
+    execute<TResponse>(query: Query<JsonRpcParams, TResponse>, config?: RpcConfig): Promise<TResponse>;
+    executeAll<TResponses extends unknown[]>(batchQuery: BatchQuery<JsonRpcParams[], TResponses>, config?: RpcConfig): Promise<TResponses>;
+    // (undocumented)
+    executeAll<TResponses extends unknown[]>(batchQuery: Query<JsonRpcParams, unknown>[], config?: RpcConfig): Promise<TResponses>;
     // (undocumented)
     url: string;
 }
@@ -2653,8 +2672,11 @@ interface ScryptParams {
     r: number;
 }
 
-// @public (undocumented)
-function sendQuery<TResponse>(url: string, query: Query<unknown[], TResponse>, config?: RpcConfig): Promise<RPCResponse<TResponse>>;
+// @public
+function sendQuery<TResponse>(url: string, query: Query<JsonRpcParams, TResponse>, config?: RpcConfig): Promise<RPCResponse<TResponse>>;
+
+// @public
+function sendQueryList(url: string, batch: Query<JsonRpcParams, unknown>[], config?: RpcConfig): Promise<RPCResponse<unknown>[]>;
 
 // @public (undocumented)
 interface SendResult {
@@ -2848,7 +2870,9 @@ function TokenTrackerRpcMixin<TBase extends RpcDispatcherMixin>(base: TBase): {
         getNep11Transfers(accountIdentifier: string, startTime?: string | undefined, endTime?: string | undefined): Promise<GetNep11TransfersResult>;
         getNep11Balances(accountIdentifier: string): Promise<GetNep11BalancesResult>;
         url: string;
-        execute<TResponse>(query: Query<unknown[], TResponse>, config?: RpcConfig | undefined): Promise<TResponse>;
+        execute<TResponse>(query: Query<JsonRpcParams, TResponse>, config?: RpcConfig | undefined): Promise<TResponse>;
+        executeAll<TResponses extends unknown[]>(batchQuery: BatchQuery<JsonRpcParams[], TResponses>, config?: RpcConfig | undefined): Promise<TResponses>;
+        executeAll<TResponses_1 extends unknown[]>(batchQuery: Query<JsonRpcParams, unknown>[], config?: RpcConfig | undefined): Promise<TResponses_1>;
     };
 } & TBase;
 

--- a/packages/neon-core/__integration__/rpc/RPCClient.ts
+++ b/packages/neon-core/__integration__/rpc/RPCClient.ts
@@ -69,6 +69,28 @@ beforeAll(async () => {
   }
 }, 20000);
 
+describe("batch", () => {
+  test("batch", async () => {
+    const batch = rpc.BatchQuery.of(rpc.Query.getBlockCount())
+      .add(rpc.Query.validateAddress("helloworld"))
+      .add(rpc.Query.getBlockHash(0));
+    const responses = await client.batch(batch);
+
+    expect(responses.length).toBe(3);
+    expect(responses[0]).toEqual(expect.any(Number));
+    expect(responses[1].isvalid).toBeFalsy();
+    expect(responses[2]).toEqual(expect.any(String));
+  });
+
+  test("single failure throws", async () => {
+    const batch = rpc.BatchQuery.of(rpc.Query.getBlockCount())
+      .add(new rpc.Query({ method: "unknownmethod" }))
+      .add(rpc.Query.getBlockHash(0));
+
+    expect(client.batch(batch)).rejects.toThrow();
+  });
+});
+
 describe("RPC Methods", () => {
   describe("getBlock", () => {
     test("height as index, verbose = 0", async () => {

--- a/packages/neon-core/src/rpc/BatchQuery.ts
+++ b/packages/neon-core/src/rpc/BatchQuery.ts
@@ -1,5 +1,9 @@
 import { Query, JsonRpcParams } from "./Query";
 
+/**
+ * Helper class that maintains the types in a list of Queries.
+ * This allows the RpcDispatcher to return correctly typed responses.
+ */
 export class BatchQuery<
   TParams extends JsonRpcParams[],
   TResponses extends unknown[]

--- a/packages/neon-core/src/rpc/BatchQuery.ts
+++ b/packages/neon-core/src/rpc/BatchQuery.ts
@@ -1,0 +1,25 @@
+import { Query, JsonRpcParams } from "./Query";
+
+export class BatchQuery<
+  TParams extends JsonRpcParams[],
+  TResponses extends unknown[]
+> {
+  public queries: Query<JsonRpcParams, unknown>[];
+
+  private constructor(q: Query<JsonRpcParams, TResponses>) {
+    this.queries = [q];
+  }
+
+  public add<TParam extends JsonRpcParams, TResponse>(
+    q: Query<TParam, TResponse>
+  ): BatchQuery<[...TParams, TParam], [...TResponses, TResponse]> {
+    this.queries.push(q);
+    return this;
+  }
+
+  public static of<TParams extends JsonRpcParams, TResponse>(
+    q: Query<TParams, TResponse>
+  ): BatchQuery<[TParams], [TResponse]> {
+    return new BatchQuery(q);
+  }
+}

--- a/packages/neon-core/src/rpc/clients/RpcDispatcher.ts
+++ b/packages/neon-core/src/rpc/clients/RpcDispatcher.ts
@@ -1,7 +1,8 @@
-import { Query, RPCResponse, RPCErrorResponse } from "../Query";
+import { Query, RPCResponse, RPCErrorResponse, JsonRpcParams } from "../Query";
 import logger from "../../logging";
 import { fetch } from "cross-fetch";
 import { AbortController } from "abort-controller";
+import { BatchQuery } from "../BatchQuery";
 
 const log = logger("rpc");
 
@@ -16,23 +17,11 @@ export type RpcDispatcherMixin = GConstructor<RpcDispatcher>;
 
 export async function sendQuery<TResponse>(
   url: string,
-  query: Query<unknown[], TResponse>,
+  query: Query<JsonRpcParams, TResponse>,
   config: RpcConfig = {}
 ): Promise<RPCResponse<TResponse>> {
   log.info(`RPC: ${url} executing Query[${query.method}]`);
-  const fetchConfig: RequestInit = {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(query.export()),
-  };
-
-  if (config.timeout) {
-    const timeoutController = new AbortController();
-    setTimeout(() => timeoutController.abort(), config.timeout);
-    fetchConfig.signal = timeoutController.signal;
-  }
+  const fetchConfig = _createFetchReq(query.export(), config);
   const response = await fetch(url, fetchConfig);
 
   if (response.ok) {
@@ -41,6 +30,49 @@ export async function sendQuery<TResponse>(
   throw new Error(
     `Encountered HTTP code ${response.status} while executing Query[${query.method}]`
   );
+}
+
+async function sendBatch<
+  TParams extends JsonRpcParams[],
+  TResponses extends unknown[]
+>(
+  url: string,
+  batch: BatchQuery<TParams, TResponses>,
+  config: RpcConfig = {}
+): Promise<RPCResponse<unknown>[]> {
+  const fetchConfig = _createFetchReq(
+    batch.queries.map((q) => q.export()),
+    config
+  );
+
+  const response = await fetch(url, fetchConfig);
+
+  if (response.ok) {
+    return response.json();
+  }
+  throw new Error(
+    `Encountered HTTP code ${
+      response.status
+    } while executing Query[${batch.queries.map((q) => q.method).join(",")}]`
+  );
+}
+
+function _createFetchReq(body: object, config: RpcConfig): RequestInit {
+  const fetchConfig: RequestInit = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  };
+
+  if (config.timeout) {
+    const timeoutController = new AbortController();
+    setTimeout(() => timeoutController.abort(), config.timeout);
+    fetchConfig.signal = timeoutController.signal;
+  }
+
+  return fetchConfig;
 }
 
 /**
@@ -70,7 +102,7 @@ export class RpcDispatcher {
    * Takes an Query object and executes it. Throws if error is encountered.
    */
   public async execute<TResponse>(
-    query: Query<unknown[], TResponse>,
+    query: Query<JsonRpcParams, TResponse>,
     config?: RpcConfig
   ): Promise<TResponse> {
     const rpcResponse = await sendQuery(this.url, query, config ?? {});
@@ -78,6 +110,34 @@ export class RpcDispatcher {
       throw new RpcError(rpcResponse.error);
     }
     return rpcResponse.result;
+  }
+
+  /**
+   * Takes an array of Queries and executes them.
+   * Throws if any of the queries encounters an error.
+   * @param batchQuery - Array of queries wrapped in BatchQuery
+   * @param config - Configuration to apply to the RPC call
+   * @returns
+   */
+  public async batch<
+    TParams extends JsonRpcParams[],
+    TResponses extends unknown[]
+  >(
+    batchQuery: BatchQuery<TParams, TResponses>,
+    config?: RpcConfig
+  ): Promise<TResponses> {
+    const responses = await sendBatch(this.url, batchQuery, config ?? {});
+    if (responses.some((r) => r.error)) {
+      const allErrs: Record<string, RPCErrorResponse> = {};
+
+      responses.forEach((r, idx) => {
+        if (r.error) {
+          allErrs[`query[${idx}]`] = r.error;
+        }
+      });
+      throw new RpcError({ code: -1, message: JSON.stringify(allErrs) });
+    }
+    return responses.map((r) => r.result) as TResponses;
   }
 }
 

--- a/packages/neon-core/src/rpc/index.ts
+++ b/packages/neon-core/src/rpc/index.ts
@@ -4,3 +4,4 @@ export * from "./Query";
 export * from "./RPCClient";
 export * from "./parse";
 export * from "./clients";
+export * from "./BatchQuery";


### PR DESCRIPTION
BatchQuery allows for an array of jsonrpc calls to be sent over a single rpc call instead of trying to join them together. The batching mechanism is designed with the type system so that the return values are correctly typed. However, this means that the system is forced to throw when any error occurs.
If your request has a danger of failing, use the `sendQueryList` method directly as it does not handle the typing or response unwrapping.

- Add BatchQuery
- Add RpcDispatcher.executeAll and sendQueryList methods