### PR TITLE
chore(deps): update terser-webpack-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "lerna": "9.0.4",
         "prettier": "3.8.1",
         "rimraf": "6.1.3",
-        "terser-webpack-plugin": "5.3.16",
+        "terser-webpack-plugin": "5.4.0",
         "ts-jest": "29.4.6",
         "ts-loader": "9.5.4",
         "tslint-config-prettier": "1.18.0",
@@ -12470,16 +12470,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -13093,16 +13083,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -13698,16 +13678,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lerna": "9.0.4",
     "prettier": "3.8.1",
     "rimraf": "6.1.3",
-    "terser-webpack-plugin": "5.3.16",
+    "terser-webpack-plugin": "5.4.0",
     "ts-jest": "29.4.6",
     "ts-loader": "9.5.4",
     "tslint-config-prettier": "1.18.0",


### PR DESCRIPTION
## Summary

Updates root bundling tooling:

- `terser-webpack-plugin`: `5.3.16` -> `5.4.0`

This removes the vulnerable `serialize-javascript` dependency path.

Fixes #963.

## Audit impact

After this update, `npm audit --json` no longer reports:

- `terser-webpack-plugin`
- `serialize-javascript`

The remaining audit findings are tracked separately in #954, #956, #958-#962, #965, and #966.

## Validation

- `npm run build`
- `npm run dist`
- `git diff --check`
- `npm audit --json` verified the #963 package group is removed
