### PR TITLE
feat(dapi): Create new neon-dapi package

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,4 +24,8 @@ module.exports = {
   testRegex:
     "((/packages/.*/)?__(tests|integration)__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  moduleNameMapper: {
+    "^@cityofzion/neon-core$": "<rootDir>/packages/neon-core/src/index.ts",
+    "^(\\.{1,2}/.+)\\.js$": "$1",
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -559,6 +559,10 @@
       "resolved": "packages/neon-core",
       "link": true
     },
+    "node_modules/@cityofzion/neon-dapi": {
+      "resolved": "packages/neon-dapi",
+      "link": true
+    },
     "node_modules/@cityofzion/neon-js": {
       "resolved": "packages/neon-js",
       "link": true
@@ -15006,6 +15010,17 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "packages/neon-dapi": {
+      "name": "@cityofzion/neon-dapi",
+      "version": "5.9.0",
+      "license": "MIT",
+      "dependencies": {
+        "@ledgerhq/hw-transport": "6.32.0"
+      },
+      "peerDependencies": {
+        "@cityofzion/neon-core": "^5.9.0"
+      }
     },
     "packages/neon-js": {
       "name": "@cityofzion/neon-js",

--- a/packages/neon-core/src/u/BinaryWriter.ts
+++ b/packages/neon-core/src/u/BinaryWriter.ts
@@ -1,0 +1,73 @@
+import { HexString } from "./HexString";
+
+const MAX_SCRIPT_SIZE = 0xffff;
+
+export class BinaryWriter {
+  private _stream = new Uint8Array(MAX_SCRIPT_SIZE);
+  private _view = new DataView(this._stream.buffer);
+  private _position = 0;
+
+  writeUint32(value: number): void {
+    this._view.setUint32(this._position, value, true);
+    this._position += 4;
+  }
+
+  writeUint64(value: number | bigint): void {
+    let v = value;
+    if (typeof value === "number") {
+      v = BigInt(value);
+    }
+    this._view.setBigUint64(this._position, v as bigint, true);
+    this._position += 8;
+  }
+
+  writeUInt160(value: string): void {
+    this.writeBytes(HexString.fromHex(value, true).toArrayBuffer());
+  }
+
+  writeUint16(value: number): void {
+    this._view.setUint16(this._position, value, true);
+    this._position += 2;
+  }
+
+  writeBytes(value: Uint8Array): void {
+    this._stream.set(value, this._position);
+    this._position += value.length;
+  }
+
+  writeVarInt(value: number): void {
+    if (value < 0) {
+      throw new Error("value too small");
+    } else if (value < 0xfd) {
+      this.writeBytes(new Uint8Array([value]));
+    } else if (value <= 0xffff) {
+      this.writeBytes(new Uint8Array([0xfd]));
+      this.writeUint16(value);
+    } else if (value <= 0xffffffff) {
+      this.writeBytes(new Uint8Array([0xfe]));
+      this.writeUint32(value);
+    } else {
+      this.writeBytes(new Uint8Array([0xff]));
+      this.writeUint64(value);
+    }
+  }
+
+  writeVarString(value: string): void {
+    const data = new TextEncoder().encode(value);
+    this.writeVarInt(data.length);
+    this._stream.set(data, this._position);
+    this._position += data.length;
+  }
+
+  toArray(): Uint8Array {
+    return this._stream.slice(0, this._position);
+  }
+
+  toHex(): string {
+    return HexString.fromArrayBuffer(this.toArray()).toString();
+  }
+
+  get length(): number {
+    return this._position;
+  }
+}

--- a/packages/neon-core/src/u/index.ts
+++ b/packages/neon-core/src/u/index.ts
@@ -5,3 +5,4 @@ export * from "./StringStream";
 export * from "./HexString";
 export * from "./BigInteger";
 export * from "./serialize";
+export * from "./BinaryWriter";

--- a/packages/neon-dapi/README.md
+++ b/packages/neon-dapi/README.md
@@ -38,15 +38,15 @@ Methods that require direct wallet UI interaction (`pickAddress`, `on`, `removeL
 
 Standardized error class thrown by all `DapiOperations` methods. Each error carries a `DapiErrorCode` so dApps can handle failure cases programmatically.
 
-### `ENetwork`
+### `DapiNetwork`
 
 Enum with the canonical Neo N3 network magic numbers.
 
 ```ts
-import { ENetwork } from "@cityofzion/neon-dapi";
+import { DapiNetwork } from "@cityofzion/neon-dapi";
 
-ENetwork.MAINNET // 860833102
-ENetwork.TESTNET // 894710606
+DapiNetwork.MAINNET // 860833102
+DapiNetwork.TESTNET // 894710606
 ```
 
 ## Conformance Suite

--- a/packages/neon-dapi/README.md
+++ b/packages/neon-dapi/README.md
@@ -1,0 +1,85 @@
+# neon-dapi
+
+## Overview
+
+TypeScript implementation of the [NEP-21 dAPI standard](https://github.com/neo-project/proposals/blob/master/nep-21.mediawiki) for Neo N3. Provides the `DapiProvider` interface that wallets must implement, along with `DapiOperations` — a helper class that handles the blockchain heavy lifting so wallet developers only need to wire up user interaction.
+
+## Installation
+
+```sh
+npm i @cityofzion/neon-dapi @cityofzion/neon-core
+```
+
+`@cityofzion/neon-core` is a peer dependency and must be installed alongside this package.
+
+## Concepts
+
+### Types
+
+All NEP-21 types are exported from this package and can be imported directly. Key types include:
+
+- **`DapiProvider`** — The interface wallets must implement. Defines the full NEP-21 surface exposed to dApps: account access, asset transfers, contract invocations, signing, and blockchain queries.
+- **`Account`**, **`Signer`**, **`Transaction`**, **`Block`** — Core blockchain data structures.
+- **`InvocationArguments`**, **`InvocationResult`** — Input and output for contract calls.
+- **`ContractParametersContext`** — Unsigned transaction context used in multi-sig flows (`makeTransaction` → `sign` → `relay`).
+- **`TransactionOptions`** — Fee and validity overrides for transaction building.
+- **`SignOptions`**, **`SignedMessage`** — Message signing configuration and result.
+- **`AuthenticationChallengePayload`**, **`AuthenticationResponsePayload`** — NEP-20 authentication payloads.
+- **`ProviderReadyEvent`**, **`ProviderRequestEvent`**, **`AccountChangedEvent`**, **`NetworkChangedEvent`** — Custom DOM events for the provider lifecycle and wallet state changes.
+- Primitive aliases — **`UInt160`**, **`UInt256`**, **`ECPoint`**, **`Integer`**, **`Base64Encoded`**, **`Network`** — string/number aliases with semantic names matching the NEP-21 spec.
+
+### `DapiOperations` class
+
+A helper that implements the blockchain and cryptographic operations required by `DapiProvider`. It is not a provider itself — it exists to reduce boilerplate by handling RPC calls, transaction building, signing, and fee calculation.
+
+Methods that require direct wallet UI interaction (`pickAddress`, `on`, `removeListener`) are intentionally omitted from `DapiOperations` because they depend on the specific wallet environment and cannot be generalized.
+
+### `DapiError`
+
+Standardized error class thrown by all `DapiOperations` methods. Each error carries a `DapiErrorCode` so dApps can handle failure cases programmatically.
+
+### `ENetwork`
+
+Enum with the canonical Neo N3 network magic numbers.
+
+```ts
+import { ENetwork } from "@cityofzion/neon-dapi";
+
+ENetwork.MAINNET // 860833102
+ENetwork.TESTNET // 894710606
+```
+
+## Conformance Suite
+
+The package ships a browser-based conformance suite (`conformance/`) that validates any injected NEP-21 provider against the full spec. Each method is exercised and results are reported as pass/fail directly in the page.
+
+The suite runs against the live injected provider — no mocking occurs. Useful for wallet developers to verify their `DapiProvider` implementation before release.
+
+### Running
+
+Serve the conformance directory with any static file server and open it in a browser that has a Neo wallet extension active:
+
+```sh
+# Using npx serve
+npx serve packages/neon-dapi/conformance
+```
+
+Then open `http://localhost:3000` (or whichever port your server uses) in the browser.
+
+> **Note:** Some tests require a connected account with funds on the target network.
+
+Click **Run All** to execute the full suite, or run individual tests from the UI.
+
+### `DapiErrorCode`
+
+| Code | Value | Meaning |
+|---|---|---|
+| `UNKNOWN` | 10000 | An unknown error has occurred. |
+| `UNSUPPORTED` | 10001 | The requested feature is not supported. |
+| `INVALID` | 10002 | The input data is in an invalid format. |
+| `NOTFOUND` | 10003 | The requested data doesn't exist. |
+| `FAILED` | 10004 | The contract execution failed. |
+| `TIMEOUT` | 10005 | The operation was cancelled due to timeout. |
+| `CANCELED` | 10006 | The operation was cancelled by the user. |
+| `INSUFFICIENT_FUNDS` | 10007 | The operation failed due to insufficient balance. |
+| `RPC_ERROR` | 10008 | An exception was thrown by the RPC server. |

--- a/packages/neon-dapi/__tests__/DapiOperations.ts
+++ b/packages/neon-dapi/__tests__/DapiOperations.ts
@@ -72,13 +72,14 @@ describe("DapiOperations.authenticate", () => {
     const payload = makePayload();
     const response = await ops.authenticate(payload);
 
-    const networkHex = u.num2hexstring(response.network, 4, true);
-    const nonceHex = u.num2hexstring(Number(payload.nonce), 8, true);
-    const timestampHex = u.num2hexstring(response.timestamp, 4, true);
-    const hashHex = account.scriptHash.replace(/^0x/i, "");
-    const actionHex = u.str2hexstring(payload.action);
-    const domainHex = u.str2hexstring(payload.domain);
-    const message = `${networkHex}${nonceHex}${timestampHex}${hashHex}${actionHex}${domainHex}`;
+    const bw = new u.BinaryWriter();
+    bw.writeUint64(Number(payload.nonce));
+    bw.writeUint32(response.timestamp);
+    bw.writeUint32(response.network);
+    bw.writeUInt160(account.scriptHash);
+    bw.writeVarString(payload.action);
+    bw.writeVarString(payload.domain);
+    const message = bw.toHex();
 
     const signatureHex = u.base642hex(response.signature);
     const isValid = wallet.verify(message, signatureHex, account.publicKey);

--- a/packages/neon-dapi/__tests__/DapiOperations.ts
+++ b/packages/neon-dapi/__tests__/DapiOperations.ts
@@ -1,0 +1,1293 @@
+import { u, wallet } from "@cityofzion/neon-core";
+
+import { DapiErrorCode } from "../src/DapiError";
+import { DapiOperations } from "../src/DapiOperations";
+import type { AuthenticationChallengePayload } from "../src/types";
+import { DapiNetwork } from "../src/constants";
+
+jest.mock("@cityofzion/neon-core", () => {
+  const actual = jest.requireActual("@cityofzion/neon-core");
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      RPCClient: jest.fn().mockImplementation(() => ({})),
+    },
+  };
+});
+
+const ACCOUNT = "0x1234567890abcdef1234567890abcdef12345678";
+const TXID =
+  "0x1f4d1defa46faa5e7b9b8d3f79a06bec777d7c26c4aa5f6f5899a291daa87c15";
+const BLOCK_HASH =
+  "0xabc123def456abc123def456abc123def456abc123def456abc123def456abc1";
+
+function makePayload(
+  overrides?: Partial<AuthenticationChallengePayload>,
+): AuthenticationChallengePayload {
+  return {
+    action: "Authentication",
+    grant_type: "Signature",
+    allowed_algorithms: ["ECDSA-P256"],
+    domain: "test.example.com",
+    networks: [DapiNetwork.TESTNET],
+    nonce: "123456789",
+    timestamp: Math.floor(Date.now() / 1000),
+    ...overrides,
+  };
+}
+
+describe("DapiOperations.authenticate", () => {
+  const account: wallet.Account = new wallet.Account();
+  const ops: DapiOperations = new DapiOperations({
+    // It is empty because we are mocking the RPCClient
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account,
+  });
+
+  test("returns correct response shape", async () => {
+    const payload = makePayload();
+    const response = await ops.authenticate(payload);
+
+    expect(response.address).toBe(account.address);
+    expect(response.algorithm).toBe("ECDSA-P256");
+    expect(typeof response.network).toBe("number");
+    expect(response.pubkey).toBe(account.publicKey);
+    expect(response.nonce).toBe(payload.nonce);
+    expect(typeof response.timestamp).toBe("number");
+    expect(typeof response.signature).toBe("string");
+  });
+
+  test("timestamp is a recent unix timestamp", async () => {
+    const before = Math.floor(Date.now() / 1000);
+    const response = await ops.authenticate(makePayload());
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(response.timestamp).toBeGreaterThanOrEqual(before);
+    expect(response.timestamp).toBeLessThanOrEqual(after);
+  });
+
+  test("signature is cryptographically valid", async () => {
+    const payload = makePayload();
+    const response = await ops.authenticate(payload);
+
+    const networkHex = u.num2hexstring(response.network, 1, true);
+    const nonceHex = u.num2hexstring(Number(payload.nonce), 8, true);
+    const timestampHex = u.num2hexstring(response.timestamp, 8, true);
+    const hashHex = account.scriptHash.replace(/^0x/i, "");
+    const message = `${networkHex}${nonceHex}${timestampHex}${hashHex}`;
+
+    const signatureHex = u.base642hex(response.signature);
+    const isValid = wallet.verify(message, signatureHex, account.publicKey);
+    expect(isValid).toBe(true);
+  });
+
+  test("throws DapiError INVALID when networks array is empty", async () => {
+    const payload = makePayload({ networks: [] });
+
+    await expect(ops.authenticate(payload)).rejects.toMatchObject({
+      code: DapiErrorCode.INVALID,
+    });
+  });
+
+  test("throws DapiError INVALID when network is not supported", async () => {
+    const payload = makePayload({ networks: [DapiNetwork.MAINNET] });
+
+    await expect(ops.authenticate(payload)).rejects.toMatchObject({
+      code: DapiErrorCode.INVALID,
+    });
+  });
+});
+
+describe("DapiOperations.getAccounts", () => {
+  const account = new wallet.Account();
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account,
+  });
+
+  test("account address matches connected account", () => {
+    const [result] = ops.getAccounts();
+    expect(result.address).toBe(account.address);
+    expect(result.hash).toBe(account.scriptHash);
+    expect(result.extra).toBeNull();
+    expect(result.contract).toEqual(account.contract);
+  });
+
+  test("label matches account label", () => {
+    const account = new wallet.Account();
+    account.label = "test-label";
+    const ops = new DapiOperations({
+      rpcClient: "",
+      network: DapiNetwork.TESTNET,
+      account,
+    });
+
+    const [result] = ops.getAccounts();
+
+    expect(result.label).toBe("test-label");
+  });
+});
+
+describe("DapiOperations.getBalance", () => {
+  const ASSET = "0xd2a4cff31913016155e38e474a2c06d08be276cf";
+  const ACCOUNT = "0x1234567890abcdef1234567890abcdef12345678";
+
+  const ops: DapiOperations = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  test("returns balance when state is HALT and stack has Integer", async () => {
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue({
+      state: "HALT",
+      stack: [{ type: "Integer", value: "100000000" }],
+    });
+
+    const result = await ops.getBalance(ASSET, ACCOUNT);
+
+    expect(result).toBe("100000000");
+  });
+
+  test("returns zero balance", async () => {
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue({
+      state: "HALT",
+      stack: [{ type: "Integer", value: "0" }],
+    });
+
+    const result = await ops.getBalance(ASSET, ACCOUNT);
+
+    expect(result).toBe("0");
+  });
+
+  test("throws DapiError FAILED when state is not HALT", async () => {
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue({
+      state: "FAULT",
+      exception: "Insufficient funds",
+      stack: [],
+    });
+
+    await expect(ops.getBalance(ASSET, ACCOUNT)).rejects.toMatchObject({
+      code: DapiErrorCode.FAILED,
+      message: "Insufficient funds",
+    });
+  });
+
+  test("throws DapiError FAILED using fallback message when exception is absent", async () => {
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue({
+      state: "FAULT",
+      stack: [],
+    });
+
+    await expect(ops.getBalance(ASSET, ACCOUNT)).rejects.toMatchObject({
+      code: DapiErrorCode.FAILED,
+    });
+  });
+
+  test("throws DapiError INVALID when stack type is not Integer", async () => {
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue({
+      state: "HALT",
+      stack: [{ type: "ByteString", value: "aGVsbG8=" }],
+    });
+
+    await expect(ops.getBalance(ASSET, ACCOUNT)).rejects.toMatchObject({
+      code: DapiErrorCode.INVALID,
+    });
+  });
+
+  test("throws DapiError INVALID when stack is empty", async () => {
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue({
+      state: "HALT",
+      stack: [],
+    });
+
+    await expect(ops.getBalance(ASSET, ACCOUNT)).rejects.toMatchObject({
+      code: DapiErrorCode.INVALID,
+    });
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockRejectedValue(new Error("RPC error"));
+
+    await expect(ops.getBalance(ASSET, ACCOUNT)).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.getApplicationLog", () => {
+  const TXID =
+    "0x1f4d1defa46faa5e7b9b8d3f79a06bec777d7c26c4aa5f6f5899a291daa87c15";
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  test("returns mapped application log", async () => {
+    ops.rpcClient.getApplicationLog = jest.fn().mockResolvedValue({
+      txid: TXID,
+      executions: [
+        {
+          trigger: "Application",
+          vmstate: "HALT",
+          gasconsumed: "1234567",
+          stack: [{ type: "Integer", value: "1" }],
+          notifications: [],
+        },
+      ],
+    });
+
+    const result = await ops.getApplicationLog(TXID);
+
+    expect(result.txid).toBe(TXID);
+    expect(result.executions).toHaveLength(1);
+    expect(result.executions[0].trigger).toBe("Application");
+    expect(result.executions[0].vmstate).toBe("HALT");
+    expect(result.executions[0].gasconsumed).toBe("1234567");
+    expect(result.executions[0].stack).toEqual([
+      { type: "Integer", value: "1" },
+    ]);
+    expect(result.executions[0].notifications).toEqual([]);
+  });
+
+  test("maps multiple executions", async () => {
+    ops.rpcClient.getApplicationLog = jest.fn().mockResolvedValue({
+      txid: TXID,
+      executions: [
+        {
+          trigger: "Application",
+          vmstate: "HALT",
+          gasconsumed: "100",
+          stack: [],
+          notifications: [],
+        },
+        {
+          trigger: "Verification",
+          vmstate: "HALT",
+          gasconsumed: "200",
+          stack: [],
+          notifications: [],
+        },
+      ],
+    });
+
+    const result = await ops.getApplicationLog(TXID);
+
+    expect(result.executions).toHaveLength(2);
+    expect(result.executions[1].trigger).toBe("Verification");
+  });
+
+  test("defaults stack to empty array when null", async () => {
+    ops.rpcClient.getApplicationLog = jest.fn().mockResolvedValue({
+      txid: TXID,
+      executions: [
+        {
+          trigger: "Application",
+          vmstate: "HALT",
+          gasconsumed: "0",
+          stack: null,
+          notifications: [],
+        },
+      ],
+    });
+
+    const result = await ops.getApplicationLog(TXID);
+
+    expect(result.executions[0].stack).toEqual([]);
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.getApplicationLog = jest
+      .fn()
+      .mockRejectedValue(new Error("not found"));
+
+    await expect(ops.getApplicationLog(TXID)).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.getBlock", () => {
+  const mockRpcBlock = {
+    hash: BLOCK_HASH,
+    size: 1024,
+    confirmations: 10,
+    nextblockhash:
+      "0xdef456abc123def456abc123def456abc123def456abc123def456abc123def4",
+    version: 0,
+    previousblockhash:
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    merkleroot:
+      "0xaaaa000000000000000000000000000000000000000000000000000000000000",
+    time: 1700000000,
+    nonce: "0000000000000000",
+    index: 42,
+    primary: 0,
+    nextconsensus: "NXV7ZhHiyM1aHXwvUNBLNAkCwZ6wgeKyMY",
+    tx: [],
+  };
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  test("maps all block fields correctly", async () => {
+    ops.rpcClient.getBlock = jest.fn().mockResolvedValue(mockRpcBlock);
+
+    const result = await ops.getBlock(BLOCK_HASH);
+
+    expect(result.hash).toBe(mockRpcBlock.hash);
+    expect(result.size).toBe(mockRpcBlock.size);
+    expect(result.confirmations).toBe(mockRpcBlock.confirmations);
+    expect(result.nextBlockHash).toBe(mockRpcBlock.nextblockhash);
+    expect(result.version).toBe(mockRpcBlock.version);
+    expect(result.previousBlockHash).toBe(mockRpcBlock.previousblockhash);
+    expect(result.merkleRoot).toBe(mockRpcBlock.merkleroot);
+    expect(result.time).toBe(mockRpcBlock.time);
+    expect(result.nonce).toBe(mockRpcBlock.nonce);
+    expect(result.index).toBe(mockRpcBlock.index);
+    expect(result.primary).toBe(mockRpcBlock.primary);
+    expect(result.nextConsensus).toBe(mockRpcBlock.nextconsensus);
+  });
+
+  test("calls rpcClient.getBlock with hash and verbosity 1", async () => {
+    ops.rpcClient.getBlock = jest.fn().mockResolvedValue(mockRpcBlock);
+
+    await ops.getBlock(BLOCK_HASH);
+
+    expect(ops.rpcClient.getBlock).toHaveBeenCalledWith(BLOCK_HASH, 1);
+  });
+
+  test("maps transactions with block context injected", async () => {
+    const mockTx = {
+      hash: TXID,
+      size: 256,
+      version: 0,
+      nonce: 1,
+      sender: ACCOUNT,
+      sysfee: "100",
+      netfee: "50",
+      validuntilblock: 1000,
+      signers: [],
+      attributes: [],
+      script: "base64script==",
+    };
+
+    ops.rpcClient.getBlock = jest.fn().mockResolvedValue({
+      ...mockRpcBlock,
+      tx: [mockTx],
+    });
+
+    const result = await ops.getBlock(BLOCK_HASH);
+
+    expect(result.tx).toHaveLength(1);
+    expect(result.tx[0].hash).toBe(TXID);
+    expect(result.tx[0].blockHash).toBe(BLOCK_HASH);
+    expect(result.tx[0].blockTime).toBe(mockRpcBlock.time);
+    expect(result.tx[0].confirmations).toBe(mockRpcBlock.confirmations);
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.getBlock = jest
+      .fn()
+      .mockRejectedValue(new Error("not found"));
+
+    await expect(ops.getBlock(BLOCK_HASH)).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.getBlockCount", () => {
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  test("returns block count from rpcClient", async () => {
+    ops.rpcClient.getBlockCount = jest.fn().mockResolvedValue(1234);
+
+    const result = await ops.getBlockCount();
+
+    expect(result).toBe(1234);
+  });
+
+  test("calls rpcClient.getBlockCount with no arguments", async () => {
+    ops.rpcClient.getBlockCount = jest.fn().mockResolvedValue(0);
+
+    await ops.getBlockCount();
+
+    expect(ops.rpcClient.getBlockCount).toHaveBeenCalledWith();
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.getBlockCount = jest
+      .fn()
+      .mockRejectedValue(new Error("RPC error"));
+
+    await expect(ops.getBlockCount()).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.getStorage", () => {
+  const CONTRACT_HASH = "0xd2a4cff31913016155e38e474a2c06d08be276cf";
+  const KEY_BASE64 = "dGVzdA=="; // "test" in base64
+  const VALUE_BASE64 = "aGVsbG8="; // "hello" in base64
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  test("returns storage value from rpcClient", async () => {
+    ops.rpcClient.getStorage = jest.fn().mockResolvedValue(VALUE_BASE64);
+
+    const result = await ops.getStorage(CONTRACT_HASH, KEY_BASE64);
+
+    expect(result).toBe(VALUE_BASE64);
+  });
+
+  test("converts base64 key to hex before calling rpcClient", async () => {
+    ops.rpcClient.getStorage = jest.fn().mockResolvedValue(VALUE_BASE64);
+
+    await ops.getStorage(CONTRACT_HASH, KEY_BASE64);
+
+    const { u: uActual } = jest.requireActual("@cityofzion/neon-core");
+    expect(ops.rpcClient.getStorage).toHaveBeenCalledWith(
+      CONTRACT_HASH,
+      uActual.base642hex(KEY_BASE64),
+    );
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.getStorage = jest
+      .fn()
+      .mockRejectedValue(new Error("not found"));
+
+    await expect(
+      ops.getStorage(CONTRACT_HASH, KEY_BASE64),
+    ).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.getTokenInfo", () => {
+  const ASSET_ID = "0xd2a4cff31913016155e38e474a2c06d08be276cf";
+  // "R0FT" is base64 of hex "474153" which decodes to ASCII "GAS"
+  const SYMBOL_BASE64 = "R0FT";
+
+  const haltResult = (
+    type: string,
+    value: string,
+  ): { state: string; stack: { type: string; value: string }[] } => ({
+    state: "HALT",
+    stack: [{ type, value }],
+  });
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  test("returns decimals, symbol and totalSupply", async () => {
+    ops.rpcClient.executeAll = jest
+      .fn()
+      .mockResolvedValue([
+        haltResult("Integer", "8"),
+        haltResult("ByteString", SYMBOL_BASE64),
+        haltResult("Integer", "10000000000000000"),
+      ]);
+
+    const result = await ops.getTokenInfo(ASSET_ID);
+
+    expect(result.decimals).toBe(8);
+    expect(result.symbol).toBe("GAS");
+    expect(result.totalSupply).toBe("10000000000000000");
+  });
+
+  test("throws DapiError FAILED when decimals state is not HALT", async () => {
+    ops.rpcClient.executeAll = jest
+      .fn()
+      .mockResolvedValue([
+        { state: "FAULT", stack: [] },
+        haltResult("ByteString", SYMBOL_BASE64),
+        haltResult("Integer", "100"),
+      ]);
+
+    await expect(ops.getTokenInfo(ASSET_ID)).rejects.toMatchObject({
+      code: DapiErrorCode.FAILED,
+    });
+  });
+
+  test("throws DapiError FAILED when any state is not HALT", async () => {
+    ops.rpcClient.executeAll = jest
+      .fn()
+      .mockResolvedValue([
+        haltResult("Integer", "8"),
+        { state: "FAULT", stack: [] },
+        haltResult("Integer", "100"),
+      ]);
+
+    await expect(ops.getTokenInfo(ASSET_ID)).rejects.toMatchObject({
+      code: DapiErrorCode.FAILED,
+    });
+  });
+
+  test("throws DapiError INVALID when decimals stack type is not Integer", async () => {
+    ops.rpcClient.executeAll = jest
+      .fn()
+      .mockResolvedValue([
+        haltResult("ByteString", "OA=="),
+        haltResult("ByteString", SYMBOL_BASE64),
+        haltResult("Integer", "100"),
+      ]);
+
+    await expect(ops.getTokenInfo(ASSET_ID)).rejects.toMatchObject({
+      code: DapiErrorCode.INVALID,
+    });
+  });
+
+  test("throws DapiError INVALID when symbol stack type is not ByteString", async () => {
+    ops.rpcClient.executeAll = jest
+      .fn()
+      .mockResolvedValue([
+        haltResult("Integer", "8"),
+        haltResult("Integer", "12345"),
+        haltResult("Integer", "100"),
+      ]);
+
+    await expect(ops.getTokenInfo(ASSET_ID)).rejects.toMatchObject({
+      code: DapiErrorCode.INVALID,
+    });
+  });
+
+  test("throws DapiError INVALID when totalSupply stack type is not Integer", async () => {
+    ops.rpcClient.executeAll = jest
+      .fn()
+      .mockResolvedValue([
+        haltResult("Integer", "8"),
+        haltResult("ByteString", SYMBOL_BASE64),
+        haltResult("ByteString", "aGVsbG8="),
+      ]);
+
+    await expect(ops.getTokenInfo(ASSET_ID)).rejects.toMatchObject({
+      code: DapiErrorCode.INVALID,
+    });
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.executeAll = jest
+      .fn()
+      .mockRejectedValue(new Error("RPC error"));
+
+    await expect(ops.getTokenInfo(ASSET_ID)).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.getTransaction", () => {
+  const mockRpcTx = {
+    hash: TXID,
+    size: 256,
+    version: 0,
+    nonce: 42,
+    sender: ACCOUNT,
+    sysfee: "100",
+    netfee: "50",
+    validuntilblock: 1000,
+    signers: [],
+    attributes: [],
+    script: "base64script==",
+    blockhash: BLOCK_HASH,
+    blocktime: 1700000000,
+    confirmations: 5,
+  };
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  test("calls getRawTransaction with txid and verbosity 1", async () => {
+    ops.rpcClient.getRawTransaction = jest.fn().mockResolvedValue(mockRpcTx);
+
+    await ops.getTransaction(TXID);
+
+    expect(ops.rpcClient.getRawTransaction).toHaveBeenCalledWith(TXID, 1);
+  });
+
+  test("maps rpc transaction fields to Transaction type", async () => {
+    ops.rpcClient.getRawTransaction = jest.fn().mockResolvedValue(mockRpcTx);
+
+    const result = await ops.getTransaction(TXID);
+
+    expect(result.hash).toBe(TXID);
+    expect(result.size).toBe(mockRpcTx.size);
+    expect(result.version).toBe(mockRpcTx.version);
+    expect(result.nonce).toBe(mockRpcTx.nonce);
+    expect(result.sender).toBe(mockRpcTx.sender);
+    expect(result.systemFee).toBe(mockRpcTx.sysfee);
+    expect(result.networkFee).toBe(mockRpcTx.netfee);
+    expect(result.validUntilBlock).toBe(mockRpcTx.validuntilblock);
+    expect(result.blockHash).toBe(mockRpcTx.blockhash);
+    expect(result.blockTime).toBe(mockRpcTx.blocktime);
+    expect(result.confirmations).toBe(mockRpcTx.confirmations);
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.getRawTransaction = jest
+      .fn()
+      .mockRejectedValue(new Error("not found"));
+
+    await expect(ops.getTransaction(TXID)).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.call", () => {
+  const invocation = {
+    hash: "0xd2a4cff31913016155e38e474a2c06d08be276cf",
+    operation: "balanceOf",
+    args: [{ type: "Hash160" as const, value: ACCOUNT }],
+  };
+
+  const mockInvokeResult = {
+    gasconsumed: "1234567",
+    script: "base64script==",
+    stack: [{ type: "Integer", value: "100" }],
+    state: "HALT",
+    exception: null,
+    notifications: [],
+  };
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  test("returns mapped invocation result", async () => {
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue(mockInvokeResult);
+
+    const result = await ops.call(invocation);
+
+    expect(result.gasconsumed).toBe(mockInvokeResult.gasconsumed);
+    expect(result.script).toBe(mockInvokeResult.script);
+    expect(result.stack).toEqual(mockInvokeResult.stack);
+    expect(result.state).toBe(mockInvokeResult.state);
+    expect(result.notifications).toEqual(mockInvokeResult.notifications);
+  });
+
+  test("exception is undefined when null", async () => {
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockResolvedValue({ ...mockInvokeResult, exception: null });
+
+    const result = await ops.call(invocation);
+
+    expect(result.exception).toBeUndefined();
+  });
+
+  test("exception is returned when present", async () => {
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockResolvedValue({ ...mockInvokeResult, exception: "contract error" });
+
+    const result = await ops.call(invocation);
+
+    expect(result.exception).toBe("contract error");
+  });
+
+  test("calls invokeScript with connected account as signer", async () => {
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue(mockInvokeResult);
+
+    await ops.call(invocation);
+
+    const [, signers] = (ops.rpcClient.invokeScript as jest.Mock).mock.calls[0];
+    expect(signers).toHaveLength(1);
+    expect(signers[0].account.toBigEndian()).toBe(
+      ops.account.scriptHash.replace(/^0x/i, ""),
+    );
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockRejectedValue(new Error("RPC error"));
+
+    await expect(ops.call(invocation)).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.invoke", () => {
+  const invocations = [
+    {
+      hash: "0xd2a4cff31913016155e38e474a2c06d08be276cf",
+      operation: "transfer",
+      args: [
+        { type: "Hash160" as const, value: ACCOUNT },
+        { type: "Hash160" as const, value: ACCOUNT },
+        { type: "Integer" as const, value: "100" },
+        { type: "Any" as const, value: undefined },
+      ],
+    },
+  ];
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  beforeEach(() => {
+    ops.rpcClient.getBlockCount = jest.fn().mockResolvedValue(1000);
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockResolvedValue({ state: "HALT", gasconsumed: "100", stack: [] });
+    ops.rpcClient.calculateNetworkFee = jest.fn().mockResolvedValue(50);
+    ops.rpcClient.getVersion = jest
+      .fn()
+      .mockResolvedValue({ protocol: { network: DapiNetwork.TESTNET } });
+    ops.rpcClient.sendRawTransaction = jest.fn().mockResolvedValue(TXID);
+  });
+
+  test("returns txid from sendRawTransaction", async () => {
+    const result = await ops.invoke(invocations);
+
+    expect(result).toBe(TXID);
+  });
+
+  test("calls sendRawTransaction", async () => {
+    await ops.invoke(invocations);
+
+    expect(ops.rpcClient.sendRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses suggestedSystemFee from options when provided", async () => {
+    await ops.invoke(invocations, undefined, undefined, {
+      suggestedSystemFee: 999,
+    });
+
+    // invokeScript should not be called for fee estimation when suggestedSystemFee is set
+    expect(ops.rpcClient.invokeScript).not.toHaveBeenCalled();
+  });
+
+  test("uses validUntilBlock from options when provided", async () => {
+    await ops.invoke(invocations, undefined, undefined, {
+      validUntilBlock: 5000,
+      suggestedSystemFee: 100,
+    });
+
+    // getBlockCount should not be called when validUntilBlock is set
+    expect(ops.rpcClient.getBlockCount).not.toHaveBeenCalled();
+  });
+
+  test("throws DapiError when sendRawTransaction rejects", async () => {
+    ops.rpcClient.sendRawTransaction = jest
+      .fn()
+      .mockRejectedValue(new Error("broadcast failed"));
+
+    await expect(ops.invoke(invocations)).rejects.toBeInstanceOf(Error);
+  });
+
+  test("throws DapiError when getVersion rejects", async () => {
+    ops.rpcClient.getVersion = jest
+      .fn()
+      .mockRejectedValue(new Error("RPC error"));
+
+    await expect(ops.invoke(invocations)).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.send", () => {
+  const ASSET = "0xd2a4cff31913016155e38e474a2c06d08be276cf";
+  const TO = "0xabcdef1234567890abcdef1234567890abcdef12";
+  const AMOUNT = "100000000";
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  beforeEach(() => {
+    ops.rpcClient.getBlockCount = jest.fn().mockResolvedValue(1000);
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockResolvedValue({ state: "HALT", gasconsumed: "100", stack: [] });
+    ops.rpcClient.calculateNetworkFee = jest.fn().mockResolvedValue(50);
+    ops.rpcClient.getVersion = jest
+      .fn()
+      .mockResolvedValue({ protocol: { network: DapiNetwork.TESTNET } });
+    ops.rpcClient.sendRawTransaction = jest.fn().mockResolvedValue(TXID);
+  });
+
+  test("returns txid from sendRawTransaction", async () => {
+    const result = await ops.send(ASSET, ops.account.scriptHash, TO, AMOUNT);
+
+    expect(result).toBe(TXID);
+  });
+
+  test("calls sendRawTransaction once", async () => {
+    await ops.send(ASSET, ops.account.scriptHash, TO, AMOUNT);
+
+    expect(ops.rpcClient.sendRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses connected account as signer", async () => {
+    await ops.send(ASSET, ops.account.scriptHash, TO, AMOUNT);
+
+    const [, signers] = (ops.rpcClient.invokeScript as jest.Mock).mock.calls[0];
+    expect(signers[0].account.toBigEndian()).toBe(
+      ops.account.scriptHash.replace(/^0x/i, ""),
+    );
+  });
+
+  test("throws DapiError when sendRawTransaction rejects", async () => {
+    ops.rpcClient.sendRawTransaction = jest
+      .fn()
+      .mockRejectedValue(new Error("broadcast failed"));
+
+    await expect(
+      ops.send(ASSET, ops.account.scriptHash, TO, AMOUNT),
+    ).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.calculateInvokeFee", () => {
+  const invocations = [
+    {
+      hash: "0xd2a4cff31913016155e38e474a2c06d08be276cf",
+      operation: "transfer",
+      args: [],
+    },
+  ];
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  beforeEach(() => {
+    ops.rpcClient.getBlockCount = jest.fn().mockResolvedValue(1000);
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue({
+      state: "HALT",
+      gasconsumed: "100000000",
+      stack: [],
+    });
+    ops.rpcClient.calculateNetworkFee = jest.fn().mockResolvedValue(50000000);
+  });
+
+  test("returns a number", async () => {
+    const result = await ops.calculateInvokeFee(invocations);
+
+    expect(typeof result).toBe("number");
+  });
+
+  test("result reflects sum of system and network fee", async () => {
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue({
+      state: "HALT",
+      gasconsumed: "100000000",
+      stack: [],
+    });
+    ops.rpcClient.calculateNetworkFee = jest.fn().mockResolvedValue(50000000);
+
+    const result = await ops.calculateInvokeFee(invocations);
+
+    // 100000000 + 50000000 = 150000000 satoshi = 1.5 GAS
+    expect(result).toBeCloseTo(1.5, 5);
+  });
+
+  test("skips invokeScript when suggestedSystemFee is provided", async () => {
+    await ops.calculateInvokeFee(invocations, undefined, undefined, {
+      suggestedSystemFee: 100,
+    });
+
+    expect(ops.rpcClient.invokeScript).not.toHaveBeenCalled();
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockRejectedValue(new Error("RPC error"));
+
+    await expect(ops.calculateInvokeFee(invocations)).rejects.toBeInstanceOf(
+      Error,
+    );
+  });
+});
+
+describe("DapiOperations.calculateSendFee", () => {
+  const ASSET = "0xd2a4cff31913016155e38e474a2c06d08be276cf";
+  const TO = "0xabcdef1234567890abcdef1234567890abcdef12";
+  const AMOUNT = "100000000";
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  beforeEach(() => {
+    ops.rpcClient.getBlockCount = jest.fn().mockResolvedValue(1000);
+    ops.rpcClient.invokeScript = jest.fn().mockResolvedValue({
+      state: "HALT",
+      gasconsumed: "100000000",
+      stack: [],
+    });
+    ops.rpcClient.calculateNetworkFee = jest.fn().mockResolvedValue(50000000);
+  });
+
+  test("returns a number", async () => {
+    const result = await ops.calculateSendFee(
+      ASSET,
+      ops.account.scriptHash,
+      TO,
+      AMOUNT,
+    );
+
+    expect(typeof result).toBe("number");
+  });
+
+  test("result reflects sum of system and network fee", async () => {
+    const result = await ops.calculateSendFee(
+      ASSET,
+      ops.account.scriptHash,
+      TO,
+      AMOUNT,
+    );
+
+    expect(result).toBeCloseTo(1.5, 5);
+  });
+
+  test("uses connected account as signer", async () => {
+    await ops.calculateSendFee(ASSET, ops.account.scriptHash, TO, AMOUNT);
+
+    const [, signers] = (ops.rpcClient.invokeScript as jest.Mock).mock.calls[0];
+    expect(signers[0].account.toBigEndian()).toBe(
+      ops.account.scriptHash.replace(/^0x/i, ""),
+    );
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockRejectedValue(new Error("RPC error"));
+
+    await expect(
+      ops.calculateSendFee(ASSET, ops.account.scriptHash, TO, AMOUNT),
+    ).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.makeTransaction", () => {
+  const invocations = [
+    {
+      hash: "0xd2a4cff31913016155e38e474a2c06d08be276cf",
+      operation: "transfer",
+      args: [],
+    },
+  ];
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  beforeEach(() => {
+    ops.rpcClient.getBlockCount = jest.fn().mockResolvedValue(1000);
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockResolvedValue({ state: "HALT", gasconsumed: "100", stack: [] });
+    ops.rpcClient.calculateNetworkFee = jest.fn().mockResolvedValue(50);
+    ops.rpcClient.getVersion = jest
+      .fn()
+      .mockResolvedValue({ protocol: { network: DapiNetwork.TESTNET } });
+  });
+
+  test("returns correct type field", async () => {
+    const result = await ops.makeTransaction(invocations);
+
+    expect(result.type).toBe("Neo.Network.P2P.Payloads.Transaction");
+  });
+
+  test("network comes from getVersion", async () => {
+    const result = await ops.makeTransaction(invocations);
+
+    expect(result.network).toBe(DapiNetwork.TESTNET);
+  });
+
+  test("hash starts with 0x", async () => {
+    const result = await ops.makeTransaction(invocations);
+
+    expect(result.hash).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  test("data is a non-empty base64 string", async () => {
+    const result = await ops.makeTransaction(invocations);
+
+    expect(typeof result.data).toBe("string");
+    expect(result.data.length).toBeGreaterThan(0);
+  });
+
+  test("items is empty when no signers provided", async () => {
+    const result = await ops.makeTransaction(invocations);
+
+    expect(Object.keys(result.items)).toHaveLength(0);
+  });
+
+  test("items has one entry per signer", async () => {
+    const signers = [
+      { account: ops.account.scriptHash, scopes: "CalledByEntry" as const },
+    ];
+
+    const result = await ops.makeTransaction(invocations, signers);
+
+    expect(Object.keys(result.items)).toHaveLength(1);
+  });
+
+  test("each item has empty script, parameters and signatures", async () => {
+    const signers = [
+      { account: ops.account.scriptHash, scopes: "CalledByEntry" as const },
+    ];
+
+    const result = await ops.makeTransaction(invocations, signers);
+    const item = Object.values(result.items)[0];
+
+    expect(item.script).toBe("");
+    expect(item.parameters).toEqual([]);
+    expect(item.signatures).toEqual({});
+  });
+
+  test("throws DapiError when rpcClient rejects", async () => {
+    ops.rpcClient.getVersion = jest
+      .fn()
+      .mockRejectedValue(new Error("RPC error"));
+
+    await expect(ops.makeTransaction(invocations)).rejects.toBeInstanceOf(
+      Error,
+    );
+  });
+});
+
+describe("DapiOperations.sign", () => {
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  const invocations = [
+    {
+      hash: "0xd2a4cff31913016155e38e474a2c06d08be276cf",
+      operation: "transfer",
+      args: [],
+    },
+  ];
+
+  beforeEach(() => {
+    ops.rpcClient.getBlockCount = jest.fn().mockResolvedValue(1000);
+    ops.rpcClient.invokeScript = jest
+      .fn()
+      .mockResolvedValue({ state: "HALT", gasconsumed: "100", stack: [] });
+    ops.rpcClient.calculateNetworkFee = jest.fn().mockResolvedValue(50);
+    ops.rpcClient.getVersion = jest
+      .fn()
+      .mockResolvedValue({ protocol: { network: DapiNetwork.TESTNET } });
+  });
+
+  test("throws DapiError INVALID when account is not part of the transaction", async () => {
+    const context = await ops.makeTransaction(invocations);
+
+    // context has no items — account not registered as signer
+    await expect(ops.sign(context)).rejects.toMatchObject({
+      code: DapiErrorCode.INVALID,
+    });
+  });
+
+  test("returns updated context with correct type", async () => {
+    const signers = [
+      { account: ops.account.scriptHash, scopes: "CalledByEntry" as const },
+    ];
+    const context = await ops.makeTransaction(invocations, signers);
+
+    const result = await ops.sign(context);
+
+    expect(result.type).toBe("Neo.Network.P2P.Payloads.Transaction");
+  });
+
+  test("adds signature for connected account pubkey", async () => {
+    const signers = [
+      { account: ops.account.scriptHash, scopes: "CalledByEntry" as const },
+    ];
+    const context = await ops.makeTransaction(invocations, signers);
+
+    const result = await ops.sign(context);
+
+    const item = result.items[ops.account.scriptHash.replace(/^0x/i, "")];
+    expect(item.signatures[ops.account.publicKey]).toBeDefined();
+    expect(typeof item.signatures[ops.account.publicKey]).toBe("string");
+  });
+
+  test("network is preserved from original context", async () => {
+    const signers = [
+      { account: ops.account.scriptHash, scopes: "CalledByEntry" as const },
+    ];
+    const context = await ops.makeTransaction(invocations, signers);
+
+    const result = await ops.sign(context);
+
+    expect(result.network).toBe(context.network);
+  });
+
+  test("returned context data is different from unsigned context", async () => {
+    const signers = [
+      { account: ops.account.scriptHash, scopes: "CalledByEntry" as const },
+    ];
+    const context = await ops.makeTransaction(invocations, signers);
+
+    const result = await ops.sign(context);
+
+    // signed tx serializes differently (includes witness)
+    expect(result.hash).toBe(context.hash);
+  });
+
+  test("parameters contain a Signature entry matching the account signature", async () => {
+    const signers = [
+      { account: ops.account.scriptHash, scopes: "CalledByEntry" as const },
+    ];
+    const context = await ops.makeTransaction(invocations, signers);
+
+    const result = await ops.sign(context);
+
+    const item = result.items[ops.account.scriptHash.replace(/^0x/i, "")];
+    const signatureParam = item.parameters.find((p) => p.type === "Signature");
+
+    expect(signatureParam).toBeDefined();
+    expect(signatureParam?.value).toBe(item.signatures[ops.account.publicKey]);
+  });
+});
+
+describe("DapiOperations.relay", () => {
+  const context = {
+    type: "Neo.Network.P2P.Payloads.Transaction" as const,
+    hash: TXID,
+    network: DapiNetwork.TESTNET,
+    data: "c2lnbmVkdHg=",
+    items: {},
+  };
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account: new wallet.Account(),
+  });
+
+  test("returns txid from sendRawTransaction", async () => {
+    ops.rpcClient.sendRawTransaction = jest.fn().mockResolvedValue(TXID);
+
+    const result = await ops.relay(context);
+
+    expect(result).toBe(TXID);
+  });
+
+  test("calls sendRawTransaction with context.data", async () => {
+    ops.rpcClient.sendRawTransaction = jest.fn().mockResolvedValue(TXID);
+
+    await ops.relay(context);
+
+    expect(ops.rpcClient.sendRawTransaction).toHaveBeenCalledWith(context.data);
+  });
+
+  test("throws DapiError when sendRawTransaction rejects", async () => {
+    ops.rpcClient.sendRawTransaction = jest
+      .fn()
+      .mockRejectedValue(new Error("broadcast failed"));
+
+    await expect(ops.relay(context)).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("DapiOperations.signMessage", () => {
+  const account = new wallet.Account();
+
+  const ops = new DapiOperations({
+    rpcClient: "",
+    network: DapiNetwork.TESTNET,
+    account,
+  });
+
+  test("returns correct response shape", async () => {
+    const result = await ops.signMessage("hello");
+
+    expect(typeof result.payload).toBe("string");
+    expect(typeof result.signature).toBe("string");
+    expect(result.account).toBe(account.scriptHash);
+    expect(result.pubkey).toBe(account.publicKey);
+  });
+
+  test("payload is utf8 message encoded as base64", async () => {
+    const result = await ops.signMessage("hello");
+
+    const { u: uActual } = jest.requireActual("@cityofzion/neon-core");
+    expect(result.payload).toBe(uActual.utf82base64("hello"));
+  });
+
+  test("signature is cryptographically valid for utf8 message", async () => {
+    const message = "hello world";
+    const result = await ops.signMessage(message);
+
+    const { u: uActual, wallet: walletActual } = jest.requireActual(
+      "@cityofzion/neon-core",
+    );
+    const hexMessage = uActual.str2hexstring(message);
+    const signatureHex = uActual.base642hex(result.signature);
+
+    expect(
+      walletActual.verify(hexMessage, signatureHex, account.publicKey),
+    ).toBe(true);
+  });
+
+  test("accepts base64 encoded message when isBase64Encoded is true", async () => {
+    const { u: uActual, wallet: walletActual } = jest.requireActual(
+      "@cityofzion/neon-core",
+    );
+    const base64Message = uActual.utf82base64("hello");
+
+    const result = await ops.signMessage(base64Message, undefined, {
+      isBase64Encoded: true,
+    });
+
+    const hexMessage = uActual.base642hex(base64Message);
+    const signatureHex = uActual.base642hex(result.signature);
+    expect(
+      walletActual.verify(hexMessage, signatureHex, account.publicKey),
+    ).toBe(true);
+  });
+
+  test("throws DapiError INVALID when account does not match", async () => {
+    const otherAccount = new wallet.Account();
+
+    await expect(
+      ops.signMessage("hello", otherAccount.scriptHash),
+    ).rejects.toMatchObject({ code: DapiErrorCode.INVALID });
+  });
+
+  test("throws DapiError INVALID when isTypedData is true", async () => {
+    await expect(
+      ops.signMessage("hello", undefined, { isTypedData: true }),
+    ).rejects.toMatchObject({ code: DapiErrorCode.INVALID });
+  });
+
+  test("does not throw when account matches connected account", async () => {
+    await expect(
+      ops.signMessage("hello", account.scriptHash),
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/neon-dapi/__tests__/DapiOperations.ts
+++ b/packages/neon-dapi/__tests__/DapiOperations.ts
@@ -72,11 +72,13 @@ describe("DapiOperations.authenticate", () => {
     const payload = makePayload();
     const response = await ops.authenticate(payload);
 
-    const networkHex = u.num2hexstring(response.network, 1, true);
+    const networkHex = u.num2hexstring(response.network, 4, true);
     const nonceHex = u.num2hexstring(Number(payload.nonce), 8, true);
-    const timestampHex = u.num2hexstring(response.timestamp, 8, true);
+    const timestampHex = u.num2hexstring(response.timestamp, 4, true);
     const hashHex = account.scriptHash.replace(/^0x/i, "");
-    const message = `${networkHex}${nonceHex}${timestampHex}${hashHex}`;
+    const actionHex = u.str2hexstring(payload.action);
+    const domainHex = u.str2hexstring(payload.domain);
+    const message = `${networkHex}${nonceHex}${timestampHex}${hashHex}${actionHex}${domainHex}`;
 
     const signatureHex = u.base642hex(response.signature);
     const isValid = wallet.verify(message, signatureHex, account.publicKey);

--- a/packages/neon-dapi/api-extractor.json
+++ b/packages/neon-dapi/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "../../api-extractor-base.json"
+}

--- a/packages/neon-dapi/conformance/conformance.css
+++ b/packages/neon-dapi/conformance/conformance.css
@@ -1,0 +1,378 @@
+:root {
+  --bg: #0a0e14;
+  --surf: #141a22;
+  --surf2: #1c2430;
+  --border: #263040;
+  --text: #cdd9e5;
+  --muted: #768390;
+  --dim: #3d4752;
+  --accent: #39d98a;
+  --pass: #3fb950;
+  --fail: #f85149;
+  --warn: #e3b341;
+  --info: #58a6ff;
+  --mono: "SF Mono", "Cascadia Code", "Fira Code", "Consolas", monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+  --r: 6px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.wrap {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px 20px 64px;
+}
+
+/* ── Header ── */
+
+header {
+  margin-bottom: 28px;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.logo-mark {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+h1 {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.sub {
+  color: var(--muted);
+  font-size: 12px;
+  margin-left: 44px;
+  margin-top: 2px;
+}
+
+/* ── Provider pill ── */
+
+.pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 13px;
+  background: var(--surf);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  margin-bottom: 20px;
+  font-size: 13px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--dim);
+  transition:
+    background 0.3s,
+    box-shadow 0.3s;
+}
+
+.dot.found {
+  background: var(--pass);
+  box-shadow: 0 0 7px var(--pass);
+}
+.dot.error {
+  background: var(--fail);
+}
+
+/* ── Toolbar ── */
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 16px;
+  border-radius: var(--r);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: opacity 0.15s;
+  font-family: var(--sans);
+}
+
+.btn:hover {
+  opacity: 0.82;
+}
+.btn:active {
+  opacity: 0.65;
+}
+.btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #000;
+}
+.btn-ghost {
+  background: var(--surf2);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.sbar {
+  font-size: 12px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Test groups ── */
+
+.group {
+  background: var(--surf);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  overflow: hidden;
+  margin-bottom: 10px;
+}
+
+.group-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+}
+
+.group-title {
+  font-weight: 600;
+  font-size: 13px;
+  flex: 1;
+}
+
+.group-badge {
+  font-size: 11px;
+}
+
+.chev {
+  color: var(--dim);
+  font-size: 9px;
+  transition: transform 0.18s;
+  cursor: pointer;
+  padding: 2px 4px;
+}
+
+.chev.open {
+  transform: rotate(90deg);
+}
+
+.group-body {
+  border-top: 1px solid var(--border);
+}
+.group-body.hide {
+  display: none;
+}
+
+/* ── Test rows ── */
+
+.trow {
+  border-bottom: 1px solid var(--border);
+}
+.trow:last-child {
+  border-bottom: none;
+}
+
+.tmain {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 14px;
+  cursor: pointer;
+  min-height: 38px;
+}
+
+.tmain:hover {
+  background: var(--surf2);
+}
+
+.ticon {
+  width: 14px;
+  text-align: center;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.tname {
+  flex: 1;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.ttag {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid #6b4f00;
+  color: var(--warn);
+  flex-shrink: 0;
+}
+
+.tdur {
+  font-size: 11px;
+  color: var(--dim);
+  font-variant-numeric: tabular-nums;
+  min-width: 42px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.tstat {
+  font-size: 11px;
+  font-weight: 700;
+  min-width: 42px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.btn-run {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 2px 7px;
+  flex-shrink: 0;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.btn-run:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.s-idle {
+  color: var(--dim);
+}
+.s-run {
+  color: var(--info);
+}
+.s-pass {
+  color: var(--pass);
+}
+.s-fail {
+  color: var(--fail);
+}
+
+/* ── Test detail ── */
+
+.tdetail {
+  padding: 10px 14px 10px 37px;
+  border-top: 1px solid var(--border);
+  background: #070b10;
+}
+
+.tdetail.hide {
+  display: none;
+}
+
+.terror {
+  color: var(--fail);
+  font-family: var(--mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-bottom: 6px;
+}
+
+.terror.hide {
+  display: none;
+}
+
+.tres {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 200px;
+  overflow-y: auto;
+  line-height: 1.5;
+}
+
+/* ── Summary ── */
+
+.summary {
+  margin-top: 20px;
+  padding: 12px 16px;
+  background: var(--surf);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.summary.hide {
+  display: none;
+}
+
+.sv {
+  font-weight: 700;
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+  margin-right: 4px;
+}
+
+.sv-pass {
+  color: var(--pass);
+}
+.sv-fail {
+  color: var(--fail);
+}
+.sv-skip {
+  color: var(--dim);
+}
+
+.st {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 12px;
+}

--- a/packages/neon-dapi/conformance/conformance.js
+++ b/packages/neon-dapi/conformance/conformance.js
@@ -1,0 +1,889 @@
+// ── Assertion helpers ─────────────────────────────────────────────────────────
+
+const toJson = (value) => JSON.stringify(value);
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+// Set to a known account script hash on the target network
+const GAS = "0xd2a4cff31913016155e38e474a2c06d08be276cf";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+const authenticateTest = {
+  id: "auth",
+  name: "authenticate",
+  tag: "interactive",
+  fn: async (provider) => {
+    const payload = {
+      action: "Authentication",
+      grant_type: "Signature",
+      allowed_algorithms: ["ECDSA-P256"],
+      domain: location.hostname || "localhost",
+      networks: [894710606],
+      nonce: Math.floor(Math.random() * 1e9).toString(),
+      timestamp: Math.floor(Date.now() / 1000),
+    };
+
+    const authResponse = await provider.authenticate(payload);
+
+    assert(
+      authResponse && typeof authResponse === "object",
+      "expected object response",
+    );
+    assert(
+      authResponse.algorithm === "ECDSA-P256",
+      'expected algorithm "ECDSA-P256", got ' + toJson(authResponse.algorithm),
+    );
+    assert(
+      typeof authResponse.network === "number",
+      "expected network number, got " + typeof authResponse.network,
+    );
+    assert(
+      typeof authResponse.pubkey === "string" && authResponse.pubkey.length > 0,
+      "pubkey must be non-empty string",
+    );
+    assert(
+      typeof authResponse.address === "string" &&
+        authResponse.address.length > 0,
+      "address must be non-empty string",
+    );
+    assert(typeof authResponse.nonce === "string", "nonce must be string");
+    assert(
+      typeof authResponse.timestamp === "number",
+      "timestamp must be number",
+    );
+    assert(
+      typeof authResponse.signature === "string" &&
+        authResponse.signature.length > 0,
+      "signature must be non-empty string",
+    );
+
+    return authResponse;
+  },
+};
+
+const getAccountsTest = {
+  id: "getAccounts",
+  name: "getAccounts",
+  fn: async (provider) => {
+    const accounts = await provider.getAccounts();
+
+    assert(Array.isArray(accounts), "expected array, got " + typeof accounts);
+    assert(
+      accounts.length > 0,
+      "expected at least one account — connect an account in the wallet first",
+    );
+
+    const firstAccount = accounts[0];
+    assert(
+      typeof firstAccount.hash === "string" && firstAccount.hash.length > 0,
+      "account.hash must be non-empty string",
+    );
+    assert(
+      typeof firstAccount.address === "string" &&
+        firstAccount.address.length > 0,
+      "account.address must be non-empty string",
+    );
+    if (firstAccount.label !== undefined)
+      assert(
+        typeof firstAccount.label === "string",
+        "account.label must be string if present",
+      );
+    if (firstAccount.contract !== undefined) {
+      assert(
+        typeof firstAccount.contract === "object",
+        "account.contract must be object if present",
+      );
+      assert(
+        Array.isArray(firstAccount.contract.parameters),
+        "account.contract.parameters must be array",
+      );
+      assert(
+        typeof firstAccount.contract.deployed === "boolean",
+        "account.contract.deployed must be boolean",
+      );
+    }
+
+    return accounts;
+  },
+};
+
+const callTest = {
+  id: "call",
+  name: "call",
+  fn: async (provider) => {
+    const callResult = await provider.call({
+      hash: GAS,
+      operation: "symbol",
+      args: [],
+    });
+
+    assert(
+      callResult && typeof callResult === "object",
+      "expected object response",
+    );
+    assert(
+      typeof callResult.script === "string" && callResult.script.length > 0,
+      "script must be non-empty string",
+    );
+    assert(
+      callResult.state === "HALT",
+      'expected state "HALT", got ' + toJson(callResult.state),
+    );
+    assert(
+      Number.isInteger(Number(callResult.gasconsumed)),
+      "gasconsumed must be a non-float integer, got " +
+        toJson(callResult.gasconsumed),
+    );
+    assert(
+      Array.isArray(callResult.notifications),
+      "notifications must be array",
+    );
+    assert(
+      Array.isArray(callResult.stack) && callResult.stack.length > 0,
+      "stack must be non-empty array",
+    );
+    assert(
+      callResult.stack[0].type === "ByteString",
+      'expected stack[0].type "ByteString", got ' +
+        toJson(callResult.stack[0].type),
+    );
+
+    return callResult;
+  },
+};
+
+const getBalanceTest = {
+  id: "getBalance",
+  name: "getBalance",
+  fn: async (provider) => {
+    const accounts = await provider.getAccounts();
+    assert(
+      Array.isArray(accounts) && accounts.length > 0,
+      "no connected accounts — connect an account in the wallet first",
+    );
+
+    console.log(accounts);
+
+    const balance = await provider.getBalance(GAS, accounts[0].hash);
+
+    assert(
+      typeof balance === "string" || typeof balance === "number",
+      "expected string or number, got " + typeof balance,
+    );
+    assert(
+      Number.isInteger(Number(balance)),
+      "balance must be a non-float integer, got " + toJson(balance),
+    );
+    assert(
+      Number(balance) >= 0,
+      "balance must be non-negative, got " + toJson(balance),
+    );
+
+    return balance;
+  },
+};
+
+const getApplicationLogTest = {
+  id: "getApplicationLog",
+  name: "getApplicationLog",
+  fn: async (provider) => {
+    const applicationLog = await provider.getApplicationLog(
+      "0xdf8bb3aa6fcd3b0b9e54a7ae563cd13648fb2ad42f67c4ea47435bd014d10626",
+    );
+
+    assert(
+      applicationLog && typeof applicationLog === "object",
+      "expected object response",
+    );
+    assert(
+      typeof applicationLog.txid === "string" && applicationLog.txid.length > 0,
+      "txid must be non-empty string",
+    );
+    assert(
+      Array.isArray(applicationLog.executions) &&
+        applicationLog.executions.length > 0,
+      "executions must be non-empty array",
+    );
+
+    const firstExecution = applicationLog.executions[0];
+    assert(
+      typeof firstExecution.trigger === "string",
+      "executions[0].trigger must be string",
+    );
+    assert(
+      typeof firstExecution.vmstate === "string",
+      "executions[0].vmstate must be string",
+    );
+    assert(
+      Number.isInteger(Number(firstExecution.gasconsumed)),
+      "executions[0].gasconsumed must be a non-float integer, got " +
+        toJson(firstExecution.gasconsumed),
+    );
+    assert(
+      Array.isArray(firstExecution.stack),
+      "executions[0].stack must be array",
+    );
+    assert(
+      Array.isArray(firstExecution.notifications),
+      "executions[0].notifications must be array",
+    );
+
+    return applicationLog;
+  },
+};
+
+const getBlockCountTest = {
+  id: "getBlockCount",
+  name: "getBlockCount",
+  fn: async (provider) => {
+    const blockCount = await provider.getBlockCount();
+
+    assert(
+      typeof blockCount === "number",
+      "expected number, got " + typeof blockCount,
+    );
+    assert(
+      Number.isInteger(blockCount),
+      "blockCount must be a non-float integer, got " + toJson(blockCount),
+    );
+    assert(
+      blockCount > 0,
+      "blockCount must be greater than 0, got " + toJson(blockCount),
+    );
+
+    return blockCount;
+  },
+};
+
+const getBlockTest = {
+  id: "getBlock",
+  name: "getBlock",
+  fn: async (provider) => {
+    const blockCount = await provider.getBlockCount();
+    const block = await provider.getBlock(Number(blockCount - 1));
+
+    assert(block && typeof block === "object", "expected object response");
+    assert(
+      typeof block.hash === "string" && block.hash.length > 0,
+      "block.hash must be non-empty string",
+    );
+    assert(
+      Number.isInteger(block.size) && block.size > 0,
+      "block.size must be a positive integer, got " + toJson(block.size),
+    );
+    assert(
+      Number.isInteger(block.confirmations) && block.confirmations > 0,
+      "block.confirmations must be a positive integer, got " +
+        toJson(block.confirmations),
+    );
+    assert(
+      Number.isInteger(block.version),
+      "block.version must be integer, got " + toJson(block.version),
+    );
+    assert(
+      typeof block.previousBlockHash === "string",
+      "block.previousBlockHash must be string",
+    );
+    assert(
+      typeof block.merkleRoot === "string" && block.merkleRoot.length > 0,
+      "block.merkleRoot must be non-empty string",
+    );
+    assert(
+      Number.isInteger(block.time) && block.time > 0,
+      "block.time must be a positive integer, got " + toJson(block.time),
+    );
+    assert(
+      typeof block.nonce === "string" && block.nonce.length > 0,
+      "block.nonce must be non-empty string",
+    );
+    assert(
+      Number.isInteger(block.index),
+      "block.index must be integer, got " + toJson(block.index),
+    );
+    assert(
+      Number.isInteger(block.primary),
+      "block.primary must be integer, got " + toJson(block.primary),
+    );
+    assert(
+      typeof block.nextConsensus === "string" && block.nextConsensus.length > 0,
+      "block.nextConsensus must be non-empty string",
+    );
+    assert(Array.isArray(block.tx), "block.tx must be array");
+
+    return block;
+  },
+};
+
+const getStorageTest = {
+  id: "getStorage",
+  name: "getStorage",
+  fn: async (provider) => {
+    const totalSupplyKey = "Cw==";
+    const storageValue = await provider.getStorage(GAS, "Cw==");
+
+    assert(
+      typeof storageValue === "string" && storageValue.length > 0,
+      "expected non-empty string, got " + typeof storageValue,
+    );
+    assert(
+      /^[A-Za-z0-9+/]*={0,2}$/.test(storageValue),
+      "storageValue must be valid base64, got " + toJson(storageValue),
+    );
+
+    return storageValue;
+  },
+};
+
+const getTokenInfoTest = {
+  id: "getTokenInfo",
+  name: "getTokenInfo",
+  fn: async (provider) => {
+    const tokenInfo = await provider.getTokenInfo(GAS);
+
+    assert(
+      tokenInfo && typeof tokenInfo === "object",
+      "expected object response",
+    );
+    assert(
+      typeof tokenInfo.symbol === "string" && tokenInfo.symbol.length > 0,
+      "tokenInfo.symbol must be non-empty string",
+    );
+    assert(
+      tokenInfo.symbol === "GAS",
+      'expected symbol "GAS", got ' + toJson(tokenInfo.symbol),
+    );
+    assert(
+      Number.isInteger(tokenInfo.decimals),
+      "tokenInfo.decimals must be a non-float integer, got " +
+        toJson(tokenInfo.decimals),
+    );
+    assert(
+      tokenInfo.decimals === 8,
+      "tokenInfo.decimals must be 8, got " + toJson(tokenInfo.decimals),
+    );
+    assert(
+      typeof tokenInfo.totalSupply === "string" ||
+        typeof tokenInfo.totalSupply === "number",
+      "tokenInfo.totalSupply must be string or number, got " +
+        typeof tokenInfo.totalSupply,
+    );
+    assert(
+      Number.isInteger(Number(tokenInfo.totalSupply)),
+      "tokenInfo.totalSupply must be a non-float integer, got " +
+        toJson(tokenInfo.totalSupply),
+    );
+
+    return tokenInfo;
+  },
+};
+
+const getTransactionTest = {
+  id: "getTransaction",
+  name: "getTransaction",
+  fn: async (provider) => {
+    const applicationLog = await provider.getApplicationLog(
+      "0xdf8bb3aa6fcd3b0b9e54a7ae563cd13648fb2ad42f67c4ea47435bd014d10626",
+    );
+    const transaction = await provider.getTransaction(applicationLog.txid);
+
+    assert(
+      transaction && typeof transaction === "object",
+      "expected object response",
+    );
+    assert(
+      typeof transaction.hash === "string" && transaction.hash.length > 0,
+      "transaction.hash must be non-empty string",
+    );
+    assert(
+      transaction.hash === applicationLog.txid,
+      "transaction.hash must match requested txid",
+    );
+    assert(
+      Number.isInteger(transaction.size) && transaction.size > 0,
+      "transaction.size must be a positive integer, got " +
+        toJson(transaction.size),
+    );
+    assert(
+      Number.isInteger(transaction.version),
+      "transaction.version must be integer, got " + toJson(transaction.version),
+    );
+    assert(
+      Number.isInteger(transaction.nonce),
+      "transaction.nonce must be integer, got " + toJson(transaction.nonce),
+    );
+    assert(
+      typeof transaction.blockHash === "string" &&
+        transaction.blockHash.length > 0,
+      "transaction.blockHash must be non-empty string",
+    );
+    assert(
+      Number.isInteger(transaction.blockTime) && transaction.blockTime > 0,
+      "transaction.blockTime must be a positive integer, got " +
+        toJson(transaction.blockTime),
+    );
+    assert(
+      Number.isInteger(transaction.confirmations) &&
+        transaction.confirmations > 0,
+      "transaction.confirmations must be a positive integer, got " +
+        toJson(transaction.confirmations),
+    );
+    assert(
+      Number.isInteger(Number(transaction.systemFee)),
+      "transaction.systemFee must be a non-float integer, got " +
+        toJson(transaction.systemFee),
+    );
+    assert(
+      Number.isInteger(Number(transaction.networkFee)),
+      "transaction.networkFee must be a non-float integer, got " +
+        toJson(transaction.networkFee),
+    );
+    assert(
+      Number.isInteger(transaction.validUntilBlock),
+      "transaction.validUntilBlock must be integer, got " +
+        toJson(transaction.validUntilBlock),
+    );
+    assert(
+      typeof transaction.sender === "string" && transaction.sender.length > 0,
+      "transaction.sender must be non-empty string",
+    );
+    assert(
+      Array.isArray(transaction.signers),
+      "transaction.signers must be array",
+    );
+    assert(
+      Array.isArray(transaction.attributes),
+      "transaction.attributes must be array",
+    );
+    assert(
+      typeof transaction.script === "string" && transaction.script.length > 0,
+      "transaction.script must be non-empty string",
+    );
+
+    return transaction;
+  },
+};
+
+const invokeTest = {
+  id: "invoke",
+  name: "invoke",
+  tag: "interactive",
+  fn: async (provider) => {
+    const accounts = await provider.getAccounts();
+    assert(
+      Array.isArray(accounts) && accounts.length > 0,
+      "no connected accounts — connect an account in the wallet first",
+    );
+
+    const senderHash = accounts[0].hash;
+
+    const txid = await provider.invoke(
+      [
+        {
+          hash: GAS,
+          operation: "transfer",
+          args: [
+            { type: "Hash160", value: senderHash },
+            { type: "Hash160", value: senderHash },
+            { type: "Integer", value: 1 },
+            { type: "String", value: "321" },
+          ],
+        },
+      ],
+      [{ account: senderHash, scopes: "CalledByEntry" }],
+    );
+
+    assert(
+      typeof txid === "string" && txid.length > 0,
+      "expected non-empty string txid, got " + typeof txid,
+    );
+    assert(
+      txid.startsWith("0x"),
+      'txid must start with "0x", got ' + toJson(txid),
+    );
+    assert(
+      txid.length === 66,
+      "txid must be 66 characters (0x + 64 hex), got length " + txid.length,
+    );
+
+    return txid;
+  },
+};
+
+const sendTest = {
+  id: "send",
+  name: "send",
+  tag: "interactive",
+  fn: async (provider) => {
+    const accounts = await provider.getAccounts();
+    assert(
+      Array.isArray(accounts) && accounts.length > 0,
+      "no connected accounts — connect an account in the wallet first",
+    );
+
+    const senderHash = accounts[0].hash;
+
+    // Send 1 datoshi (0.00000001 GAS) to self — minimal cost, safe for testnet
+    const txid = await provider.send(GAS, senderHash, senderHash, "1");
+
+    assert(
+      typeof txid === "string" && txid.length > 0,
+      "expected non-empty string txid, got " + typeof txid,
+    );
+    assert(
+      txid.startsWith("0x"),
+      'txid must start with "0x", got ' + toJson(txid),
+    );
+    assert(
+      txid.length === 66,
+      "txid must be 66 characters (0x + 64 hex), got length " + txid.length,
+    );
+
+    return txid;
+  },
+};
+
+const signMessageTest = {
+  id: "signMessage",
+  name: "signMessage",
+  tag: "interactive",
+  fn: async (provider) => {
+    const signedMessage = await provider.signMessage("Hello Neo");
+
+    assert(
+      signedMessage && typeof signedMessage === "object",
+      "expected object response",
+    );
+    assert(
+      typeof signedMessage.payload === "string" &&
+        signedMessage.payload.length > 0,
+      "signedMessage.payload must be non-empty string",
+    );
+    assert(
+      /^[A-Za-z0-9+/]*={0,2}$/.test(signedMessage.payload),
+      "signedMessage.payload must be valid base64",
+    );
+    assert(
+      typeof signedMessage.signature === "string" &&
+        signedMessage.signature.length > 0,
+      "signedMessage.signature must be non-empty string",
+    );
+    assert(
+      /^[A-Za-z0-9+/]*={0,2}$/.test(signedMessage.signature),
+      "signedMessage.signature must be valid base64",
+    );
+    assert(
+      typeof signedMessage.account === "string" &&
+        signedMessage.account.length > 0,
+      "signedMessage.account must be non-empty string",
+    );
+    assert(
+      typeof signedMessage.pubkey === "string" &&
+        signedMessage.pubkey.length > 0,
+      "signedMessage.pubkey must be non-empty string",
+    );
+
+    return signedMessage;
+  },
+};
+
+const makeTransactionTest = {
+  id: "makeTransaction",
+  name: "makeTransaction",
+  tag: "interactive",
+  fn: async (provider) => {
+    const accounts = await provider.getAccounts();
+    assert(
+      Array.isArray(accounts) && accounts.length > 0,
+      "no connected accounts — connect an account in the wallet first",
+    );
+
+    const senderHash = accounts[0].hash;
+    const signers = [{ account: senderHash, scopes: "CalledByEntry" }];
+    const context = await provider.makeTransaction(
+      [
+        {
+          hash: GAS,
+          operation: "transfer",
+          args: [
+            { type: "Hash160", value: senderHash },
+            { type: "Hash160", value: senderHash },
+            { type: "Integer", value: 1 },
+            { type: "String", value: "321" },
+          ],
+        },
+      ],
+      signers,
+    );
+
+    assert(context && typeof context === "object", "expected object response");
+    assert(
+      context.type === "Neo.Network.P2P.Payloads.Transaction",
+      'context.type must be "Neo.Network.P2P.Payloads.Transaction", got ' +
+        toJson(context.type),
+    );
+    assert(
+      typeof context.hash === "string" && context.hash.length > 0,
+      "context.hash must be non-empty string",
+    );
+    assert(
+      context.hash.startsWith("0x"),
+      'context.hash must start with "0x", got ' + toJson(context.hash),
+    );
+    assert(
+      typeof context.data === "string" && context.data.length > 0,
+      "context.data must be non-empty string",
+    );
+    assert(
+      /^[A-Za-z0-9+/]*={0,2}$/.test(context.data),
+      "context.data must be valid base64",
+    );
+
+    assert(
+      context.items && typeof context.items === "object",
+      "context.items must be object",
+    );
+    const itemKeys = Object.keys(context.items);
+    assert(
+      itemKeys.length === signers.length,
+      "context.items must have the same number of entries as signers",
+    );
+    for (const key of itemKeys) {
+      const item = context.items[key];
+      assert(
+        key === senderHash,
+        "context.items[" + key + "] must be equal to senderHash",
+      );
+      assert(
+        typeof item === "object" && item !== null,
+        "context.items[" + key + "] must be object",
+      );
+      assert(
+        typeof item.script === "string" && item.script.length === 0,
+        "context.items[" + key + "].script must be empty string",
+      );
+      assert(
+        Array.isArray(item.parameters) && item.parameters.length === 0,
+        "context.items[" + key + "].parameters must be array",
+      );
+      assert(
+        typeof item.signatures === "object" &&
+          Object.keys(item.signatures).length === 0,
+        "context.items[" + key + "].signatures must be object",
+      );
+    }
+    assert(
+      typeof context.network === "number",
+      "context.network must be number, got " + typeof context.network,
+    );
+
+    return context;
+  },
+};
+
+const signTest = {
+  id: "sign",
+  name: "sign",
+  tag: "interactive",
+  fn: async (provider) => {
+    const accounts = await provider.getAccounts();
+    assert(
+      Array.isArray(accounts) && accounts.length > 0,
+      "no connected accounts — connect an account in the wallet first",
+    );
+
+    const senderHash = accounts[0].hash;
+    const signers = [{ account: senderHash, scopes: "CalledByEntry" }];
+
+    const context = await provider.makeTransaction(
+      [
+        {
+          hash: GAS,
+          operation: "transfer",
+          args: [
+            { type: "Hash160", value: senderHash },
+            { type: "Hash160", value: senderHash },
+            { type: "Integer", value: 1 },
+            { type: "String", value: "321" },
+          ],
+        },
+      ],
+      signers,
+    );
+
+    const signedContext = await provider.sign(context);
+
+    assert(
+      signedContext && typeof signedContext === "object",
+      "expected object response",
+    );
+    assert(
+      signedContext.type === "Neo.Network.P2P.Payloads.Transaction",
+      'signedContext.type must be "Neo.Network.P2P.Payloads.Transaction", got ' +
+        toJson(signedContext.type),
+    );
+    assert(
+      signedContext.hash === context.hash,
+      "signedContext.hash must match original context hash",
+    );
+    assert(
+      typeof signedContext.data === "string" && signedContext.data.length > 0,
+      "signedContext.data must be non-empty string",
+    );
+    assert(
+      /^[A-Za-z0-9+/]*={0,2}$/.test(signedContext.data),
+      "signedContext.data must be valid base64",
+    );
+
+    assert(
+      signedContext.items && typeof signedContext.items === "object",
+      "signedContext.items must be object",
+    );
+    const itemKeys = Object.keys(signedContext.items);
+    assert(
+      itemKeys.length === signers.length,
+      "signedContext.items must have at least one entry",
+    );
+    for (const key of itemKeys) {
+      const item = signedContext.items[key];
+
+      assert(
+        key === senderHash,
+        "context.items[" + key + "] must be equal to senderHash",
+      );
+      assert(
+        typeof item.script === "string" && item.script.length > 0,
+        "context.items[" + key + "].script must be non-empty string",
+      );
+      assert(
+        /^[A-Za-z0-9+/]*={0,2}$/.test(item.script),
+        "context.items[" + key + "].script must be valid base64",
+      );
+
+      assert(
+        Array.isArray(item.parameters),
+        "context.items[" + key + "].parameters must be array",
+      );
+      const signatureParameters = item.parameters.find(
+        (parameter) => parameter.type === "Signature",
+      );
+      assert(
+        typeof signatureParameters.value === "string" &&
+          signatureParameters.value.length > 0,
+        "context.items[" +
+          key +
+          "].parameters must have at least one signature",
+      );
+      assert(
+        /^[A-Za-z0-9+/]*={0,2}$/.test(signatureParameters.value),
+        "context.items[" +
+          key +
+          "].parameters must have at least one signature",
+      );
+
+      assert(
+        typeof item.signatures === "object" && item.signatures !== null,
+        "signedContext.items[" + key + "].signatures must be object",
+      );
+      const signatureKeys = Object.keys(item.signatures);
+      assert(
+        signatureKeys.length > 0,
+        "signedContext.items[" +
+          key +
+          "].signatures must have at least one signature",
+      );
+      for (const pubkey of signatureKeys) {
+        assert(
+          /^[A-Za-z0-9+/]*={0,2}$/.test(item.signatures[pubkey]),
+          "signature for pubkey " + pubkey + " must be valid base64",
+        );
+      }
+    }
+    assert(
+      typeof signedContext.network === "number",
+      "signedContext.network must be number, got " +
+        typeof signedContext.network,
+    );
+
+    return signedContext;
+  },
+};
+
+const relayTest = {
+  id: "relay",
+  name: "relay",
+  tag: "interactive",
+  fn: async (provider) => {
+    const accounts = await provider.getAccounts();
+    assert(
+      Array.isArray(accounts) && accounts.length > 0,
+      "no connected accounts — connect an account in the wallet first",
+    );
+
+    const senderHash = accounts[0].hash;
+
+    const context = await provider.makeTransaction(
+      [
+        {
+          hash: GAS,
+          operation: "transfer",
+          args: [
+            { type: "Hash160", value: senderHash },
+            { type: "Hash160", value: senderHash },
+            { type: "Integer", value: 1 },
+            { type: "String", value: "321" },
+          ],
+        },
+      ],
+      [{ account: accounts[0].hash, scopes: "CalledByEntry" }],
+    );
+    const signedContext = await provider.sign(context);
+    const txid = await provider.relay(signedContext);
+
+    assert(
+      typeof txid === "string" && txid.length > 0,
+      "expected non-empty string txid, got " + typeof txid,
+    );
+    assert(
+      txid.startsWith("0x"),
+      'txid must start with "0x", got ' + toJson(txid),
+    );
+    assert(
+      txid.length === 66,
+      "txid must be 66 characters (0x + 64 hex), got length " + txid.length,
+    );
+
+    return txid;
+  },
+};
+
+// ── Groups ────────────────────────────────────────────────────────────────────
+
+const GROUPS = [
+  {
+    id: "ia",
+    title: "Tests",
+    tests: [
+      authenticateTest,
+      getAccountsTest,
+      callTest,
+      getBalanceTest,
+      getBlockCountTest,
+      getBlockTest,
+      getStorageTest,
+      getTokenInfoTest,
+      getTransactionTest,
+      getApplicationLogTest,
+      invokeTest,
+      sendTest,
+      signMessageTest,
+      makeTransactionTest,
+      signTest,
+      relayTest,
+    ],
+  },
+];

--- a/packages/neon-dapi/conformance/index.html
+++ b/packages/neon-dapi/conformance/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neo DAPI Conformance Suite</title>
+  <link rel="stylesheet" href="conformance.css" />
+</head>
+
+<body>
+  <div class="wrap">
+    <header>
+      <div class="logo">
+        <div class="logo-mark">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M8 1L15 5V11L8 15L1 11V5L8 1Z" fill="#000" opacity=".5" />
+            <path d="M8 3.5L12.5 6V10L8 12.5L3.5 10V6L8 3.5Z" fill="#000" />
+          </svg>
+        </div>
+        <h1>Neo DAPI Conformance Suite</h1>
+      </div>
+      <p class="sub">Open in a browser with a Neo wallet extension active · tests run against the injected provider</p>
+    </header>
+
+    <div class="pill">
+      <div class="dot" id="pdot"></div>
+      <span id="ptxt">Waiting for provider…</span>
+    </div>
+
+    <div class="toolbar">
+      <button class="btn btn-primary" id="btnRun" onclick="runAll()" disabled>▶ Run All</button>
+      <button class="btn btn-ghost" onclick="resetAll()">↺ Reset</button>
+      <span class="spacer"></span>
+      <span class="sbar" id="sbar">—</span>
+    </div>
+
+    <div id="groups"></div>
+
+    <div class="summary hide" id="summary">
+      <div><span class="sv sv-pass" id="sPass">0</span> passed</div>
+      <div><span class="sv sv-fail" id="sFail">0</span> failed</div>
+      <div><span class="sv sv-skip" id="sSkip">0</span> skipped</div>
+      <span class="st" id="sTime"></span>
+    </div>
+  </div>
+
+  <script src="conformance.js"></script>
+  <script src="ui.js"></script>
+</body>
+
+</html>

--- a/packages/neon-dapi/conformance/ui.js
+++ b/packages/neon-dapi/conformance/ui.js
@@ -1,0 +1,222 @@
+// ── State ─────────────────────────────────────────────────────────────────────
+
+let provider = null;
+const state = {};
+
+function allTests() {
+  return GROUPS.flatMap((g) => g.tests);
+}
+
+// ── Provider discovery ────────────────────────────────────────────────────────
+
+function discover() {
+  const timeout = setTimeout(() => {
+    document.getElementById("pdot").className = "dot error";
+    document.getElementById("ptxt").textContent =
+      "No provider found — install a Neo wallet extension and reload";
+  }, 5000);
+
+  window.addEventListener(
+    "Neo.DapiProvider.ready",
+    (e) => {
+      clearTimeout(timeout);
+      provider = e.detail.provider;
+      document.getElementById("pdot").className = "dot found";
+      document.getElementById("ptxt").innerHTML =
+        "Provider: <strong>" + provider.name + "</strong> v" + provider.version;
+      document.getElementById("btnRun").disabled = false;
+      document.getElementById("sbar").textContent =
+        "Ready · " + allTests().length + " tests";
+    },
+    { once: true },
+  );
+
+  window.dispatchEvent(new Event("Neo.DapiProvider.request"));
+}
+
+// ── Render ────────────────────────────────────────────────────────────────────
+
+function render() {
+  document.getElementById("groups").innerHTML = GROUPS.map(
+    (g) => `
+    <div class="group">
+      <div class="group-head">
+        <span class="group-title">${g.title}</span>
+        <span class="group-badge" id="badge-${g.id}"></span>
+        <span class="chev open" id="chev-${g.id}" onclick="toggleGrp('${g.id}')">▶</span>
+      </div>
+      <div class="group-body" id="body-${g.id}">
+        ${g.tests
+          .map(
+            (t) => `
+          <div class="trow">
+            <div class="tmain" onclick="toggleDet('${t.id}')">
+              <span class="ticon s-idle" id="ico-${t.id}">○</span>
+              <span class="tname">${t.name}</span>
+              ${t.tag ? '<span class="ttag">' + t.tag + "</span>" : ""}
+              <span class="tdur" id="dur-${t.id}"></span>
+              <span class="tstat s-idle" id="st-${t.id}">—</span>
+              <button class="btn-run" onclick="event.stopPropagation(); runOne('${t.id}')">▶</button>
+            </div>
+            <div class="tdetail hide" id="det-${t.id}">
+              <div class="terror hide" id="err-${t.id}"></div>
+              <div class="tres" id="res-${t.id}"></div>
+            </div>
+          </div>
+        `,
+          )
+          .join("")}
+      </div>
+    </div>
+  `,
+  ).join("");
+}
+
+// ── Run ───────────────────────────────────────────────────────────────────────
+
+async function runTest(t) {
+  if (!provider) return;
+  setState(t.id, "run");
+  const t0 = performance.now();
+  try {
+    const r = await t.fn(provider);
+    setState(t.id, "pass", r, null, Math.round(performance.now() - t0));
+  } catch (e) {
+    setState(t.id, "fail", null, e, Math.round(performance.now() - t0));
+  }
+}
+
+async function runOne(id) {
+  const t = allTests().find((t) => t.id === id);
+  if (t) await runTest(t);
+}
+
+async function runAll() {
+  if (!provider) return;
+  document.getElementById("btnRun").disabled = true;
+  document.getElementById("summary").classList.add("hide");
+  const t0 = performance.now();
+  for (const g of GROUPS)
+    for (const t of g.tests) {
+      await runTest(t);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  showSummary(Math.round(performance.now() - t0));
+  document.getElementById("btnRun").disabled = false;
+}
+
+// ── State updates ─────────────────────────────────────────────────────────────
+
+function setState(id, status, result, err, ms) {
+  state[id] = { status, result, err, ms };
+
+  const ICONS = { idle: "○", run: "◌", pass: "✓", fail: "✗" };
+  const LABELS = { idle: "—", run: "…", pass: "PASS", fail: "FAIL" };
+  const COLORS = {
+    pass: "var(--pass)",
+    fail: "var(--fail)",
+    run: "var(--info)",
+    idle: "var(--dim)",
+  };
+
+  const ico = document.getElementById("ico-" + id);
+  ico.textContent = ICONS[status];
+  ico.style.color = COLORS[status];
+
+  const st = document.getElementById("st-" + id);
+  st.className = "tstat s-" + status;
+  st.textContent = LABELS[status];
+
+  if (ms != null) document.getElementById("dur-" + id).textContent = ms + "ms";
+
+  const errEl = document.getElementById("err-" + id);
+  if (err) {
+    errEl.textContent = err.message || String(err);
+    errEl.classList.remove("hide");
+    document.getElementById("det-" + id).classList.remove("hide");
+  } else {
+    errEl.classList.add("hide");
+  }
+
+  if (result != null)
+    document.getElementById("res-" + id).textContent = JSON.stringify(
+      result,
+      null,
+      2,
+    );
+
+  updateBadge(id);
+  updateBar();
+}
+
+function updateBadge(tid) {
+  for (const g of GROUPS) {
+    if (!g.tests.find((t) => t.id === tid)) continue;
+    const pass = g.tests.filter((t) => state[t.id]?.status === "pass").length;
+    const fail = g.tests.filter((t) => state[t.id]?.status === "fail").length;
+    const el = document.getElementById("badge-" + g.id);
+    if (!el) continue;
+    if (fail)
+      el.innerHTML =
+        '<span style="color:var(--fail)">' + fail + " failed</span>";
+    else if (pass === g.tests.length)
+      el.innerHTML = '<span style="color:var(--pass)">all passed</span>';
+    else if (pass)
+      el.innerHTML =
+        '<span style="color:var(--muted)">' +
+        pass +
+        "/" +
+        g.tests.length +
+        "</span>";
+    else el.innerHTML = "";
+  }
+}
+
+function updateBar() {
+  const all = allTests();
+  const done = all.filter(
+    (t) => state[t.id]?.status === "pass" || state[t.id]?.status === "fail",
+  ).length;
+  document.getElementById("sbar").textContent =
+    done + " / " + all.length + " run";
+}
+
+function showSummary(ms) {
+  const all = allTests();
+  document.getElementById("sPass").textContent = all.filter(
+    (t) => state[t.id]?.status === "pass",
+  ).length;
+  document.getElementById("sFail").textContent = all.filter(
+    (t) => state[t.id]?.status === "fail",
+  ).length;
+  document.getElementById("sSkip").textContent = all.filter(
+    (t) => !state[t.id] || state[t.id]?.status === "idle",
+  ).length;
+  document.getElementById("sTime").textContent = ms + "ms total";
+  document.getElementById("summary").classList.remove("hide");
+}
+
+// ── UI toggles ────────────────────────────────────────────────────────────────
+
+function resetAll() {
+  Object.keys(state).forEach((k) => delete state[k]);
+  render();
+  document.getElementById("summary").classList.add("hide");
+  document.getElementById("sbar").textContent = provider
+    ? "Ready · " + allTests().length + " tests"
+    : "—";
+}
+
+function toggleGrp(id) {
+  document.getElementById("body-" + id).classList.toggle("hide");
+  document.getElementById("chev-" + id).classList.toggle("open");
+}
+
+function toggleDet(id) {
+  document.getElementById("det-" + id).classList.toggle("hide");
+}
+
+// ── Boot ──────────────────────────────────────────────────────────────────────
+
+render();
+discover();

--- a/packages/neon-dapi/jest.config.js
+++ b/packages/neon-dapi/jest.config.js
@@ -1,0 +1,3 @@
+const config = require("../../jest.config");
+config.globals["ts-jest"]["tsconfig"] = "../../tsconfig-test.json";
+module.exports = config;

--- a/packages/neon-dapi/package.json
+++ b/packages/neon-dapi/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@cityofzion/neon-dapi",
+  "description": "Neon Ledger integration for Node.js",
+  "version": "5.9.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CityOfZion/neon-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "neo",
+    "dapi",
+    "javascript",
+    "libraries"
+  ],
+  "author": "Raul Duarte Pereira (https://github.com/raulduartep)",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "ae": "api-extractor run --local",
+    "build": "tsc -b tsconfig.source.json",
+    "dist": "tsc -p tsconfig.source.json -m commonjs --outDir dist",
+    "dist:prod": "tsc -p tsconfig.source.json -m commonjs --outDir dist",
+    "clean": "rimraf ./lib ./dist ./temp tsconfig.tsbuildinfo",
+    "prepublishOnly": "npm run clean && npm run build && npm run dist:prod",
+    "lint": "eslint src/**/*.ts __tests__/**/*.ts",
+    "pretty": "prettier --write --loglevel=warn \"./{src,__{tests,integration}__}/**/*.ts\"",
+    "start": "jest --watch",
+    "test": "jest --config jest.config.js",
+    "test:unit": "jest --config jest.config.js"
+  },
+  "dependencies": {
+    "@ledgerhq/hw-transport": "6.32.0"
+  },
+  "peerDependencies": {
+    "@cityofzion/neon-core": "^5.9.0"
+  },
+  "files": [
+    "lib/",
+    "dist/"
+  ]
+}

--- a/packages/neon-dapi/src/DapiError.ts
+++ b/packages/neon-dapi/src/DapiError.ts
@@ -1,0 +1,55 @@
+type DapiErrorJSON = {
+  code: DapiErrorCode;
+  message: string;
+};
+
+export enum DapiErrorCode {
+  UNKNOWN = 10000, // An unknown error has occurred.
+  UNSUPPORTED = 10001, // The requested feature or operation is not supported.
+  INVALID = 10002, // The input data is in an invalid format.
+  NOTFOUND = 10003, // The requested data doesn't exist.
+  FAILED = 10004, // The contract execution failed.
+  TIMEOUT = 10005, // The requested operation was cancelled due to timeout.
+  CANCELED = 10006, // The requested operation was cancelled by the user.
+  INSUFFICIENT_FUNDS = 10007, // The requested operation failed due to insufficient balance.
+  RPC_ERROR = 10008, // An exception was thrown by the RPC server.
+}
+
+const ERROR_CODE_BY_RPC_CODE: Record<number, DapiErrorCode> = {
+  [-300]: DapiErrorCode.INSUFFICIENT_FUNDS,
+  [-504]: DapiErrorCode.INSUFFICIENT_FUNDS,
+  [-511]: DapiErrorCode.INSUFFICIENT_FUNDS,
+  [-608]: DapiErrorCode.FAILED,
+};
+
+export class DapiError extends Error {
+  code: DapiErrorCode;
+
+  constructor(code: DapiErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+
+  toJSON(): DapiErrorJSON {
+    return { code: this.code, message: this.message };
+  }
+
+  static parseError(error: unknown): DapiError {
+    if (error instanceof DapiError) {
+      return error;
+    }
+
+    if (error instanceof Error) {
+      if ("code" in error && typeof error.code === "number") {
+        return new DapiError(
+          ERROR_CODE_BY_RPC_CODE[error.code] || DapiErrorCode.RPC_ERROR,
+          error.message,
+        );
+      }
+
+      return new DapiError(DapiErrorCode.UNKNOWN, error.message);
+    }
+
+    return new DapiError(DapiErrorCode.UNKNOWN, "Unknown error");
+  }
+}

--- a/packages/neon-dapi/src/DapiOperations.ts
+++ b/packages/neon-dapi/src/DapiOperations.ts
@@ -37,7 +37,7 @@ import {
   getWitnesses,
   transformTransaction,
 } from "./utils.js";
-import type { DapiNetwork } from "./constants.js";
+import { DapiNetwork } from "./constants.js";
 
 type DapiOperationsConfig = {
   rpcClient: string | rpc.RPCClient;
@@ -84,8 +84,6 @@ export class DapiOperations {
     payload: AuthenticationChallengePayload,
   ): Promise<AuthenticationResponsePayload> {
     try {
-      const timestamp = Math.floor(Date.now() / 1000);
-
       if (!payload.networks.length) {
         throw new DapiError(DapiErrorCode.INVALID, "Networks is empty");
       }
@@ -94,15 +92,17 @@ export class DapiOperations {
         throw new DapiError(DapiErrorCode.INVALID, "Network is not supported");
       }
 
-      const networkHex = u.num2hexstring(this.network, 4, true);
-      const nonceHex = u.num2hexstring(Number(payload.nonce), 8, true);
-      const timestampHex = u.num2hexstring(timestamp, 4, true);
-      const hashHex = this.account.scriptHash.replace(/^0x/i, "");
-      const actionHex = u.str2hexstring(payload.action);
-      const domainHex = u.str2hexstring(payload.domain);
+      const bw = new u.BinaryWriter();
 
-      const hash =
-        networkHex + nonceHex + timestampHex + hashHex + actionHex + domainHex;
+      const timestamp = Math.floor(Date.now() / 1000);
+      bw.writeUint64(Number(payload.nonce));
+      bw.writeUint32(timestamp);
+      bw.writeUint32(this.network);
+      bw.writeUInt160(this.account.scriptHash);
+      bw.writeVarString(payload.action);
+      bw.writeVarString(payload.domain);
+
+      const hash = bw.toHex();
 
       const signature = wallet.sign(hash, this.account.privateKey);
 

--- a/packages/neon-dapi/src/DapiOperations.ts
+++ b/packages/neon-dapi/src/DapiOperations.ts
@@ -27,6 +27,7 @@ import type {
   Account,
 } from "./types.js";
 import {
+  buildSendInvokeParams,
   calculateFee,
   getAttributes,
   getNetworkFee,
@@ -93,20 +94,22 @@ export class DapiOperations {
         throw new DapiError(DapiErrorCode.INVALID, "Network is not supported");
       }
 
-      const network = payload.networks[0];
-      const networkHex = u.num2hexstring(network, 1, true);
+      const networkHex = u.num2hexstring(this.network, 4, true);
       const nonceHex = u.num2hexstring(Number(payload.nonce), 8, true);
-      const timestampHex = u.num2hexstring(timestamp, 8, true);
+      const timestampHex = u.num2hexstring(timestamp, 4, true);
       const hashHex = this.account.scriptHash.replace(/^0x/i, "");
+      const actionHex = u.str2hexstring(payload.action);
+      const domainHex = u.str2hexstring(payload.domain);
 
-      const hash = `${networkHex}${nonceHex}${timestampHex}${hashHex}`;
+      const hash =
+        networkHex + nonceHex + timestampHex + hashHex + actionHex + domainHex;
 
       const signature = wallet.sign(hash, this.account.privateKey);
 
       return {
         address: this.account.address,
         algorithm: "ECDSA-P256",
-        network,
+        network: this.network,
         pubkey: this.account.publicKey,
         nonce: payload.nonce,
         timestamp,
@@ -192,6 +195,7 @@ export class DapiOperations {
           gasconsumed: execution.gasconsumed,
           stack: execution.stack ?? [],
           notifications: execution.notifications,
+          exception: execution.exception,
         })),
       };
     } catch (error) {
@@ -595,21 +599,15 @@ export class DapiOperations {
     data?: Argument,
   ): Promise<UInt256> {
     try {
-      return await this.invoke(
-        [
-          {
-            hash: asset,
-            operation: "transfer",
-            args: [
-              { type: "Hash160", value: from },
-              { type: "Hash160", value: to },
-              { type: "Integer", value: amount },
-              { type: "Any", value: data },
-            ],
-          },
-        ],
-        [{ account: this.account.scriptHash, scopes: "CalledByEntry" }],
+      const { invocations, signers } = buildSendInvokeParams(
+        this.account,
+        asset,
+        from,
+        to,
+        amount,
+        data,
       );
+      return await this.invoke(invocations, signers);
     } catch (error) {
       throw DapiError.parseError(error);
     }
@@ -633,23 +631,15 @@ export class DapiOperations {
     data?: Argument,
   ): Promise<number> {
     try {
-      return await calculateFee(
+      const { invocations, signers } = buildSendInvokeParams(
         this.account,
-        this.rpcClient,
-        [
-          {
-            hash: asset,
-            operation: "transfer",
-            args: [
-              { type: "Hash160", value: from },
-              { type: "Hash160", value: to },
-              { type: "Integer", value: amount },
-              { type: "Any", value: data },
-            ],
-          },
-        ],
-        [{ account: this.account.scriptHash, scopes: "CalledByEntry" }],
+        asset,
+        from,
+        to,
+        amount,
+        data,
       );
+      return await this.calculateInvokeFee(invocations, signers);
     } catch (error) {
       throw DapiError.parseError(error);
     }
@@ -827,7 +817,7 @@ export class DapiOperations {
       const signature = wallet.sign(hexMessage, this.account.privateKey);
 
       return {
-        payload: u.utf82base64(message),
+        payload: u.hex2base64(hexMessage),
         signature: u.hex2base64(signature),
         account: this.account.scriptHash,
         pubkey: this.account.publicKey,

--- a/packages/neon-dapi/src/DapiOperations.ts
+++ b/packages/neon-dapi/src/DapiOperations.ts
@@ -1,0 +1,839 @@
+import { rpc, tx, u, wallet } from "@cityofzion/neon-core";
+
+import { DapiError, DapiErrorCode } from "./DapiError.js";
+import type {
+  ApplicationLog,
+  Argument,
+  AuthenticationChallengePayload,
+  AuthenticationResponsePayload,
+  Base64Encoded,
+  Block,
+  ContractParametersContext,
+  ContractParameterType,
+  Integer,
+  InvocationArguments,
+  InvocationResult,
+  Signer,
+  SignedMessage,
+  SignOptions,
+  Token,
+  Transaction,
+  TransactionAttribute,
+  TransactionOptions,
+  TriggerType,
+  UInt160,
+  UInt256,
+  VMState,
+  Account,
+} from "./types.js";
+import {
+  calculateFee,
+  getAttributes,
+  getNetworkFee,
+  getScriptBuilder,
+  getSystemFee,
+  getValidUntilBlock,
+  getWitnesses,
+  transformTransaction,
+} from "./utils.js";
+import type { DapiNetwork } from "./constants.js";
+
+type DapiOperationsConfig = {
+  rpcClient: string | rpc.RPCClient;
+  network: DapiNetwork;
+  account: string | wallet.Account;
+};
+
+/**
+ * Helper class that implements the blockchain and cryptographic operations required by `DapiProvider`.
+ *
+ * This class is not a `DapiProvider` itself — it exists to reduce boilerplate in concrete provider
+ * implementations by handling the heavy lifting: RPC calls, transaction building, signing, and fee
+ * calculation.
+ *
+ * Not all `DapiProvider` methods are covered here. Methods that require direct wallet UI interaction
+ * (e.g. `pickAddress`) are intentionally omitted because they depend on the
+ * specific wallet environment and cannot be generalized.
+ */
+export class DapiOperations {
+  rpcClient: rpc.RPCClient;
+  account: wallet.Account;
+  network: DapiNetwork;
+
+  constructor({ rpcClient, network, account }: DapiOperationsConfig) {
+    this.rpcClient =
+      rpcClient instanceof rpc.RPCClient
+        ? rpcClient
+        : new rpc.RPCClient(rpcClient);
+
+    this.account =
+      account instanceof wallet.Account ? account : new wallet.Account(account);
+
+    this.network = network;
+  }
+
+  /**
+   * Requests authentication. Usually used to log in to a website.
+   * The authentication process is described in detail in NEP-20.
+   * @param payload - The authentication challenge payload issued by the dApp.
+   * @returns A signed authentication response payload.
+   * @throws DapiError - UNSUPPORTED | INVALID | TIMEOUT | CANCELED
+   */
+  async authenticate(
+    payload: AuthenticationChallengePayload,
+  ): Promise<AuthenticationResponsePayload> {
+    try {
+      const timestamp = Math.floor(Date.now() / 1000);
+
+      if (!payload.networks.length) {
+        throw new DapiError(DapiErrorCode.INVALID, "Networks is empty");
+      }
+
+      if (!payload.networks.includes(this.network)) {
+        throw new DapiError(DapiErrorCode.INVALID, "Network is not supported");
+      }
+
+      const network = payload.networks[0];
+      const networkHex = u.num2hexstring(network, 1, true);
+      const nonceHex = u.num2hexstring(Number(payload.nonce), 8, true);
+      const timestampHex = u.num2hexstring(timestamp, 8, true);
+      const hashHex = this.account.scriptHash.replace(/^0x/i, "");
+
+      const hash = `${networkHex}${nonceHex}${timestampHex}${hashHex}`;
+
+      const signature = wallet.sign(hash, this.account.privateKey);
+
+      return {
+        address: this.account.address,
+        algorithm: "ECDSA-P256",
+        network,
+        pubkey: this.account.publicKey,
+        nonce: payload.nonce,
+        timestamp,
+        signature: u.hex2base64(signature),
+      };
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Returns the current connected account in the wallet.
+   * @returns Array containing the connected account.
+   */
+  getAccounts(): Account[] {
+    return [
+      {
+        address: this.account.address,
+        hash: this.account.scriptHash,
+        contract: this.account.contract as Account["contract"],
+        extra: null,
+        label: this.account.label,
+      },
+    ];
+  }
+
+  /**
+   * Gets the balance of the specified account for the given asset.
+   * The account can be in the wallet or an arbitrary address.
+   * @param asset - The script hash of the NEP-17 token contract.
+   * @param account - The script hash of the account to query.
+   * @returns The token balance as an integer string.
+   * @throws DapiError - INVALID | NOTFOUND | FAILED | RPC_ERROR
+   */
+  async getBalance(asset: UInt160, account: UInt160): Promise<Integer> {
+    try {
+      const scriptBuilder = getScriptBuilder([
+        {
+          operation: "balanceOf",
+          hash: asset,
+          args: [{ type: "Hash160", value: account }],
+        },
+      ]);
+
+      const result = await this.rpcClient.invokeScript(
+        u.HexString.fromHex(scriptBuilder.build()),
+        [{ account, scopes: "CalledByEntry" }],
+      );
+
+      if (result.state !== "HALT") {
+        throw new DapiError(
+          DapiErrorCode.FAILED,
+          result.exception || "Transaction state is not HALT",
+        );
+      }
+
+      const stack = result.stack[0];
+
+      if (stack?.type !== "Integer" || typeof stack.value !== "string") {
+        throw new DapiError(DapiErrorCode.INVALID, "Invalid stack type");
+      }
+
+      return stack.value;
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Gets the application log of the specified transaction.
+   * @param txid - The transaction hash.
+   * @returns The application log containing all executions and notifications.
+   * @throws DapiError - INVALID | RPC_ERROR
+   */
+  async getApplicationLog(txid: UInt256): Promise<ApplicationLog> {
+    try {
+      const applicationLog = await this.rpcClient.getApplicationLog(txid);
+      return {
+        txid: applicationLog.txid,
+        executions: applicationLog.executions.map((execution) => ({
+          trigger: execution.trigger as TriggerType,
+          vmstate: execution.vmstate as VMState,
+          gasconsumed: execution.gasconsumed,
+          stack: execution.stack ?? [],
+          notifications: execution.notifications,
+        })),
+      };
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Gets the block by its hash.
+   * @param hash - The block hash.
+   * @returns The block data including all transactions.
+   * @throws DapiError - INVALID | NOTFOUND | RPC_ERROR
+   */
+  getBlock(hash: UInt256): Promise<Block>;
+  /**
+   * Gets the block by its index.
+   * @param index - The block index (height).
+   * @returns The block data including all transactions.
+   * @throws DapiError - INVALID | NOTFOUND | RPC_ERROR
+   */
+  getBlock(index: number): Promise<Block>;
+  async getBlock(hashOrIndex: UInt256 | number): Promise<Block> {
+    try {
+      const block = await this.rpcClient.getBlock(hashOrIndex, 1);
+
+      const transactions = block.tx.map((transaction) =>
+        transformTransaction({
+          ...transaction,
+          blockhash: block.hash,
+          blocktime: block.time,
+          confirmations: block.confirmations,
+        }),
+      );
+
+      return {
+        hash: block.hash,
+        size: block.size,
+        confirmations: block.confirmations,
+        nextBlockHash: block.nextblockhash,
+        version: block.version,
+        previousBlockHash: block.previousblockhash,
+        merkleRoot: block.merkleroot,
+        time: block.time,
+        nonce: block.nonce,
+        index: block.index,
+        primary: block.primary,
+        nextConsensus: block.nextconsensus,
+        tx: transactions,
+      };
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Gets the total number of blocks in the blockchain.
+   * @returns The current block count.
+   * @throws DapiError - RPC_ERROR
+   */
+  async getBlockCount(): Promise<number> {
+    try {
+      return await this.rpcClient.getBlockCount();
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Gets a storage entry from a contract.
+   * @param hash - The script hash of the contract.
+   * @param key - The storage key encoded as base64.
+   * @returns The storage value encoded as base64.
+   * @throws DapiError - INVALID | NOTFOUND | RPC_ERROR
+   */
+  async getStorage(hash: UInt160, key: Base64Encoded): Promise<Base64Encoded> {
+    try {
+      return await this.rpcClient.getStorage(hash, u.base642hex(key));
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Gets symbol, decimals, and total supply of a NEP-17 token.
+   * @param assetId - The script hash of the token contract.
+   * @returns Token metadata including symbol, decimals, and total supply.
+   * @throws DapiError - INVALID | NOTFOUND | FAILED | RPC_ERROR
+   */
+  async getTokenInfo(assetId: UInt160): Promise<Token> {
+    try {
+      const decimalsScriptBuilder = getScriptBuilder([
+        { hash: assetId, operation: "decimals" },
+      ]);
+      const symbolScriptBuilder = getScriptBuilder([
+        { hash: assetId, operation: "symbol" },
+      ]);
+      const totalSupplyScriptBuilder = getScriptBuilder([
+        { hash: assetId, operation: "totalSupply" },
+      ]);
+
+      const [decimalsResult, symbolResult, totalSupplyResult] =
+        await this.rpcClient.executeAll<
+          [rpc.InvokeResult, rpc.InvokeResult, rpc.InvokeResult]
+        >([
+          rpc.Query.invokeScript(
+            u.HexString.fromHex(decimalsScriptBuilder.build()),
+            [],
+          ),
+          rpc.Query.invokeScript(
+            u.HexString.fromHex(symbolScriptBuilder.build()),
+            [],
+          ),
+          rpc.Query.invokeScript(
+            u.HexString.fromHex(totalSupplyScriptBuilder.build()),
+            [],
+          ),
+        ]);
+
+      if (
+        decimalsResult.state !== "HALT" ||
+        symbolResult.state !== "HALT" ||
+        totalSupplyResult.state !== "HALT"
+      ) {
+        throw new DapiError(
+          DapiErrorCode.FAILED,
+          "Transaction state is not HALT",
+        );
+      }
+
+      const decimalsStack = decimalsResult.stack[0];
+      const symbolStack = symbolResult.stack[0];
+      const totalSupplyStack = totalSupplyResult.stack[0];
+
+      if (
+        decimalsStack?.type !== "Integer" ||
+        typeof decimalsStack.value !== "string"
+      ) {
+        throw new DapiError(
+          DapiErrorCode.INVALID,
+          "Invalid decimals stack type",
+        );
+      }
+
+      if (
+        symbolStack?.type !== "ByteString" ||
+        typeof symbolStack.value !== "string"
+      ) {
+        throw new DapiError(DapiErrorCode.INVALID, "Invalid symbol stack type");
+      }
+
+      if (
+        totalSupplyStack?.type !== "Integer" ||
+        typeof totalSupplyStack.value !== "string"
+      ) {
+        throw new DapiError(
+          DapiErrorCode.INVALID,
+          "Invalid totalSupply stack type",
+        );
+      }
+
+      return {
+        decimals: Number(decimalsStack.value),
+        symbol: u.HexString.fromBase64(symbolStack.value).toAscii(),
+        totalSupply: totalSupplyStack.value,
+      };
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Gets the transaction by its hash.
+   * @param txid - The transaction hash.
+   * @returns The transaction data.
+   * @throws DapiError - INVALID | NOTFOUND | RPC_ERROR
+   */
+  async getTransaction(txid: UInt256): Promise<Transaction> {
+    try {
+      const transaction = await this.rpcClient.getRawTransaction(txid, 1);
+      return transformTransaction(transaction);
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Calls a contract off-chain and returns the execution result without broadcasting a transaction.
+   * @param invocation - The contract invocation arguments.
+   * @returns The result of the script execution.
+   * @throws DapiError - INVALID | RPC_ERROR
+   */
+  async call(invocation: InvocationArguments): Promise<InvocationResult> {
+    try {
+      const scriptBuilder = getScriptBuilder([invocation]);
+
+      const result = await this.rpcClient.invokeScript(
+        u.HexString.fromHex(scriptBuilder.build()),
+        [
+          new tx.Signer({
+            account: this.account.scriptHash,
+            scopes: tx.WitnessScope.CalledByEntry,
+          }),
+        ],
+      );
+
+      return {
+        gasconsumed: result.gasconsumed,
+        script: result.script,
+        stack: result.stack,
+        state: result.state,
+        exception: result.exception || undefined,
+        notifications: result.notifications,
+      };
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Calls one or more contracts on-chain and broadcasts the transaction.
+   * @param invocations - One or more contract invocations to execute in the transaction.
+   * @param signers - Optional list of signers for the transaction.
+   * @param attributes - Optional transaction attributes.
+   * @param options - Optional fee and validity overrides.
+   * @returns The hash of the broadcasted transaction.
+   * @throws DapiError - INVALID | FAILED | TIMEOUT | CANCELED | RPC_ERROR
+   */
+  async invoke(
+    invocations: InvocationArguments[],
+    signers?: Signer[],
+    attributes?: TransactionAttribute[],
+    options?: TransactionOptions,
+  ): Promise<UInt256> {
+    try {
+      const transaction = new tx.Transaction();
+
+      const scriptBuilder = getScriptBuilder(invocations);
+
+      transaction.script = u.HexString.fromHex(scriptBuilder.build());
+
+      transaction.validUntilBlock = await getValidUntilBlock(
+        this.rpcClient,
+        options,
+      );
+
+      transaction.signers =
+        signers?.map((signer) => new tx.Signer(signer)) || [];
+
+      transaction.witnesses = getWitnesses(this.account, signers || []);
+
+      transaction.attributes = getAttributes(attributes);
+
+      transaction.systemFee = await getSystemFee(
+        this.rpcClient,
+        scriptBuilder,
+        transaction.signers,
+        options,
+      );
+
+      transaction.networkFee = await getNetworkFee(this.rpcClient, transaction);
+
+      const version = await this.rpcClient.getVersion();
+
+      transaction.sign(this.account, version.protocol.network);
+
+      return await this.rpcClient.sendRawTransaction(transaction);
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Calculates the total fee (system + network) for an invoke transaction without broadcasting it.
+   * @param invocations - One or more contract invocations.
+   * @param signers - Optional list of signers for the transaction.
+   * @param attributes - Optional transaction attributes.
+   * @param options - Optional fee and validity overrides.
+   * @returns The total fee in GAS as a decimal number.
+   * @throws DapiError - INVALID | RPC_ERROR
+   */
+  async calculateInvokeFee(
+    invocations: InvocationArguments[],
+    signers?: Signer[],
+    attributes?: TransactionAttribute[],
+    options?: TransactionOptions,
+  ): Promise<number> {
+    try {
+      return await calculateFee(
+        this.account,
+        this.rpcClient,
+        invocations,
+        signers,
+        attributes,
+        options,
+      );
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Builds a transaction for one or more contract invocations without broadcasting it.
+   * Returns a `ContractParametersContext` that can be passed to `sign` and then `relay`.
+   * @param invocations - One or more contract invocations.
+   * @param signers - Optional list of signers for the transaction.
+   * @param attributes - Optional transaction attributes.
+   * @param options - Optional fee and validity overrides.
+   * @returns An unsigned contract parameters context ready for signing.
+   * @throws DapiError - INVALID | FAILED | TIMEOUT | CANCELED | RPC_ERROR
+   */
+  async makeTransaction(
+    invocations: InvocationArguments[],
+    signers?: Signer[],
+    attributes?: TransactionAttribute[],
+    options?: TransactionOptions,
+  ): Promise<ContractParametersContext> {
+    try {
+      const transaction = new tx.Transaction();
+
+      const scriptBuilder = getScriptBuilder(invocations);
+
+      transaction.script = u.HexString.fromHex(scriptBuilder.build());
+
+      transaction.validUntilBlock = await getValidUntilBlock(
+        this.rpcClient,
+        options,
+      );
+
+      transaction.signers =
+        signers?.map((signer) => new tx.Signer(signer)) || [];
+
+      transaction.attributes = getAttributes(attributes);
+
+      transaction.systemFee = await getSystemFee(
+        this.rpcClient,
+        scriptBuilder,
+        transaction.signers,
+        options,
+      );
+
+      transaction.networkFee = await getNetworkFee(this.rpcClient, transaction);
+
+      const version = await this.rpcClient.getVersion();
+
+      const items = transaction.signers.reduce(
+        (acc, signer) => {
+          const account = signer.account.toBigEndian();
+
+          acc[account] = {
+            script: "",
+            parameters: [],
+            signatures: {},
+          };
+
+          return acc;
+        },
+        {} as ContractParametersContext["items"],
+      );
+
+      return {
+        type: "Neo.Network.P2P.Payloads.Transaction",
+        hash: `0x${transaction.hash()}`,
+        network: version.protocol.network,
+        data: u.hex2base64(transaction.serialize(false)),
+        items,
+      };
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Broadcasts a signed transaction to the network.
+   * @param context - A fully signed contract parameters context.
+   * @returns The hash of the broadcasted transaction.
+   * @throws DapiError - INVALID | TIMEOUT | CANCELED | INSUFFICIENT_FUNDS | RPC_ERROR
+   */
+  async relay(context: ContractParametersContext): Promise<UInt256> {
+    try {
+      return await this.rpcClient.sendRawTransaction(context.data);
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Transfers a NEP-17 asset and broadcasts the transaction.
+   * @param asset - The script hash of the NEP-17 token contract.
+   * @param from - The script hash of the sender account (must be the connected account).
+   * @param to - The script hash of the recipient account.
+   * @param amount - The amount to transfer as an integer string.
+   * @param data - Optional extra data forwarded to the token's `transfer` method.
+   * @returns The hash of the broadcasted transaction.
+   * @throws DapiError - INVALID | NOTFOUND | FAILED | TIMEOUT | CANCELED | INSUFFICIENT_FUNDS | RPC_ERROR
+   */
+  async send(
+    asset: UInt160,
+    from: UInt160,
+    to: UInt160,
+    amount: Integer,
+    data?: Argument,
+  ): Promise<UInt256> {
+    try {
+      return await this.invoke(
+        [
+          {
+            hash: asset,
+            operation: "transfer",
+            args: [
+              { type: "Hash160", value: from },
+              { type: "Hash160", value: to },
+              { type: "Integer", value: amount },
+              { type: "Any", value: data },
+            ],
+          },
+        ],
+        [{ account: this.account.scriptHash, scopes: "CalledByEntry" }],
+      );
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Calculates the total fee (system + network) for a NEP-17 transfer without broadcasting it.
+   * @param asset - The script hash of the NEP-17 token contract.
+   * @param from - The script hash of the sender account.
+   * @param to - The script hash of the recipient account.
+   * @param amount - The amount to transfer as an integer string.
+   * @param data - Optional extra data forwarded to the token's `transfer` method.
+   * @returns The total fee in GAS as a decimal number.
+   * @throws DapiError - INVALID | RPC_ERROR
+   */
+  async calculateSendFee(
+    asset: UInt160,
+    from: UInt160,
+    to: UInt160,
+    amount: Integer,
+    data?: Argument,
+  ): Promise<number> {
+    try {
+      return await calculateFee(
+        this.account,
+        this.rpcClient,
+        [
+          {
+            hash: asset,
+            operation: "transfer",
+            args: [
+              { type: "Hash160", value: from },
+              { type: "Hash160", value: to },
+              { type: "Integer", value: amount },
+              { type: "Any", value: data },
+            ],
+          },
+        ],
+        [{ account: this.account.scriptHash, scopes: "CalledByEntry" }],
+      );
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Signs a transaction with the connected account.
+   * For multi-signature transactions, call this once per participating account and
+   * pass the updated context to the next signer until the threshold is met.
+   * @param context - The contract parameters context containing the unsigned transaction.
+   * @returns An updated context with the signature appended. If the signing threshold is
+   *          reached for a multi-sig account, the witness is also added.
+   * @throws DapiError - UNSUPPORTED | INVALID | NOTFOUND | TIMEOUT | CANCELED
+   */
+  async sign(
+    context: ContractParametersContext,
+  ): Promise<ContractParametersContext> {
+    try {
+      const transaction = tx.Transaction.deserialize(
+        u.base642hex(context.data),
+      );
+
+      let scriptHash: string | undefined;
+      let verificationScript: string | undefined;
+      let signatures: Record<string, string> | undefined;
+      let verificationScriptPublicKeys: string[] | undefined;
+      let parameters: Argument[] | undefined;
+
+      for (const [contextItemScriptHash, contextItem] of Object.entries(
+        context.items,
+      )) {
+        // If already exists a verification script, we need to verify if the connected account is part of the verification script
+        // For multisig accounts, the dApp should provide the script in the first sign attempt, since the account's contract script is the verification script of the multisig account and it is not possible to determine the verification script from the scriptHash
+        // It does not means it is necessarily a multisig account, it could be a transaction with two signers and the second sign call will have the verification script in the context since the first call already added the verification script
+        if (contextItem.script.length > 0) {
+          const contextItemVerificationScript = u.base642hex(
+            contextItem.script,
+          );
+          const publicKeys = wallet.getPublicKeysFromVerificationScript(
+            contextItemVerificationScript,
+          );
+          if (publicKeys.includes(this.account.publicKey)) {
+            scriptHash = contextItemScriptHash;
+            verificationScript = contextItemVerificationScript;
+            signatures = contextItem.signatures;
+            verificationScriptPublicKeys = publicKeys;
+            parameters = contextItem.parameters;
+
+            break;
+          }
+        }
+
+        if (contextItemScriptHash === this.account.scriptHash) {
+          scriptHash = contextItemScriptHash;
+          verificationScript = wallet.getVerificationScriptFromPublicKey(
+            this.account.publicKey,
+          );
+          signatures = contextItem.signatures;
+          verificationScriptPublicKeys = [this.account.publicKey];
+          parameters = this.account.contract.parameters.map((parameter) => ({
+            type: parameter.type as ContractParameterType,
+            value: undefined,
+          }));
+
+          break;
+        }
+      }
+
+      if (
+        !scriptHash ||
+        !verificationScript ||
+        !signatures ||
+        !verificationScriptPublicKeys ||
+        !parameters
+      ) {
+        throw new DapiError(
+          DapiErrorCode.INVALID,
+          "Connected account is not part of the transaction",
+        );
+      }
+
+      const signMessage = transaction.getMessageForSigning(context.network);
+      const signature = wallet.sign(signMessage, this.account.privateKey);
+      const base64Signature = u.hex2base64(signature);
+      const updatedSignatures = {
+        ...signatures,
+        [this.account.publicKey]: base64Signature,
+      };
+
+      const updatedParameters = parameters.filter(
+        (parameter) => parameter.type !== "Signature",
+      );
+      verificationScriptPublicKeys.forEach((publicKey) => {
+        updatedParameters.push({
+          type: "Signature",
+          value: updatedSignatures[publicKey],
+        });
+      });
+
+      const isMultiSig = verificationScriptPublicKeys.length > 1;
+      if (isMultiSig) {
+        const publicKeysSignatures = verificationScriptPublicKeys
+          .map((publicKey) => updatedSignatures[publicKey])
+          .filter((sig) => sig !== undefined)
+          .map((sig) => u.base642hex(sig));
+        const threshold =
+          wallet.getSigningThresholdFromVerificationScript(verificationScript);
+
+        if (threshold === publicKeysSignatures.length) {
+          transaction.addWitness(
+            tx.Witness.buildMultiSig(
+              signMessage,
+              publicKeysSignatures,
+              verificationScript,
+            ),
+          );
+        }
+      } else {
+        transaction.addWitness(
+          tx.Witness.fromSignature(signature, this.account.publicKey),
+        );
+      }
+
+      return {
+        type: "Neo.Network.P2P.Payloads.Transaction",
+        hash: `0x${transaction.hash()}`,
+        network: context.network,
+        data: u.hex2base64(transaction.serialize(true)),
+        items: {
+          ...context.items,
+          [scriptHash]: {
+            script: u.hex2base64(verificationScript),
+            parameters: updatedParameters,
+            signatures: updatedSignatures,
+          },
+        },
+      };
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+
+  /**
+   * Signs a message with the connected account using ECDSA-P256.
+   * @param message - The message to sign. Treated as a UTF-8 string unless `options.isBase64Encoded` is true.
+   * @param account - Optional script hash to verify the connected account matches before signing.
+   * @param options - Encoding and signature options.
+   * @returns The signed message with payload, signature, account, and public key.
+   * @throws DapiError - INVALID | NOTFOUND | TIMEOUT | CANCELED
+   */
+  async signMessage(
+    message: string | Base64Encoded,
+    account?: UInt160,
+    options?: SignOptions,
+  ): Promise<SignedMessage> {
+    try {
+      if (options?.isTypedData) {
+        throw new DapiError(
+          DapiErrorCode.INVALID,
+          "Typed data is not supported yet",
+        );
+      }
+
+      if (account && this.account.scriptHash !== account) {
+        throw new DapiError(DapiErrorCode.INVALID, "Account does not match");
+      }
+
+      let hexMessage: string;
+      if (options?.isBase64Encoded) {
+        hexMessage = u.base642hex(message);
+      } else {
+        hexMessage = u.str2hexstring(message);
+      }
+
+      const signature = wallet.sign(hexMessage, this.account.privateKey);
+
+      return {
+        payload: u.utf82base64(message),
+        signature: u.hex2base64(signature),
+        account: this.account.scriptHash,
+        pubkey: this.account.publicKey,
+      };
+    } catch (error) {
+      throw DapiError.parseError(error);
+    }
+  }
+}

--- a/packages/neon-dapi/src/constants.ts
+++ b/packages/neon-dapi/src/constants.ts
@@ -1,0 +1,4 @@
+export enum DapiNetwork {
+  MAINNET = 860833102,
+  TESTNET = 894710606,
+}

--- a/packages/neon-dapi/src/index.ts
+++ b/packages/neon-dapi/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./DapiError";
+export * from "./DapiOperations";
+export * from "./constants";
+export * from "./types";

--- a/packages/neon-dapi/src/types.ts
+++ b/packages/neon-dapi/src/types.ts
@@ -1,0 +1,527 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Represents a piece of data encoded as a base64 string.
+export type Base64Encoded = string;
+
+// Represents a N3 address.
+// Example: "NSiVJYZej4XsxG5CUpdwn7VRQk8iiiDMPM"
+export type Address = string;
+
+// A 160-bit hash represented by a hexadecimal string.
+// Example: "0x682cca3ebdc66210e5847d7f8115846586079d4a"
+export type UInt160 = string;
+
+// A 256-bit hash represented by a hexadecimal string.
+// Example: "0x1f4d1defa46faa5e7b9b8d3f79a06bec777d7c26c4aa5f6f5899a291daa87c15"
+export type UInt256 = string;
+
+// Represents an ECC public key.
+// Example: "03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c"
+export type ECPoint = string;
+
+// A large integer of any length expressed as a string or number.
+// It is used to represent values that may exceed the safe integer limit of JavaScript.
+export type Integer = number | string;
+
+// Represents a piece of data encoded as a hexadecimal string.
+export type HexString = string;
+
+// Represents a version.
+// Example: "1.0.0"
+export type Version = string;
+
+// Represents the N3 network.
+// MAINNET: 860833102
+// TESTNET: 894710606
+export type Network = number;
+
+// Represents the name of the event in IDapiProvider.
+export type EventName =
+  | "accountchanged" // Triggered when the user has changed the connected account in the wallet.
+  | "networkchanged"; // Triggered when the user switches the current network.
+
+// Represents the type of Parameter. See NEP-14 for more details.
+export type ContractParameterType =
+  | "Any" // Indicates that the parameter can be of any type.
+  | "Boolean" // Indicates that the parameter is of Boolean type.
+  | "Integer" // Indicates that the parameter is an integer.
+  | "ByteArray" // Indicates that the parameter is a byte array.
+  | "String" // Indicates that the parameter is a string.
+  | "Hash160" // Indicates that the parameter is a 160-bit hash.
+  | "Hash256" // Indicates that the parameter is a 256-bit hash.
+  | "PublicKey" // Indicates that the parameter is a public key.
+  | "Signature" // Indicates that the parameter is a signature.
+  | "Array" // Indicates that the parameter is an array.
+  | "Map" // Indicates that the parameter is a map.
+  | "InteropInterface" // Indicates that the parameter is an interoperable interface.
+  | "Void"; // It can be only used as the return type of a method, meaning that the method has no return value.
+
+// Represents a parameter of a contract method.
+export type Parameter = {
+  name?: string; // The name of the parameter.
+  type: ContractParameterType; // The type of the parameter.
+};
+
+// Represents an account in a wallet.
+export type Account = {
+  hash: UInt160; // The script hash of the account.
+  address: Address; // The address of the account.
+  label?: string; // The label of the account.
+  contract?: {
+    // The contract of the account.
+    script?: Base64Encoded; // The verification script of the contract.
+    parameters: Parameter[]; // The parameters of the verification script.
+    deployed: boolean; // Indicates whether the contract is deployed on the blockchain.
+  };
+  extra?: any; // Additional data for the account.
+};
+
+// Represents the scope of a witness.
+export type WitnessScope =
+  | "None" // Indicates that no contract was witnessed. Only sign the transaction.
+  | "CalledByEntry" // Indicates that the calling contract must be the entry contract.
+  | "CustomContracts" // Custom hash for contract-specific.
+  | "CustomGroups" // Custom pubkey for group members.
+  | "WitnessRules" // Indicates that the current context must satisfy the specified rules.
+  | "Global" // This allows the witness in all contexts (default Neo2 behavior).
+  | "CalledByEntry, CustomContracts"
+  | "CalledByEntry, CustomGroups"
+  | "CalledByEntry, WitnessRules"
+  | "CustomContracts, CustomGroups"
+  | "CustomContracts, WitnessRules"
+  | "CustomGroups, WitnessRules"
+  | "CalledByEntry, CustomContracts, CustomGroups"
+  | "CalledByEntry, CustomContracts, WitnessRules"
+  | "CalledByEntry, CustomGroups, WitnessRules"
+  | "CustomContracts, CustomGroups, WitnessRules"
+  | "CalledByEntry, CustomContracts, CustomGroups, WitnessRules";
+
+export interface BooleanCondition {
+  type: "Boolean";
+  expression: boolean;
+}
+
+export interface NotCondition {
+  type: "Not";
+  expression: WitnessCondition;
+}
+
+export interface AndCondition {
+  type: "And";
+  expressions: WitnessCondition[];
+}
+
+export interface OrCondition {
+  type: "Or";
+  expressions: WitnessCondition[];
+}
+
+export interface ScriptHashCondition {
+  type: "ScriptHash";
+  hash: UInt160;
+}
+
+export interface GroupCondition {
+  type: "Group";
+  group: ECPoint;
+}
+
+export interface CalledByEntryCondition {
+  type: "CalledByEntry";
+}
+
+export interface CalledByContractCondition {
+  type: "CalledByContract";
+  hash: UInt160;
+}
+
+export interface CalledByGroupCondition {
+  type: "CalledByGroup";
+  group: ECPoint;
+}
+
+// Represents the condition of a WitnessRule.
+export type WitnessCondition =
+  | BooleanCondition
+  | NotCondition
+  | AndCondition
+  | OrCondition
+  | ScriptHashCondition
+  | GroupCondition
+  | CalledByEntryCondition
+  | CalledByContractCondition
+  | CalledByGroupCondition;
+
+// Represents the type of WitnessCondition.
+export type WitnessConditionType = WitnessCondition["type"];
+
+export type WitnessRule = {
+  action: "Deny" | "Allow";
+  condition: WitnessCondition;
+};
+
+export type Signer = {
+  account: UInt160;
+  scopes: WitnessScope;
+  allowedContracts?: UInt160[];
+  allowedGroups?: ECPoint[];
+  rules?: WitnessRule[];
+};
+
+export type HighPriorityAttribute = {
+  type: "HighPriority";
+};
+
+export type OracleResponseCode =
+  | "Success"
+  | "ProtocolNotSupported"
+  | "ConsensusUnreachable"
+  | "NotFound"
+  | "Timeout"
+  | "Forbidden"
+  | "ResponseTooLarge"
+  | "InsufficientFunds"
+  | "ContentTypeNotSupported"
+  | "Error";
+
+export type OracleResponseAttribute = {
+  type: "OracleResponse";
+  id: number;
+  code: OracleResponseCode;
+  result?: Base64Encoded;
+};
+
+export type TransactionAttribute =
+  | HighPriorityAttribute
+  | OracleResponseAttribute;
+
+export type TransactionAttributeType = TransactionAttribute["type"];
+
+export type Transaction = {
+  hash: UInt256;
+  size: number;
+  blockHash: UInt256;
+  blockTime: number;
+  confirmations: number;
+  version: number;
+  nonce: number;
+  systemFee: Integer;
+  networkFee: Integer;
+  validUntilBlock: number;
+  sender: UInt160;
+  signers: Signer[];
+  attributes: TransactionAttribute[];
+  script: Base64Encoded;
+};
+
+export type Block = {
+  hash: UInt256;
+  size: number;
+  confirmations: number;
+  nextBlockHash?: UInt256;
+  version: number;
+  previousBlockHash: UInt256;
+  merkleRoot: UInt256;
+  time: number;
+  nonce: HexString;
+  index: number;
+  primary: number;
+  nextConsensus: UInt160;
+  tx: Transaction[];
+};
+
+export type TriggerType =
+  | "OnPersist"
+  | "PostPersist"
+  | "Verification"
+  | "Application";
+
+export type VMState = "NONE" | "HALT" | "FAULT" | "BREAK";
+
+export type StackItemType =
+  | "Any"
+  | "Pointer"
+  | "Boolean"
+  | "Integer"
+  | "ByteString"
+  | "Buffer"
+  | "Array"
+  | "Struct"
+  | "Map"
+  | "InteropInterface";
+
+export type StackItem = {
+  type: StackItemType;
+  value?: any;
+};
+
+export type Notification = {
+  contract: UInt160; // The script hash of the contract that triggered the event.
+  eventname: string; // The name of the event.
+  state: StackItem; // The data of the event.
+};
+
+export type ApplicationLog = {
+  txid: UInt256;
+  executions: {
+    trigger: TriggerType;
+    vmstate: VMState;
+    exception?: string;
+    gasconsumed: Integer;
+    stack: StackItem[];
+    notifications: Notification[];
+  }[];
+};
+
+export type Token = {
+  symbol: string;
+  decimals: number;
+  totalSupply: Integer;
+};
+
+// Represents an argument for a contract call.
+export type Argument = {
+  type: ContractParameterType; // The type of the argument.
+  value?: any; // The value of the argument. It can be omitted if the type is "Any".
+};
+
+// Provides the necessary arguments for a contract call.
+export type InvocationArguments = {
+  hash: UInt160; // The hash of the contract to be called.
+  operation: string; // The operation of the contract to be called.
+  args?: Argument[]; // The arguments for the call.
+  abortOnFail?: boolean; // Indicates whether the entire transaction should fail when the contract returns `false`.
+};
+
+// Represents the result of a contract call.
+export type InvocationResult = {
+  script: Base64Encoded; // The script that was executed.
+  state: VMState; // The final state of the VM after execution.
+  gasconsumed: Integer; // The amount of gas consumed during the execution.
+  exception?: string; // The exception message if the execution failed.
+  notifications: Notification[]; // The notifications triggered during the execution.
+  stack: StackItem[]; // The return value of the execution.
+};
+
+export type TransactionOptions = {
+  suggestedSystemFee?: Integer; // The suggested system fee for the transaction. If provided, the wallet will not automatically calculate the system fee, but will use this value instead. `extraSystemFee` will be ignored if `suggestedSystemFee` is provided.
+  extraSystemFee?: Integer; // The extra system fee that the user wants to pay for the transaction. The wallet will automatically calculate the system fee and add this value to it.
+  validUntilBlock?: number; // The block until which the transaction is valid. If not provided, the wallet will use a default value.
+};
+
+export type ContractParametersContext = {
+  type: "Neo.Network.P2P.Payloads.Transaction";
+  hash: UInt256;
+  data: Base64Encoded;
+  items: Record<
+    UInt160,
+    {
+      script: Base64Encoded;
+      parameters: Argument[];
+      signatures: Record<ECPoint, Base64Encoded>;
+    }
+  >;
+  network: Network;
+};
+
+export type SignOptions = {
+  isBase64Encoded?: boolean; // Indicates whether the message is a base64 encoded string. The default value is `false`.
+  isTypedData?: boolean; // Indicates whether the message is a typed data. This value can only be set to `false` at the moment, but it is reserved for future use.
+  isLedgerCompatible?: boolean; // Indicates whether the signature should be compatible with Ledger devices. The default value is `false`. If set to `true`, the message will be wrapped in a transaction-like structure before signing.
+};
+
+export type SignedMessage = {
+  payload: Base64Encoded; // The base64 encoded payload of the message that was signed.
+  signature: Base64Encoded; // The signature of the message.
+  account: UInt160; // The account used to sign the message.
+  pubkey: ECPoint; // The public key of the account used to sign the message.
+};
+
+export type AuthenticationChallengePayload = {
+  action: "Authentication";
+  grant_type: "Signature";
+  allowed_algorithms: ["ECDSA-P256"];
+  domain: string;
+  networks: Network[];
+  nonce: string;
+  timestamp: number;
+};
+
+export type AuthenticationResponsePayload = {
+  algorithm: "ECDSA-P256";
+  network: Network;
+  pubkey: ECPoint;
+  address: Address;
+  nonce: string;
+  timestamp: number;
+  signature: Base64Encoded;
+};
+
+export interface DapiProvider {
+  // Properties
+
+  // The name of the provider.
+  name: string;
+
+  // The version of the provider.
+  version: Version;
+
+  // The version of the dAPI. It must currently be "1.0".
+  dapiVersion: Version;
+
+  // Indicates the standards supported by this provider.
+  // It should include "NEP-21" if the provider supports this standard.
+  // Example: ["NEP-11", "NEP-17", "NEP-21"]
+  compatibility: string[];
+
+  // Indicates whether the user has connected their wallet to the dApp.
+  connected: boolean;
+
+  // Indicates the network currently in use.
+  network: Network;
+
+  // Indicates the networks supported by this provider.
+  supportedNetworks: Network[];
+
+  // The icon of the provider, represented as a URL.
+  // Should be a square image with a size of at least 128x128 pixels for better display quality.
+  // The scheme of the URL should be either "https" or "data".
+  icon: string;
+
+  // The website of the provider.
+  website: string;
+
+  // Additional data for the provider.
+  extra: any;
+
+  // Events
+
+  // Adds an event handler for the specified event.
+  on(event: EventName, listener: (e: CustomEvent) => void): void;
+
+  // Removes an event handler for the specified event.
+  removeListener(event: EventName, listener: (e: CustomEvent) => void): void;
+
+  // Methods
+
+  // Requests for authentication. Usually used to log in to a website.
+  // The authentication process is described in detail in NEP-20.
+  // Possible errors: UNSUPPORTED, INVALID, TIMEOUT, CANCELED.
+  authenticate(
+    payload: AuthenticationChallengePayload,
+  ): Promise<AuthenticationResponsePayload>;
+
+  // Gets the current connected account in the wallet.
+  getAccounts(): Promise<Account[]>;
+
+  // Prompts the user to select an account from the wallet and returns the selected address.
+  // This method is usually used when the dApp needs to access an account that is different from the currently connected one.
+  // Possible errors: CANCELED.
+  pickAddress(prompt?: string): Promise<Address>;
+
+  // Gets the balance of the specified account.
+  // The account can be either in the wallet or an arbitrary address.
+  // Possible errors: INVALID, NOTFOUND, FAILED, RPC_ERROR.
+  getBalance(asset: UInt160, account: UInt160): Promise<Integer>;
+
+  // Sends assets to an account and returns the hash of the transaction.
+  // The `from` account must be in the wallet, while the `to` account can be either in the wallet or an arbitrary address.
+  // If `from` is not specified, the wallet should automatically select an account or prompt the user to select one.
+  // The `data` field can be used to pass additional data for the transfer, which can be used by the wallet or the receiving contract.
+  // Possible errors: INVALID, NOTFOUND, FAILED, TIMEOUT, CANCELED, INSUFFICIENT_FUNDS, RPC_ERROR.
+  send(
+    asset: UInt160,
+    from: UInt160,
+    to: UInt160,
+    amount: Integer,
+    data?: Argument,
+  ): Promise<UInt256>;
+
+  // Calls a contract offchain and get the execution result.
+  // Possible errors: INVALID, RPC_ERROR.
+  call(invocation: InvocationArguments): Promise<InvocationResult>;
+
+  // Calls one or more contracts onchain and returns the hash of the transaction.
+  // Possible errors: INVALID, FAILED, TIMEOUT, CANCELED, RPC_ERROR.
+  invoke(
+    invocations: InvocationArguments[],
+    signers?: Signer[],
+    attributes?: TransactionAttribute[],
+    options?: TransactionOptions,
+  ): Promise<UInt256>;
+
+  // Calls one or more contracts onchain and return the transaction without relaying.
+  // Possible errors: INVALID, FAILED, TIMEOUT, CANCELED, RPC_ERROR.
+  makeTransaction(
+    invocations: InvocationArguments[],
+    signers?: Signer[],
+    attributes?: TransactionAttribute[],
+    options?: TransactionOptions,
+  ): Promise<ContractParametersContext>;
+
+  // Signs the transaction with the current wallet. Usually used for multi-signature transactions.
+  // Possible errors: UNSUPPORTED, INVALID, NOTFOUND, TIMEOUT, CANCELED.
+  sign(context: ContractParametersContext): Promise<ContractParametersContext>;
+
+  // Signs the message with the specified account.
+  // The algorithm used is ECDsa with SHA256.
+  // If `account` is omitted, the wallet should automatically select an account or prompt the user to select one.
+  // Possible errors: INVALID, NOTFOUND, TIMEOUT, CANCELED.
+  signMessage(
+    message: string | Base64Encoded,
+    account?: UInt160,
+    options?: SignOptions,
+  ): Promise<SignedMessage>;
+
+  // Relays a transaction and returns the hash of it.
+  // Possible errors: INVALID, TIMEOUT, CANCELED, INSUFFICIENT_FUNDS, RPC_ERROR.
+  relay(context: ContractParametersContext): Promise<UInt256>;
+
+  // Gets the block of the specified hash.
+  // Possible errors: INVALID, NOTFOUND, RPC_ERROR.
+  getBlock(hash: UInt256): Promise<Block>;
+
+  // Gets the block of the specified index.
+  // Possible errors: INVALID, NOTFOUND, RPC_ERROR.
+  getBlock(index: number): Promise<Block>;
+
+  // Gets the count of blocks in the blockchain.
+  // Possible errors: RPC_ERROR.
+  getBlockCount(): Promise<number>;
+
+  // Gets the transaction of the specified hash.
+  // Possible errors: INVALID, NOTFOUND, RPC_ERROR.
+  getTransaction(txid: UInt256): Promise<Transaction>;
+
+  // Gets the application log of the specified transaction.
+  // Possible errors: INVALID, RPC_ERROR.
+  getApplicationLog(txid: UInt256): Promise<ApplicationLog>;
+
+  // Gets the specified storage entry.
+  // Possible errors: INVALID, NOTFOUND, RPC_ERROR.
+  getStorage(hash: UInt160, key: Base64Encoded): Promise<Base64Encoded>;
+
+  // Gets the information of the specified token.
+  // Possible errors: INVALID, NOTFOUND, FAILED, RPC_ERROR.
+  getTokenInfo(hash: UInt160): Promise<Token>;
+}
+
+// Represents the event when the provider is ready to be used.
+export type ProviderReadyEvent = CustomEvent<{
+  provider: DapiProvider; // The instance of the provider that is ready.
+}>;
+
+// Represents the event when a dApp requests for a provider to be injected.
+export type ProviderRequestEvent = CustomEvent<{
+  version: Version; // The version of the dAPI that the requester expects to use.
+}>;
+
+// Represents the event when the user has changed the connected account in the wallet.
+export type AccountChangedEvent = CustomEvent<{
+  accounts: Account[]; // The new connected accounts in the wallet.
+}>;
+
+// Represents the event when the user switches the current network.
+export type NetworkChangedEvent = CustomEvent<{
+  network: Network; // The new network.
+}>;

--- a/packages/neon-dapi/src/utils.ts
+++ b/packages/neon-dapi/src/utils.ts
@@ -1,0 +1,236 @@
+import { rpc, sc, tx, u, wallet } from "@cityofzion/neon-core";
+
+import type {
+  InvocationArguments,
+  Signer,
+  Transaction,
+  TransactionAttribute,
+  TransactionOptions,
+  WitnessRule,
+  WitnessScope,
+} from "./types.js";
+
+export type TransactionToTransform = tx.TransactionJson & {
+  blockhash: string;
+  blocktime: number;
+  confirmations: number;
+};
+
+export function transformTransaction(
+  transaction: TransactionToTransform,
+): Transaction {
+  const signers: Signer[] = transaction.signers.map((signer) => {
+    return {
+      account: signer.account,
+      scopes: signer.scopes as WitnessScope,
+      allowedContracts: signer.allowedcontracts,
+      allowedGroups: signer.allowedgroups,
+      rules: signer.rules as WitnessRule[],
+    };
+  });
+
+  const attributes = transaction.attributes as TransactionAttribute[];
+
+  return {
+    hash: transaction.hash ?? "",
+    size: transaction.size,
+    version: transaction.version,
+    nonce: transaction.nonce,
+    systemFee: transaction.sysfee,
+    networkFee: transaction.netfee,
+    validUntilBlock: transaction.validuntilblock,
+    sender: transaction.sender,
+    signers,
+    attributes,
+    script: transaction.script,
+    blockHash: transaction.blockhash,
+    blockTime: transaction.blocktime,
+    confirmations: transaction.confirmations,
+  };
+}
+
+export function getScriptBuilder(
+  invocations: InvocationArguments[],
+): sc.ScriptBuilder {
+  const scriptBuilder = new sc.ScriptBuilder();
+
+  for (const invocation of invocations) {
+    const args = invocation.args?.map((arg) =>
+      sc.ContractParam.fromJson({ type: arg.type, value: arg.value }),
+    );
+    scriptBuilder.emitContractCall({
+      operation: invocation.operation,
+      scriptHash: invocation.hash,
+      args,
+    });
+
+    if (invocation.abortOnFail) {
+      scriptBuilder.emit(sc.OpCode.ABORT);
+    }
+  }
+
+  return scriptBuilder;
+}
+
+export async function getValidUntilBlock(
+  rpcClient: rpc.RPCClient,
+  options?: TransactionOptions,
+): Promise<number> {
+  let validUntilBlock = options?.validUntilBlock;
+  if (validUntilBlock === undefined) {
+    const blockCount = await rpcClient.getBlockCount();
+    validUntilBlock = blockCount + 100;
+  }
+
+  return validUntilBlock;
+}
+
+export function getAttributes(
+  attributes?: TransactionAttribute[],
+): tx.TransactionAttribute[] {
+  const transactionAttributes: tx.TransactionAttribute[] = [];
+
+  attributes?.forEach((attribute) => {
+    if (attribute.type === "HighPriority") {
+      transactionAttributes.push(new tx.HighPriorityAttribute());
+    }
+
+    if (attribute.type === "OracleResponse") {
+      transactionAttributes.push(
+        new tx.OracleResponseAttribute(
+          attribute.id,
+          tx.OracleResponseCode[attribute.code],
+          attribute.result ?? "",
+        ),
+      );
+    }
+  });
+
+  return transactionAttributes;
+}
+
+export async function getSystemFee(
+  rpcClient: rpc.RPCClient,
+  scriptBuilder: sc.ScriptBuilder,
+  signers: tx.Signer[],
+  options?: TransactionOptions,
+): Promise<u.BigInteger> {
+  let systemFee: u.BigInteger;
+
+  if (options?.suggestedSystemFee) {
+    systemFee = u.BigInteger.fromNumber(options.suggestedSystemFee);
+  } else {
+    const result = await rpcClient.invokeScript(
+      u.HexString.fromHex(scriptBuilder.build()),
+      signers,
+    );
+    systemFee = u.BigInteger.fromNumber(result.gasconsumed);
+  }
+
+  if (options?.extraSystemFee) {
+    systemFee = systemFee.add(u.BigInteger.fromNumber(options.extraSystemFee));
+  }
+
+  return systemFee;
+}
+
+export async function getNetworkFee(
+  rpcClient: rpc.RPCClient,
+  transaction: tx.Transaction,
+): Promise<u.BigInteger> {
+  const txClone = new tx.Transaction(transaction);
+
+  // Remove all witnesses from the transaction
+  txClone.witnesses = [];
+
+  // Add one witness for each signer and use placeholder accounts to calculate the network fee.
+  // This is needed to calculate the network fee, since the signer is considered to calculate the fee and we need
+  // the same number of witnesses as signers, otherwise the fee calculation will fail
+  for (let i = 0; i < txClone.signers.length; i++) {
+    const placeholderAccount = new wallet.Account();
+    const signer = txClone.signers[i];
+    if (signer) {
+      signer.account = u.HexString.fromHex(placeholderAccount.scriptHash);
+    }
+
+    const verificationScript = u.HexString.fromHex(
+      wallet.getVerificationScriptFromPublicKey(placeholderAccount.publicKey),
+    );
+
+    // Fake invocation script
+    let invocationScript = new sc.OpToken(
+      sc.OpCode.PUSHDATA1,
+      "0".repeat(128),
+    ).toScript();
+
+    if (sc.isMultisigContract(verificationScript)) {
+      const threshold = wallet.getSigningThresholdFromVerificationScript(
+        verificationScript.toBigEndian(),
+      );
+
+      invocationScript = invocationScript.repeat(threshold);
+    }
+
+    txClone.addWitness(
+      new tx.Witness({ invocationScript, verificationScript }),
+    );
+  }
+
+  const networkFee = await rpcClient.calculateNetworkFee(txClone);
+  return u.BigInteger.fromNumber(networkFee);
+}
+
+export function getWitnesses(
+  neonjsAccount: wallet.Account,
+  signers: Signer[],
+): tx.Witness[] {
+  const witnesses: tx.Witness[] = [];
+
+  for (const signer of signers) {
+    witnesses.push(
+      new tx.Witness({
+        invocationScript: "",
+        verificationScript:
+          signer.account === neonjsAccount.scriptHash
+            ? wallet.getVerificationScriptFromPublicKey(neonjsAccount.publicKey)
+            : "",
+      }),
+    );
+  }
+
+  return witnesses;
+}
+
+export async function calculateFee(
+  neonjsAccount: wallet.Account,
+  rpcClient: rpc.RPCClient,
+  invocations: InvocationArguments[],
+  signers?: Signer[],
+  attributes?: TransactionAttribute[],
+  options?: TransactionOptions,
+): Promise<number> {
+  const transaction = new tx.Transaction();
+
+  const scriptBuilder = getScriptBuilder(invocations);
+
+  transaction.script = u.HexString.fromHex(scriptBuilder.build());
+
+  transaction.validUntilBlock = await getValidUntilBlock(rpcClient, options);
+
+  transaction.signers = signers?.map((signer) => new tx.Signer(signer)) || [];
+
+  transaction.witnesses = await getWitnesses(neonjsAccount, signers || []);
+
+  transaction.attributes = await getAttributes(attributes);
+
+  transaction.systemFee = await getSystemFee(
+    rpcClient,
+    scriptBuilder,
+    transaction.signers,
+    options,
+  );
+
+  transaction.networkFee = await getNetworkFee(rpcClient, transaction);
+
+  return Number(transaction.networkFee.add(transaction.systemFee).toDecimal(8));
+}

--- a/packages/neon-dapi/src/utils.ts
+++ b/packages/neon-dapi/src/utils.ts
@@ -1,11 +1,14 @@
 import { rpc, sc, tx, u, wallet } from "@cityofzion/neon-core";
 
 import type {
+  Argument,
+  Integer,
   InvocationArguments,
   Signer,
   Transaction,
   TransactionAttribute,
   TransactionOptions,
+  UInt160,
   WitnessRule,
   WitnessScope,
 } from "./types.js";
@@ -14,6 +17,11 @@ export type TransactionToTransform = tx.TransactionJson & {
   blockhash: string;
   blocktime: number;
   confirmations: number;
+};
+
+export type SendInvokeParams = {
+  invocations: InvocationArguments[];
+  signers: Signer[];
 };
 
 export function transformTransaction(
@@ -65,7 +73,7 @@ export function getScriptBuilder(
     });
 
     if (invocation.abortOnFail) {
-      scriptBuilder.emit(sc.OpCode.ABORT);
+      scriptBuilder.emit(sc.OpCode.ASSERT);
     }
   }
 
@@ -181,7 +189,7 @@ export async function getNetworkFee(
 }
 
 export function getWitnesses(
-  neonjsAccount: wallet.Account,
+  account: wallet.Account,
   signers: Signer[],
 ): tx.Witness[] {
   const witnesses: tx.Witness[] = [];
@@ -191,8 +199,8 @@ export function getWitnesses(
       new tx.Witness({
         invocationScript: "",
         verificationScript:
-          signer.account === neonjsAccount.scriptHash
-            ? wallet.getVerificationScriptFromPublicKey(neonjsAccount.publicKey)
+          signer.account === account.scriptHash
+            ? wallet.getVerificationScriptFromPublicKey(account.publicKey)
             : "",
       }),
     );
@@ -202,7 +210,7 @@ export function getWitnesses(
 }
 
 export async function calculateFee(
-  neonjsAccount: wallet.Account,
+  account: wallet.Account,
   rpcClient: rpc.RPCClient,
   invocations: InvocationArguments[],
   signers?: Signer[],
@@ -219,7 +227,7 @@ export async function calculateFee(
 
   transaction.signers = signers?.map((signer) => new tx.Signer(signer)) || [];
 
-  transaction.witnesses = await getWitnesses(neonjsAccount, signers || []);
+  transaction.witnesses = await getWitnesses(account, signers || []);
 
   transaction.attributes = await getAttributes(attributes);
 
@@ -233,4 +241,29 @@ export async function calculateFee(
   transaction.networkFee = await getNetworkFee(rpcClient, transaction);
 
   return Number(transaction.networkFee.add(transaction.systemFee).toDecimal(8));
+}
+
+export function buildSendInvokeParams(
+  account: wallet.Account,
+  asset: UInt160,
+  from: UInt160,
+  to: UInt160,
+  amount: Integer,
+  data?: Argument,
+): SendInvokeParams {
+  return {
+    invocations: [
+      {
+        hash: asset,
+        operation: "transfer",
+        args: [
+          { type: "Hash160", value: from },
+          { type: "Hash160", value: to },
+          { type: "Integer", value: amount },
+          data ?? { type: "Any" },
+        ],
+      },
+    ],
+    signers: [{ account: account.scriptHash, scopes: "CalledByEntry" }],
+  };
 }

--- a/packages/neon-dapi/tsconfig.json
+++ b/packages/neon-dapi/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "references": [
+    {
+      "path": "./tsconfig.source.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    }
+  ]
+}

--- a/packages/neon-dapi/tsconfig.source.json
+++ b/packages/neon-dapi/tsconfig.source.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "references": [{ "path": "../neon-core" }],
+  "include": ["src/**/*"]
+}

--- a/packages/neon-dapi/tsconfig.test.json
+++ b/packages/neon-dapi/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig-test.json",
+  "compilerOptions": {
+    "paths": {
+      "@cityofzion/neon-core": ["../neon-core/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
+}


### PR DESCRIPTION
## Summary

- Add `@cityofzion/neon-dapi` — TypeScript implementation of the NEP-21 dAPI standard for Neo N3
- Provide `DapiProvider` interface, `DapiOperations` helper class, typed error system (`DapiError`/`DapiErrorCode`), and all NEP-21 types
- Include a browser-based conformance suite (`conformance/`) for validating wallet provider implementations against the spec