### PR TITLE
fix(docs): update core docs

### DIFF
--- a/docs/api/core/const.md
+++ b/docs/api/core/const.md
@@ -7,11 +7,10 @@ Constants are defined and exposed as:
 
 ```ts
 import Neon from "@cityofzion/neon-js";
-const assets = Neon.CONST.ASSETS;
-const defaultRPC = Neon.CONST.DEFAULT_RPC;
+const nativeContractHashes = Neon.CONST.NATIVE_CONTRACT_HASH;
 
 import { CONST } from "@cityofzion/neon-js";
-const rpcVersion = CONST.RPC_VERSION;
+const addrVersion = CONST.DEFAULT_ADDRESS_VERSION;
 ```
 
 Do refer to the source code for all the constants available.

--- a/docs/api/core/logging.md
+++ b/docs/api/core/logging.md
@@ -7,11 +7,11 @@ The logging module is exposed only as a named import :
 
 ```ts
 import { logging } from "@cityofzion/neon-js";
-logging.logger.setAll("info"); // sets logging level of neon-js to 'info'
+logging.logger.setDefaultLevel("info"); // sets logging level of neon-js to 'info'
 const apiLogger = logging.logger.getLogger("api"); // gets the logger for the api package
 apiLogger.setLevel("warn"); // sets logging level only on the logger for the api package
 ```
 
 All logs are piped towards `stdout` and `stderr`. Each named package within
 `neon-js` will have its own logger. The initial setting for all loggers is
-'slient'.
+'silent'.

--- a/docs/api/core/rpc.md
+++ b/docs/api/core/rpc.md
@@ -8,7 +8,7 @@ The `rpc` module is exposed as:
 ```js
 import Neon, { rpc } from "@cityofzion/neon-js";
 const client = Neon.create.rpcClient(URL);
-const alternative = new rpc.rpcClient(URL);
+const alternative = new rpc.RPCClient(URL);
 ```
 
 This module contains the classes and interfaces to interact with the RPC
@@ -43,7 +43,7 @@ const alternative = new rpc.RPCClient("http://seed1.neo.org:10332");
 // Returns block number
 client.getBlockCount();
 client.getRawTransaction(
-  "f5412dba662ec8023e6fc93dba23e7b62679e0a7bebed52a0c3f70795cbb51d2",
+  "88c302bd409cbb3940f6d13e5624f832eb769e346b28afcb79e05cfd13a68fec",
   1
 );
 
@@ -142,6 +142,5 @@ interface ProtocolJSON {
   AddressVersion: number;
   StandbyValidators: string[];
   SeedList: string[];
-  SystemFee: { [key: string]: number };
 }
 ```

--- a/docs/api/core/tx.md
+++ b/docs/api/core/tx.md
@@ -22,14 +22,6 @@ processed into a block by the consensus nodes.
 // We can use this serializedTx string and send it through sendrawtransaction RPC call.
 const serializedTx = transaction.serialize();
 ```
-
-For deserialization, we have the `Transaction` static class:
-
-```js
-const transaction = tx.Transaction.deserialize(hexstring);
-console.log(transaction instanceof tx.Transaction); // true
-```
-
 ---
 
 ## Components

--- a/docs/api/core/tx.md
+++ b/docs/api/core/tx.md
@@ -6,154 +6,54 @@ title: Transactions
 The `tx` module is exposed as:
 
 ```ts
-import Neon, { tx } from "@cityofzion/neon-js";
-let transaction = Neon.create.claimTx(...args);
-transaction.addIntent(intent).addRemark("hi").sign(privateKey);
-console.log(transaction.hash);
-
-let claimTx = new tx.ClaimTransaction(...args);
-let invokeTx = new tx.InvocationTransaction();
+import { tx, wallet } from "@cityofzion/neon-js";
+const acct = new wallet.Account();
+const transaction = new tx.Transaction();
+transaction.addSigner(new tx.Signer({ account: acct.scriptHash }));
+transaction.sign(acct);
+console.log(transaction.hash());
 ```
 
 Transactions form the core of the interaction with the blockchain. In order to
 effect any state changes on the chain, a transaction is required to be sent and
 processed into a block by the consensus nodes.
 
