### PR TITLE
fix(u): fix utf82base64 conversion method

### DIFF
--- a/docs/changelog/v5.md
+++ b/docs/changelog/v5.md
@@ -5,6 +5,10 @@ sidebar_label: Latest (v5)
 sidebar_position: 1
 ---
 
+# 5.5.2
+- u
+  - Fix incorrect parsing on `utf82base64` method.
+
 # 5.5.1
 - sc
   - Fix incorrect emitting of numbers in `ScriptBuilder`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "neon-js",
+  "name": "neon-js-simpli",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/neon-core/__tests__/u/basic/base64.ts
+++ b/packages/neon-core/__tests__/u/basic/base64.ts
@@ -1,19 +1,57 @@
-import { base642hex, hex2base64 } from "../../../src/u/basic/base64";
+import {
+  base642hex,
+  base642utf8,
+  hex2base64,
+  utf82base64,
+} from "../../../src/u/basic/base64";
 
-const testCases = [
+const hexBase64testCases = [
   ["4e454f", "TkVP"], // NEO
   ["6e656f", "bmVv"], // neo
   ["11", "EQ=="],
   ["41123e7fe8", "QRI+f+g="],
 ];
-describe("base64", () => {
-  test.each(testCases)("hex2base64 %s", (input: string, expected: string) => {
-    const result = hex2base64(input);
-    expect(result).toBe(expected);
-  });
+describe("hex and base64", () => {
+  test.each(hexBase64testCases)(
+    "hex2base64 %s",
+    (input: string, expected: string) => {
+      const result = hex2base64(input);
+      expect(result).toBe(expected);
+    }
+  );
 
-  test.each(testCases)("base642hex %s", (expected: string, input: string) => {
-    const result = base642hex(input);
-    expect(result).toBe(expected);
-  });
+  test.each(hexBase64testCases)(
+    "base642hex %s",
+    (expected: string, input: string) => {
+      const result = base642hex(input);
+      expect(result).toBe(expected);
+    }
+  );
+});
+
+const utf8Base64testCases = [
+  ["NEO", "TkVP"],
+  ["neo", "bmVv"],
+  ["neon-core", "bmVvbi1jb3Jl"],
+  [
+    "αβγδεζηθικλμνξοπρστυφχψω",
+    "zrHOss6zzrTOtc62zrfOuM65zrrOu868zr3Ovs6/z4DPgc+Dz4TPhc+Gz4fPiM+J",
+  ],
+];
+describe("utf8 and base64", () => {
+  test.each(utf8Base64testCases)(
+    "utf82base64 %s",
+    (input: string, expected: string) => {
+      const result = utf82base64(input);
+      expect(result).toBe(expected);
+    }
+  );
+
+  test.each(utf8Base64testCases)(
+    "base642utf8 %s",
+    (expected: string, input: string) => {
+      const result = base642utf8(input);
+      expect(result).toBe(expected);
+    }
+  );
 });

--- a/packages/neon-core/src/u/basic/base64.ts
+++ b/packages/neon-core/src/u/basic/base64.ts
@@ -9,7 +9,7 @@ export function base642hex(input: string): string {
 }
 
 export function utf82base64(input: string): string {
-  return enc.Utf8.stringify(enc.Base64.parse(input));
+  return enc.Base64.stringify(enc.Utf8.parse(input));
 }
 
 export function base642utf8(input: string): string {


### PR DESCRIPTION
Besides fixing the `utf82base64` method, I also added tests to the `utf82base64` and `base642utf8` methods