### PR TITLE
chore(docs): fix code samples/docs

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,8 +29,8 @@ beyond 2 levels, the rest of the name is camelCased at the noun level.
 ```js
 import Neon from "@cityofzion/neon-js";
 Neon.create.privateKey();
-Neon.serialize.tx(transactionObj);
-Neon.get.publicKeyFromPrivateKey(privateKey);
+Neon.deserialize.tx(serializedTransaction);
+Neon.verify.message(message, signature, publicKey)
 ```
 
 This style is recommended for beginners or anyone who just wishes to use Neon

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -8,7 +8,7 @@ different functionality.
 
 ## Core
 
-The core package is `neon-core`, comprising of the following folders:
+The core package is `neon-core`, comprised of the following folders:
 
 - `rpc`
 - `sc`
@@ -17,16 +17,13 @@ The core package is `neon-core`, comprising of the following folders:
 - `wallet`
 
 These are the minimum packages deemed necessary for basic functionality for
-interaction with the blockchain. Two other sub modules, `CONST` and `settings`
-round off the core module with some defaults.
+interaction with the blockchain. The sub module `CONST` rounds off the core module with some defaults.
 
 For users who just require the bare functionality, you may just use the core
 package:
 
 ```js
-import { tx, wallet, settings } from "@cityofzion/neon-core";
+import { tx, wallet } from "@cityofzion/neon-core";
 const t = new tx.Transaction();
 const acct = new wallet.Account();
-
-console.log(settings.networks); // {} (empty object as there are no defaults)
 ```


### PR DESCRIPTION
close #824 
part of #826

I tested the code in the guides and that all looks fine. That leaves the small edits in this PR. Note that `settings` was removed with #755 

Since I've always been fighting the import system the old code might still be valid, but not with what I'm seeing locally which is why I updated the code snippet in `overview.md`

![image](https://user-images.githubusercontent.com/6625537/155702525-0a35d256-b3b9-4a3c-a612-ab639b1a56bc.png)
