### PR TITLE
fix(deps): update crypto-js to 4.2.0

### DIFF
--- a/docs/changelog/v5.md
+++ b/docs/changelog/v5.md
@@ -10,6 +10,9 @@ sidebar_position: 1
   - Fix incorrect emitting of numbers in `ScriptBuilder`.
   - Add support for `Map` type in `emitContractParam` function.
 
+- Others
+  - Update crypto-js to 4.2.0
+
 # 5.5.0
 
 - wallet

--- a/package-lock.json
+++ b/package-lock.json
@@ -2660,9 +2660,9 @@
       }
     },
     "node_modules/@types/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-LW9TlhpMeoQKOu6I6HvOp7eInNNnvd7B+ndAfZb826HUl7eHJJApofbHnlAxrIVS/uiCjkkHGNEaKHoGxB5IHw==",
       "dev": true
     },
     "node_modules/@types/elliptic": {
@@ -4760,9 +4760,9 @@
       }
     },
     "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -13026,6 +13026,7 @@
       }
     },
     "packages/neon-api": {
+      "name": "@cityofzion/neon-api",
       "version": "5.4.0",
       "license": "MIT",
       "peerDependencies": {
@@ -13033,6 +13034,7 @@
       }
     },
     "packages/neon-core": {
+      "name": "@cityofzion/neon-core",
       "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
@@ -13040,7 +13042,7 @@
         "bs58": "5.0.0",
         "buffer": "6.0.3",
         "cross-fetch": "^3.1.5",
-        "crypto-js": "4.1.1",
+        "crypto-js": "4.2.0",
         "elliptic": "6.5.4",
         "ethereum-cryptography": "2.0.0",
         "lodash": "4.17.21",
@@ -13049,7 +13051,7 @@
       },
       "devDependencies": {
         "@types/bn.js": "5.1.1",
-        "@types/crypto-js": "4.1.1",
+        "@types/crypto-js": "4.2.0",
         "@types/elliptic": "6.4.14",
         "@types/lodash": "4.14.191"
       },
@@ -13081,6 +13083,7 @@
       }
     },
     "packages/neon-js": {
+      "name": "@cityofzion/neon-js",
       "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
@@ -13089,6 +13092,7 @@
       }
     },
     "packages/neon-ledger": {
+      "name": "@cityofzion/neon-ledger",
       "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
@@ -13115,6 +13119,7 @@
       }
     },
     "packages/neon-uri": {
+      "name": "@cityofzion/neon-uri",
       "version": "5.4.0",
       "license": "MIT",
       "peerDependencies": {

--- a/packages/neon-core/package.json
+++ b/packages/neon-core/package.json
@@ -43,7 +43,7 @@
     "bs58": "5.0.0",
     "buffer": "6.0.3",
     "cross-fetch": "^3.1.5",
-    "crypto-js": "4.1.1",
+    "crypto-js": "4.2.0",
     "elliptic": "6.5.4",
     "ethereum-cryptography": "2.0.0",
     "lodash": "4.17.21",
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@types/bn.js": "5.1.1",
-    "@types/crypto-js": "4.1.1",
+    "@types/crypto-js": "4.2.0",
     "@types/elliptic": "6.4.14",
     "@types/lodash": "4.14.191"
   },


### PR DESCRIPTION
There is already a [chore](https://github.com/CityOfZion/neon-js/pull/919) that is kinda doing this but since the docs and `types` on `package.json` should also be updated, I was instructed to create another PR with these other changes.

As to why this PR is changing only `crypto-js`, it's because it's the only dependency that is raising a severe vulnerability.
![image](https://github.com/CityOfZion/neon-js/assets/49196318/17de3795-9468-432f-9f73-50bcf6a90f04)