### PR TITLE
fix(dapi): include neon-dapi in root tsconfig build references

### DIFF
--- a/packages/neon-dapi/package.json
+++ b/packages/neon-dapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cityofzion/neon-dapi",
-  "description": "Neon Ledger integration for Node.js",
+  "description": "Neon implementation of dApi(NEP-21)",
   "version": "5.10.0",
   "repository": {
     "type": "git",
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "ae": "api-extractor run --local",
-    "build": "tsc -b tsconfig.source.json",
-    "dist": "tsc -p tsconfig.source.json -m commonjs --outDir dist",
-    "dist:prod": "tsc -p tsconfig.source.json -m commonjs --outDir dist",
+    "build": "tsc -b",
+    "dist": "tsc -m commonjs --outDir dist",
+    "dist:prod": "tsc -m commonjs --outDir dist",
     "clean": "rimraf ./lib ./dist ./temp tsconfig.tsbuildinfo",
     "prepublishOnly": "npm run clean && npm run build && npm run dist:prod",
     "lint": "eslint src/**/*.ts __tests__/**/*.ts",
@@ -32,9 +32,6 @@
     "start": "jest --watch",
     "test": "jest --config jest.config.js",
     "test:unit": "jest --config jest.config.js"
-  },
-  "dependencies": {
-    "@ledgerhq/hw-transport": "6.32.0"
   },
   "peerDependencies": {
     "@cityofzion/neon-core": "^5.10.0"

--- a/packages/neon-dapi/tsconfig.json
+++ b/packages/neon-dapi/tsconfig.json
@@ -1,10 +1,9 @@
 {
-  "references": [
-    {
-      "path": "./tsconfig.source.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ]
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "references": [{ "path": "../neon-core" }],
+  "include": ["src/**/*"]
 }

--- a/packages/neon-dapi/tsconfig.source.json
+++ b/packages/neon-dapi/tsconfig.source.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig-base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
-  },
-  "references": [{ "path": "../neon-core" }],
-  "include": ["src/**/*"]
-}

--- a/packages/neon-dapi/tsconfig.test.json
+++ b/packages/neon-dapi/tsconfig.test.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig-test.json",
-  "compilerOptions": {
-    "paths": {
-      "@cityofzion/neon-core": ["../neon-core/src/index.ts"]
-    }
-  },
-  "include": ["src/**/*", "__tests__/**/*"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "./packages/neon-api" },
     { "path": "./packages/neon-uri" },
     { "path": "./packages/neon-ledger"},
-    { "path": "./packages/neon-js" }
+    { "path": "./packages/neon-js" },
+    { "path": "./packages/neon-dapi" }
   ]
 }


### PR DESCRIPTION
npm run build (tsc -b at root) skipped neon-dapi since it wasn't listed as a project reference.