### PR TITLE
fix(sc): support emitting Maps in ScriptBuilder

### DIFF
--- a/packages/neon-core/__tests__/sc/ScriptBuilder.ts
+++ b/packages/neon-core/__tests__/sc/ScriptBuilder.ts
@@ -103,6 +103,14 @@ describe("emitPush", () => {
     ],
     ["ContractParam(integer) -1", ContractParam.integer(-1), "0f"],
     ["ContractParam(integer) -12345", ContractParam.integer(-12345), "01c7cf"],
+    [
+      "ContractParam(map) {1: 2}",
+      ContractParam.map({
+        key: ContractParam.integer(1),
+        value: ContractParam.integer(2),
+      }),
+      "121111be",
+    ],
   ] as [string, ContractParam | string | boolean | number, string][])(
     "%s",
     (

--- a/packages/neon-core/__tests__/sc/ScriptBuilder.ts
+++ b/packages/neon-core/__tests__/sc/ScriptBuilder.ts
@@ -214,6 +214,14 @@ describe("emitContractParam", () => {
       ContractParam.string("hello world"),
       "0c0b68656c6c6f20776f726c64",
     ],
+    [
+      "ContractParam(map)",
+      ContractParam.map({
+        key: ContractParam.integer(1),
+        value: ContractParam.integer(2),
+      }),
+      "121111be",
+    ],
   ])("%s", (_msg: string, data: ContractParam, expected: string) => {
     const result = new ScriptBuilder().emitContractParam(data).build();
     expect(result).toBe(expected);

--- a/packages/neon-core/src/sc/ScriptBuilder.ts
+++ b/packages/neon-core/src/sc/ScriptBuilder.ts
@@ -8,6 +8,7 @@ import {
 } from "../u";
 import {
   ContractParam,
+  ContractParamMap,
   ContractParamType,
   likeContractParam,
 } from "./ContractParam";
@@ -120,6 +121,26 @@ export class ScriptBuilder extends StringStream {
       this.emitPush(arr[i]);
     }
     return this.emitNumber(arr.length).emit(OpCode.PACK);
+  }
+
+  /**
+   * Private method to append a map
+   */
+  private emitMap(m: ContractParamMap): this {
+    for (let i = 0; i < m.length; i++) {
+      const keyType = m[i].key.type;
+      if (
+        keyType !== ContractParamType.Boolean &&
+        keyType !== ContractParamType.Integer &&
+        keyType !== ContractParamType.String
+      ) {
+        throw new Error(`Unsupported key type: ${keyType}`);
+      }
+      this.emitPush(m[i].value);
+      this.emitPush(m[i].key);
+    }
+    this.emitPush(m.length);
+    return this.emit(OpCode.PACKMAP);
   }
 
   /**
@@ -290,6 +311,8 @@ export class ScriptBuilder extends StringStream {
         return this.emitHexString(param.value as HexString);
       case ContractParamType.PublicKey:
         return this.emitPublicKey(param.value as HexString);
+      case ContractParamType.Map:
+        return this.emitMap(param.value as ContractParamMap);
       default:
         throw new Error(`Unaccounted ContractParamType!: ${param.type}`);
     }


### PR DESCRIPTION
close #909

- [x] validate `emitPush` on a `map` works as intended and is not consumed by https://github.com/CityOfZion/neon-js/blob/master/packages/neon-core/src/sc/ScriptBuilder.ts#L91-L92