### PR TITLE
fix(rpc): fix wrong type for ApplicationLogJson

### DIFF
--- a/packages/neon-core/src/rpc/Query.ts
+++ b/packages/neon-core/src/rpc/Query.ts
@@ -5,7 +5,6 @@ import {
   ContractParam,
   StackItemJson,
   NEFJson,
-  ContractParamJson,
 } from "../sc";
 import { BlockJson, Validator, BlockHeaderJson } from "../types";
 import { HexString } from "../u";
@@ -42,7 +41,7 @@ export interface ApplicationLogJson {
     notifications: {
       contract: string;
       eventname: string;
-      state: ContractParamJson;
+      state: StackItemJson;
     }[];
   }[];
 }


### PR DESCRIPTION
Reported by Discord user @vzin777

the `state` field of notifications are StackItems not Contract parameters. 
![image](https://user-images.githubusercontent.com/6625537/179191941-4e787bf9-a26e-4e87-a58b-04046b8176cf.png)

![image](https://user-images.githubusercontent.com/6625537/179191731-b950ed0d-9076-475f-88b4-fd1c96697a1a.png)
 