### PR TITLE
fix(docs): update changelog

### DIFF
--- a/docs/changelog/v5.md
+++ b/docs/changelog/v5.md
@@ -5,13 +5,13 @@ sidebar_label: Latest (v5)
 sidebar_position: 1
 ---
 
-# 5.5.2
+# 5.6.0
 - sc
-  - Fix incorrect deserialization of NEF's compiler field when it occupies all 64 bytes available. 
+  - Fix incorrect deserialization of NEF's compiler field when it occupies all 64 bytes available.
 - u
   - Fix incorrect parsing on `utf82base64` method.
 - rpc
-  - Add `findStorage` method.
+  - Add support for `findStorage` method.
 
 # 5.5.1
 - sc


### PR DESCRIPTION
Fixing changelog version as a new feature was introduced so the minor version should be updated not the patch version.