### PR TITLE
fix(tx): fix WitnessRule and WitnessCondition deserialization

### DIFF
--- a/docs/changelog/v5.md
+++ b/docs/changelog/v5.md
@@ -4,6 +4,12 @@ slug: latest
 sidebar_label: Latest (v5)
 sidebar_position: 1
 ---
+# 5.2.1
+- tx
+  - Fix `WitnessRule` type deserialization.
+  - Fix `BooleanWitnessCondition` deserialization for `false` values.
+  - Fix `AndWitnessCondition` deserialization.
+  - Add test cases for WitnessCondition deserialization.
 
 # 5.2.0
 

--- a/packages/neon-core/__tests__/tx/components/WitnessCondition.ts
+++ b/packages/neon-core/__tests__/tx/components/WitnessCondition.ts
@@ -1,7 +1,11 @@
 import {
   AndWitnessCondition,
   BooleanWitnessCondition,
+  CalledByContractWitnessCondition,
+  CalledByGroupWitnessCondition,
   GroupWitnessCondition,
+  NotWitnessCondition,
+  OrWitnessCondition,
   ScriptHashWitnessCondition,
   WitnessCondition,
   WitnessConditionJson,
@@ -54,5 +58,84 @@ describe("static", () => {
     const serialized = result.serialize();
 
     expect(serialized).toEqual(bytes);
+  });
+});
+
+describe("deserialization", () => {
+  test("and condition", () => {
+    const bytes = "020200010000";
+    const result = WitnessCondition.deserialize(new StringStream(bytes));
+    expect(result.type).toBe(WitnessConditionType.And);
+    const castedResult = result as AndWitnessCondition;
+    expect(castedResult.expressions.length).toBe(2);
+
+    expect(castedResult.expressions[0].type).toBe(WitnessConditionType.Boolean);
+    const castedExpr1 = castedResult.expressions[0] as BooleanWitnessCondition;
+    expect(castedExpr1.expression).toBe(true);
+
+    expect(castedResult.expressions[1].type).toBe(WitnessConditionType.Boolean);
+    const castedExpr2 = castedResult.expressions[1] as BooleanWitnessCondition;
+    expect(castedExpr2.expression).toBe(false);
+  });
+
+  test("bool condition", () => {
+    const bytes = "0001";
+    const result = WitnessCondition.deserialize(new StringStream(bytes));
+    expect(result.type).toBe(WitnessConditionType.Boolean);
+    const castedResult = result as BooleanWitnessCondition;
+    expect(castedResult.expression).toBe(true);
+  });
+
+  test("not condition", () => {
+    const bytes = "010001";
+    const result = WitnessCondition.deserialize(new StringStream(bytes));
+    expect(result.type).toBe(WitnessConditionType.Not);
+    const castedResult = result as NotWitnessCondition;
+    expect(castedResult.expression).toBeInstanceOf(BooleanWitnessCondition);
+    const boolCondition = castedResult.expression as BooleanWitnessCondition;
+    expect(boolCondition.expression).toBe(true);
+  });
+
+  test("or condition", () => {
+    const bytes = "030200010000";
+    const result = WitnessCondition.deserialize(new StringStream(bytes));
+    expect(result.type).toBe(WitnessConditionType.Or);
+    const castedResult = result as OrWitnessCondition;
+    expect(castedResult.expressions.length).toBe(2);
+
+    expect(castedResult.expressions[0].type).toBe(WitnessConditionType.Boolean);
+    const castedExpr1 = castedResult.expressions[0] as BooleanWitnessCondition;
+    expect(castedExpr1.expression).toBe(true);
+
+    expect(castedResult.expressions[1].type).toBe(WitnessConditionType.Boolean);
+    const castedExpr2 = castedResult.expressions[1] as BooleanWitnessCondition;
+    expect(castedExpr2.expression).toBe(false);
+  });
+
+  test("CalledByContract condition", () => {
+    const bytes = "28e462182f173259281896e95bd8bb851435989e48";
+    const result = WitnessCondition.deserialize(new StringStream(bytes));
+    expect(result.type).toBe(WitnessConditionType.CalledByContract);
+    const castedResult = result as CalledByContractWitnessCondition;
+    expect(castedResult.hash.toString()).toBe(
+      "489e98351485bbd85be99618285932172f1862e4"
+    );
+  });
+
+  test("CalledByEntry condition", () => {
+    const bytes = "20";
+    const result = WitnessCondition.deserialize(new StringStream(bytes));
+    expect(result.type).toBe(WitnessConditionType.CalledByEntry);
+  });
+
+  test("CalledByGroup condition", () => {
+    const bytes =
+      "2902158c4a4810fa2a6a12f7d33d835680429e1a68ae61161c5b3fbc98c7f1f17765";
+    const result = WitnessCondition.deserialize(new StringStream(bytes));
+    expect(result.type).toBe(WitnessConditionType.CalledByGroup);
+    const castedResult = result as CalledByGroupWitnessCondition;
+    expect(castedResult.group.toString()).toBe(
+      "02158c4a4810fa2a6a12f7d33d835680429e1a68ae61161c5b3fbc98c7f1f17765"
+    );
   });
 });

--- a/packages/neon-core/src/tx/components/WitnessCondition.ts
+++ b/packages/neon-core/src/tx/components/WitnessCondition.ts
@@ -92,7 +92,7 @@ export abstract class WitnessCondition implements NeonSerializable {
   public static deserialize(ss: StringStream): WitnessCondition {
     const rawType = parseInt(ss.peek(1), 16);
     const witnessType = parseEnum(rawType, WitnessConditionType);
-    const implementingClass = this.getImplementation(witnessType);
+    const implementingClass = WitnessCondition.getImplementation(witnessType);
     return implementingClass.deserialize(ss);
   }
 
@@ -136,7 +136,7 @@ export class BooleanWitnessCondition extends WitnessCondition {
   }
   public static deserialize(ss: StringStream): BooleanWitnessCondition {
     readAndAssertType(ss, this._type);
-    const expression = !!ss.read(1);
+    const expression = ss.read(1) === "01";
     return new BooleanWitnessCondition(expression);
   }
 

--- a/packages/neon-core/src/tx/components/WitnessRule.ts
+++ b/packages/neon-core/src/tx/components/WitnessRule.ts
@@ -28,7 +28,7 @@ export class WitnessRule implements NeonSerializable {
   }
 
   public static deserialize(ss: StringStream): WitnessRule {
-    const action = parseEnum(ss.read(1), WitnessRuleAction);
+    const action = parseEnum(parseInt(ss.read(1), 16), WitnessRuleAction);
     const condition = WitnessCondition.deserialize(ss);
     return new WitnessRule({ action, condition });
   }


### PR DESCRIPTION
fixes https://github.com/CityOfZion/neon-js/issues/872
* `WitnessRule` deserialization failed because the type had to be converted to int first
* `BooleanAndCondition` deserialization failed because `!!"00"` evaluated to `true` not `false`.
* `AndCondition` deserialization failed because `this` was undefined when called here
https://github.com/CityOfZion/neon-js/blob/7eb101aa22d92df1bf50a0e0b7e43b2c43f0ecd6/packages/neon-core/src/tx/components/WitnessCondition.ts#L95
