### PR TITLE
fix(sc): fix NEF's compiler field deserialization when occupying 64 bytes

### DIFF
--- a/docs/changelog/v5.md
+++ b/docs/changelog/v5.md
@@ -6,6 +6,8 @@ sidebar_position: 1
 ---
 
 # 5.5.2
+- sc
+  - Fix incorrect deserialization of NEF's compiler field when it occupies all 64 bytes available. 
 - u
   - Fix incorrect parsing on `utf82base64` method.
 - rpc

--- a/packages/neon-core/src/sc/NEF.ts
+++ b/packages/neon-core/src/sc/NEF.ts
@@ -80,7 +80,10 @@ export class NEF {
 
     const compilerHexArray = Buffer.from(reader.read(64), "hex");
     const idx = compilerHexArray.indexOf(0x0);
-    const compiler = compilerHexArray.slice(0, idx).toString();
+    const compiler =
+      idx === -1
+        ? compilerHexArray.toString()
+        : compilerHexArray.slice(0, idx).toString();
 
     const sourceSize = reader.readVarInt();
     if (sourceSize > 256)


### PR DESCRIPTION
Fixes https://github.com/CityOfZion/neon-js/issues/928