### PR TITLE
CU-864ekh1aw - new Account of NeonJS needs to accept '0x' and remove it if necessary

### DIFF
--- a/packages/neon-core/__tests__/u/basic/hex.ts
+++ b/packages/neon-core/__tests__/u/basic/hex.ts
@@ -1,4 +1,4 @@
-import { reverseHex } from "../../../src/u/basic/hex";
+import { remove0xPrefix, reverseHex } from "../../../src/u/basic/hex";
 
 describe("reverseHex", () => {
   test("throws if not hexstring", () => {
@@ -9,5 +9,11 @@ describe("reverseHex", () => {
     const input = "000102030405060708090a0b0c0d0e0f";
     const result = reverseHex(input);
     expect(result).toBe("0f0e0d0c0b0a09080706050403020100");
+  });
+
+  test("Remove 0x prefix", () => {
+    const input = "0x000102030405060708090a0b0c0d0e0f";
+    const result = remove0xPrefix(input);
+    expect(result).toBe("000102030405060708090a0b0c0d0e0f");
   });
 });

--- a/packages/neon-core/__tests__/wallet/Account.ts
+++ b/packages/neon-core/__tests__/wallet/Account.ts
@@ -26,6 +26,13 @@ describe("constructor", () => {
     expect(result.address).toBe("NMBfzaEq2c5zodiNbLPoohVENARMbJim1r");
   });
 
+  test("script hash with 0x", () => {
+    const result = new Account("0x118ba6f59931a56ec469770f7fc790ece96df00d");
+    expect(result instanceof Account).toBeTruthy();
+    expect(result.address).toBe("NMBfzaEq2c5zodiNbLPoohVENARMbJim1r");
+    expect(result.scriptHash).toBe("118ba6f59931a56ec469770f7fc790ece96df00d");
+  });
+
   test("custom address version", () => {
     const result = new Account(
       "L2QTooFoDFyRFTxmtiVHt5CfsXfVnexdbENGDkkrrgTTryiLsPMG",

--- a/packages/neon-core/__tests__/wallet/verify.ts
+++ b/packages/neon-core/__tests__/wallet/verify.ts
@@ -40,12 +40,12 @@ describe("Verify: Valid", () => {
     expect(verify.isPublicKey(i, false)).toBeTruthy();
   });
 
-  test.each(["0000000000000000000000000000000000000000"])(
-    "ScriptHash: %s",
-    (i: string) => {
-      expect(verify.isScriptHash(i)).toBeTruthy();
-    }
-  );
+  test.each([
+    "0000000000000000000000000000000000000000",
+    "0x0000000000000000000000000000000000000000",
+  ])("ScriptHash: %s", (i: string) => {
+    expect(verify.isScriptHash(i)).toBeTruthy();
+  });
 
   test.each([
     "NQ9NEvVrutLL6JDtUMKMrkEG6QpWNxgNBM",

--- a/packages/neon-core/src/u/basic/hex.ts
+++ b/packages/neon-core/src/u/basic/hex.ts
@@ -1,6 +1,17 @@
 const hexRegex = /^([0-9A-Fa-f]{2})*$/;
 
 /**
+ * Format a hexstring to a supported format.
+ */
+export function remove0xPrefix(str: string): string {
+  if (str.startsWith("0x")) {
+    str = str.substring(2);
+  }
+
+  return str;
+}
+
+/**
  * Checks if input is a hexstring. Empty string is considered a hexstring.
  */
 export function isHex(str: string): boolean {

--- a/packages/neon-core/src/wallet/Account.ts
+++ b/packages/neon-core/src/wallet/Account.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_SCRYPT,
 } from "../consts";
 import logger from "../logging";
-import { hash160, HexString, reverseHex } from "../u";
+import { remove0xPrefix, hash160, HexString, reverseHex } from "../u";
 import { isMultisigContract } from "../sc";
 import * as core from "./core";
 import { constructMultiSigVerificationScript } from "./multisig";
@@ -138,7 +138,7 @@ export class Account implements NeonObject<AccountJSON> {
     } else if (isPublicKey(str, true)) {
       this._publicKey = str;
     } else if (isScriptHash(str)) {
-      this._scriptHash = str;
+      this._scriptHash = remove0xPrefix(str);
     } else if (isAddress(str)) {
       this._address = str;
       const addressVersionFromAddress = core.getAddressVersion(str);

--- a/packages/neon-core/src/wallet/verify.ts
+++ b/packages/neon-core/src/wallet/verify.ts
@@ -9,7 +9,7 @@
  */
 
 import base58 from "bs58";
-import { ab2hexstring, hash256, isHex, reverseHex } from "../u";
+import { ab2hexstring, remove0xPrefix, hash256, isHex, reverseHex } from "../u";
 import {
   getAddressFromScriptHash,
   getPublicKeyEncoded,
@@ -107,7 +107,8 @@ export function isPublicKey(key: string, encoded?: boolean): boolean {
  * Verifies if string is a scripthash. Any 20 byte hexstring is a valid scriptHash.
  */
 export function isScriptHash(scriptHash: string): boolean {
-  return isHex(scriptHash) && scriptHash.length === 40;
+  const formattedScriptHash = remove0xPrefix(scriptHash);
+  return isHex(formattedScriptHash) && formattedScriptHash.length === 40;
 }
 
 /**


### PR DESCRIPTION
This PR is important to avoid problems when passing `0x` on the scripthash to create a new Account.
It seems unecessary at first but this constructor is being used by other libraries that tries to convert different kinds of input to an Address or ScriptHash.