### PR TITLE
fix(ledger): Export the dist folder correctly

### DIFF
--- a/packages/neon-ledger/package.json
+++ b/packages/neon-ledger/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "lib/",
+    "dist/",
     "typings/"
   ],
   "devDependencies": {


### PR DESCRIPTION
This was causing the released dist folder to only contain the index.js file.