----
-
-## Classes
-
-### Transaction
-
-The family of Transaction classes are wrappers to easily manipulate and build
-transactions. The base abstract class is `BaseTransaction`. Each supported
-transaction type has its own class which allows retrieval of specific data
-through property fields.
-
-The current supported transaction types are:
-
-1. ContractTransaction (used for transferring UTXO assets)
-2. ClaimTransaction (used for claiming GAS from NEO transfers)
-3. InvocationTransaction (used for smart contract invocation)
-4. StateTransaction (used for voting)
-
 ```js
-import Neon from "@cityofzion/neon-js";
-// Let us create a ContractTransaction
-let tx = Neon.create.contractTx();
-// Now let us add an intention to send 1 NEO to someone
-tx.addIntent("NEO", 1, someAddress)
-  .addRemark("I am sending 1 NEO to someAddress") // Add an remark
-  .calculate(balance) // Now we add in the balance we retrieve from an external API and calculate the required inputs.
-  .sign(privateKey); // Sign with the private key of the balance
-
-const hash = tx.hash; // Store the hash so we can use it to query a block explorer.
-
-// Now we can use this serializedTx string and send it through sendrawtransaction RPC call.
-const serializedTx = tx.serialize();
+// We can use this serializedTx string and send it through sendrawtransaction RPC call.
+const serializedTx = transaction.serialize();
 ```
 
 For deserialization, we have the `Transaction` static class:
 
 ```js
-const contractTx = Neon.tx.Transaction.deserialize(hexstring);
-console.log(contractTx instanceof Neon.tx.ContractTransaction); // true
+const transaction = tx.Transaction.deserialize(hexstring);
+console.log(contractTx instanceof tx.ContractTransaction); // true
 ```
 
-## Methods
+---
 
-### Components
+## Components
 
 Transactions are composed of the following parts:
 
-1. Type
-
-This determines the transaction type. This determines how the transaction is
-serialized or deserialized.
-
-2. Version
+1. Version
 
 This determines the version of the transaction. Protocol may defer for different
 versions.
 
-3. Attribute
-
-Extra attributes that are attached to the transaction. An example is a Remark.
-
-4. Input
-
-The inputs of the transaction. This is the assets being 'spent' by this
-transaction. System fees are also included here. Inputs are considered 'spent'
-after the transaction is processed.
-
-5. Output
-
-The outputs of the transaction. This indicates the unspent assets created by
-this transaction. These outputs are 'unspent' and can be referenced as inputs in
-future transactions.
-
-6. Witness
+2. Witnesses
 
 The witnesses to the transaction. These are the signatures to authorise the
 transaction. Usually the private key of the owner of the input assets is used to
