### PR TITLE
chore(ci): Update default to Node14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
         description: "Node version"
         type: enum
         enum: ["12-stretch", "14-stretch", "16-stretch"]
-        default: "12-stretch"
+        default: "14-stretch"
     working_directory: ~/repo
     docker:
       - image: circleci/node:<< parameters.version >>
@@ -18,7 +18,7 @@ executors:
         description: "Node version"
         type: enum
         enum: ["12-stretch", "14-stretch", "16-stretch"]
-        default: "12-stretch"
+        default: "14-stretch"
     working_directory: ~/repo
     docker:
       - image: circleci/node:<< parameters.version >>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2010,6 +2010,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash-es@^4.17.4":
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.6.tgz#c2ed4c8320ffa6f11b43eb89e9eaeec65966a0a0"
+  integrity sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.179"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.179.tgz#490ec3288088c91295780237d2497a3aa9dfb5c5"
+  integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
+
 "@types/lodash@4.14.178":
   version "4.14.178"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
@@ -5638,6 +5650,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash-es@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Update the default env to Node14 since v12 is EOL in ~1 month. This does not remove v12 support but merely defaults all our CI env to Node14. Tests will still run on Node12.

Fix #827