### PR TITLE
Added Static Method to Account Class for Key Validation

### DIFF
--- a/packages/neon-core/src/wallet/Account.ts
+++ b/packages/neon-core/src/wallet/Account.ts
@@ -29,7 +29,7 @@ export enum KeyType {
   Address = "Address",
   WIF = "WIF",
   NEP2 = "NEP2",
-  unknown = "",
+  Unknown = "",
 }
 
 export interface AccountJSON {
@@ -112,7 +112,7 @@ export class Account implements NeonObject<AccountJSON> {
       case isNEP2(str): return KeyType.NEP2;
       default:
         // returning empty string enables falsly checks
-        return KeyType.unknown;
+        return KeyType.Unknown;
     }
   }
 

--- a/packages/neon-core/src/wallet/Account.ts
+++ b/packages/neon-core/src/wallet/Account.ts
@@ -21,6 +21,16 @@ import { NeonObject } from "../model";
 
 const log = logger("wallet");
 
+export enum KeyType {
+  PrivateKey = "PrivateKey",
+  PublicKeyUnencoded = "PublicKeyUnencoded",
+  PublicKeyEncoded = "PublicKeyEncoded",
+  ScriptHash = "ScriptHash",
+  Address = "Address",
+  WIF = "WIF",
+  NEP2 = "NEP2",
+}
+
 export interface AccountJSON {
   /** Base58 encoded string */
   address: string;
@@ -88,17 +98,20 @@ export class Account implements NeonObject<AccountJSON> {
     });
   }
 
-  public static validateKey(str: string): string | void {
+
+
+  public static validateKey(str: string): string {
     switch (true) {
-      case isPrivateKey(str): return "PrivateKey";
-      case isPublicKey(str, false): return "PublicKey_Decoded";
-      case isPublicKey(str, true): return "PublicKey_Encoded"
-      case isScriptHash(str): return "ScriptHash"
-      case isAddress(str): "Address"
-      case isWIF(str): return "WIF";
-      case isNEP2(str): return "NEP2"
+      case isPrivateKey(str): return KeyType.PrivateKey;
+      case isPublicKey(str, false): return KeyType.PublicKeyUnencoded;
+      case isPublicKey(str, true): return KeyType.PublicKeyEncoded;
+      case isScriptHash(str): return KeyType.ScriptHash;
+      case isAddress(str): return KeyType.Address;
+      case isWIF(str): return KeyType.WIF;
+      case isNEP2(str): return KeyType.NEP2;
       default:
-        return;
+        // returning empty string enables falsly checks
+        return "";
     }
   }
 

--- a/packages/neon-core/src/wallet/Account.ts
+++ b/packages/neon-core/src/wallet/Account.ts
@@ -29,6 +29,7 @@ export enum KeyType {
   Address = "Address",
   WIF = "WIF",
   NEP2 = "NEP2",
+  unknown = "",
 }
 
 export interface AccountJSON {
@@ -100,7 +101,7 @@ export class Account implements NeonObject<AccountJSON> {
 
 
 
-  public static validateKey(str: string): string {
+  public static validateKey(str: string): KeyType {
     switch (true) {
       case isPrivateKey(str): return KeyType.PrivateKey;
       case isPublicKey(str, false): return KeyType.PublicKeyUnencoded;

--- a/packages/neon-core/src/wallet/Account.ts
+++ b/packages/neon-core/src/wallet/Account.ts
@@ -88,6 +88,20 @@ export class Account implements NeonObject<AccountJSON> {
     });
   }
 
+  public static validateKey(str: string): string | void {
+    switch (true) {
+      case isPrivateKey(str): return "PrivateKey";
+      case isPublicKey(str, false): return "PublicKey_Decoded";
+      case isPublicKey(str, true): return "PublicKey_Encoded"
+      case isScriptHash(str): return "ScriptHash"
+      case isAddress(str): "Address"
+      case isWIF(str): return "WIF";
+      case isNEP2(str): return "NEP2"
+      default:
+        return;
+    }
+  }
+
   public isDefault: boolean;
   public lock: boolean;
   public contract: {

--- a/packages/neon-core/src/wallet/Account.ts
+++ b/packages/neon-core/src/wallet/Account.ts
@@ -112,7 +112,7 @@ export class Account implements NeonObject<AccountJSON> {
       case isNEP2(str): return KeyType.NEP2;
       default:
         // returning empty string enables falsly checks
-        return "";
+        return KeyType.unknown;
     }
   }
 

--- a/packages/neon-core/tsconfig.json
+++ b/packages/neon-core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig-base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    "module": "commonjs"
   },
   // default include without extensions only includes typescript stuff
   "include": ["src/**/*", "src/**/*.json"]

--- a/packages/neon-core/tsconfig.json
+++ b/packages/neon-core/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig-base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib",
-    "module": "commonjs"
+    "outDir": "lib"
   },
   // default include without extensions only includes typescript stuff
   "include": ["src/**/*", "src/**/*.json"]


### PR DESCRIPTION
Introduced a `validateKey` static method in the `Account` class that validates a string input and returns its type if valid, or `void`/`undefined` if invalid. This method streamlines validation by reducing the need for try/catch blocks and complex conditional checks, providing a clear and direct approach for assessing the health status of a string input.