-generate the signature. Do note that although this component is named `Witness`,
-its key in the Transaction object is `scripts` (we try to keep to the original
-names as described in the C# repo).
+generate the signature.
 
-7. Exclusive Data (unique to each transaction type)
+3. Signers
 
-Various data required for each transaction. For example, a ClaimTransaction will
-have the `claims` field which contains all claimable transactions. An
-InvocationTransaction will have the `script` field instead for smart contract
-invocation.
+The signers control the validity of the signatures and can be checked in smart contracts using the `CheckWitness`
+functionality. A good article on how they work and can be used can be read here https://neospcc.medium.com/thou-shalt-check-their-witnesses-485d2bf8375d
+The first signer is also known as the `sender` and will pay for the transaction fees.
 
-## Calculation Strategies
+4. Attributes
 
-You may specify the calculation strategy used when calculating inputs. The
-strategy determines how inputs are chosen to meet the intents. For example, in a
-wallet with inputs of 1,2,3,4 and 5 NEO, there are many ways to fill an intent
-of 3 NEO. We can either fill it exactly with the 5 NEO input, or choose to use
-the smallest possible inputs so as to slowly consolidate our coins.
-
-Currently, the only way to do that is to set the default strategy in settings.
-
-There are 3 strategies to choose from. They are:
-
-1. `balancedApproach`. This is the default strategy. It tried to find an single
-   input that matches the entire output. Failing that, it chooses the largest
-   possible input that fits within the output before filling the rest of the
-   requirement. Taking the example above, we will choose the 3 NEO coin
-   immediately as it fits the output exactly.
-
-2. `largestFirst`. As the name suggests, the intent is filled starting with the
-   largest input available. Here, we will choose the 5 NEO coin, constructing a
-   change output of 2 NEO.
-
-3. `smallestFirst`. We fill the intent starting with the smallest input
-   available. We will choose the inputs 1 and 2 NEO to fill the intent fo 3 NEO.
-
-```js
-import { settings, tx } from "@cityofzion/neon-js";
-
-settings.defaultCalculationStrategy = tx.calculationStrategy.smallestFirst;
-```
-
-## Fees
-
-Attaching fees is supported as the last argument in both creating transactions
-and also calculating. Fees work by having more GAS inputs than outputs. The
-difference between the inputs and the outputs are taken as fees. Fees first
-contribute towards system fees (eg. transaction costs, etc). Any excess will be
-considered as network fees and are used to prioritise transactions.
-
-In the case of InvocationTransactions, the fees paid for running the smart
-contract is indicated by a separate field. So there are 3 fees available in
-InvocationTransactions: smart contract execution fees, system fees and network
-fees. Do note they are separate so any excess fees paid towards running the
-smart contract will not spill into system or network fees.
-
-```js
-// This attaches a fee of 1 GAS.
-var newTx = new tx.ContractTransaction();
-newTx.addIntent({}).calculate(balance, null, 1);
-```
+Extra attributes that are attached to the transaction. An example is a OracleResponse.
+Attributes can only be set by special entities in the system (being the consensus committee or an Oracle node).

--- a/docs/api/core/tx.md
+++ b/docs/api/core/tx.md
@@ -27,7 +27,7 @@ For deserialization, we have the `Transaction` static class:
 
 ```js
 const transaction = tx.Transaction.deserialize(hexstring);
-console.log(contractTx instanceof tx.ContractTransaction); // true
+console.log(transaction instanceof tx.Transaction); // true
 ```
 
 ---

--- a/docs/api/core/wallet.md
+++ b/docs/api/core/wallet.md
@@ -6,12 +6,12 @@ title: Wallet
 The `wallet` module is exposed as:
 
 ```js
-import Neon, { wallet } from "@cityofzion/neon-js";
+import Neon, { wallet, CONST } from "@cityofzion/neon-js";
 const account = Neon.create.account(privateKey);
 const alternative = new wallet.Account(privateKey);
 
-Neon.is.address(string);
-wallet.isAddress(string);
+Neon.is.address(string, CONST.DEFAULT_ADDRESS_VERSION);
+wallet.isAddress(string, CONST.DEFAULT_ADDRESS_VERSION);
 ```
 
 The `wallet` module contains methods for manipulating keys, creating signatures
@@ -45,8 +45,8 @@ It can be instantiated with any key format and is smart enough to recognise the
 format and store it appropriately.
 
 ```js
-const a = Neon.create.Account("ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s");
-console.log(a.address); // ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s
+const a = Neon.create.Account("NNtxeX9UhKfHySqPQ29hQnZe22k8LwcFk1");
+console.log(a.address); // NNtxeX9UhKfHySqPQ29hQnZe22k8LwcFk1
 
 const b = new wallet.Account(
   "9ab7e154840daca3a2efadaf0df93cd3a5b51768c632f5433f86909d9b994a69"
@@ -104,90 +104,6 @@ c.encrypt("new password").then(() => c.export());
 
 This action will encrypt the private key with the provided password and replace
 any old NEP2 key.
-
-### Balance
-
-```ts
-class Balance {
-  constructor(bal?: Balance);
-
-  address: string;
-  net: "MainNet" | "TestNet";
-  assetSymbols: string[];
-  assets: { [index: string]: AssetBalance };
-  tokenSymbols: string[];
-  tokens: { [index: string]: number };
-
-  static import(jsonString: string): Balance;
-
-  addAsset(sym: string, assetBalance?: AssetBalance): this;
-  addToken(sym: string, tokenBalance?: number | Fixed8): this;
-  applyTx(tx: Transaction, confirmed?: boolean): this;
-  export(): string;
-  verifyAssets(url: string): Promise<Balance>;
-}
-```
-
-The Balance class stores the balance of the account. It is usually retrieved
-using a 3rd party API as NEO nodes do not have a RPC call to easily retrieve
-this information with a single call.
-
-```js
-// This creates a balance object but it is empty and not really useful
-Neon.create.balance({
-  net: "TestNet",
-  address: "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
-});
-
-import { wallet } from "@cityofzion/neon-js";
-// This form is useless as it is an empty balance.
-const balance = new wallet.Balance({
-  net: "TestNet",
-  address: "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
-});
-
-// This contains all symbols of assets available in this balance
-const symbols = filledBalance.assetSymbols;
-// We retrieve the unspent coins from the assets object using the symbol
-const neoCoins = filledBalance.assets["NEO"].unspent;
-// We can verify the information retrieved using verifyAssets
-filledBalance.verifyAssets("https://seed1.neo.org:20332");
-```
-
-The class is used to track the unspent coins available to construct transactions
-with. `verifyAssets` is a handy method to make sure the unspent coins provided
-by the 3rd party API is really unspent by verifying them against a NEO node.
-However, this is an expensive operation so use sparingly.
-
-The constructor is a handy method to convert a Balance-like javascript object
-into a `neon-js` Balance.
-
-### Claims
-
-```ts
-class Claims {
-  constructor(claims?: Claims);
-
-  address: string;
-  net: string;
-  claims: ClaimItem[];
-}
-```
-
-The Claims class is a collection of claims data belonging to an account. It is
-usually retrieved from a 3rd part API. We do not recommend you craft your own
-Claims manually. This class is here for completeness in terms of high level
-objects.
-
-Like Balance, the constructor is the way to convert a Claims-like object into a
-`neon-js` Claims object. This is the primary method we use to convert the claims
-object we get from 3rd party API.
-
-NEO generates GAS when held. When NEO is spent, the gas that it generates is
-unlocked and made claimable through ClaimTransaction. The formula for calcuating
-the claim per transaction is:
-
-    claim = ((start - end) * 8 + sysfee) * value
 
 ### Wallet
 

--- a/docs/changelog/v5.md
+++ b/docs/changelog/v5.md
@@ -14,6 +14,8 @@ sidebar_position: 1
 - experimental
   - Deprecate localized `calculateNetworkFee` which can't handle forks in favour of `smartCalculateNetworkFee` which uses the RPC node.
   - Update `addFees()` to use `prioritisationFee` of `CommonConfig` if specified.
+- misc
+  - Update core documentation.
 
 # 5.1.0
 


### PR DESCRIPTION
Yesterday somebody pointed out that the core docs where not completely up to date either. I updated all of them except for the `tx.md` one (more on this later). The goal was to make all samples and text valid again. I updated wallet addresses and transaction id, hashes and such to point valid Neo3 values

As for `tx.md` I'm not sure what would be valuable content. The majority of it now describes the different transactions we had in Neo2. Stuff like this are no longer a thing
```
Neon.create.claimTx(...args);
```

 The only functions we could describe are `addWitness`, `addSigner` and maybe `(de)serialize`. `addAttribute` exists but is obsolete NEO2 stuff.